### PR TITLE
Setup B-Field in Simulation

### DIFF
--- a/Detector/DetCEPCv4/compact/CepC_v4-onlyTracker.xml
+++ b/Detector/DetCEPCv4/compact/CepC_v4-onlyTracker.xml
@@ -74,4 +74,13 @@
   <!--include ref="Field_Solenoid_Map_s_4.0T.xml"/>
   <include ref="Field_AntiDID_Map_s.xml"/>
   <include ref="Field_FwdMagnets_Ideal_1000GeV.xml"/-->
+
+
+  <fields>
+
+    <field name="MagnetFields_Constant" type="ConstantField" field="magnetic">
+      <strength x="0" y="0" z="3.0*tesla"/>
+    </field>
+
+  </fields>
 </lccdd>

--- a/Simulation/DetSimGeom/src/AnExampleDetElemTool.cpp
+++ b/Simulation/DetSimGeom/src/AnExampleDetElemTool.cpp
@@ -28,7 +28,7 @@
 #include "DD4hep/Plugins.h"
 #include "DDG4/Geant4Converter.h"
 #include "DDG4/Geant4Mapping.h"
-
+#include "DDG4/Geant4Field.h"
 
 DECLARE_COMPONENT(AnExampleDetElemTool)
 
@@ -162,11 +162,16 @@ AnExampleDetElemTool::ConstructSDandField() {
     G4FieldManager* fieldManager
         = G4TransportationManager::GetTransportationManager()->GetFieldManager();
 
-    G4ThreeVector value(0,0,3.*tesla);
-    G4UniformMagField* aMagField = new G4UniformMagField(value);
+    // // Below is a uniform B-field
+    // G4ThreeVector value(0,0,3.*tesla);
+    // G4UniformMagField* mag_field = new G4UniformMagField(value);
 
-    fieldManager->SetDetectorField(aMagField);
-    fieldManager->CreateChordFinder(aMagField);
+    // DDG4 based B-field
+    dd4hep::OverlayedField fld  = lcdd->field();
+    G4MagneticField* mag_field  = new dd4hep::sim::Geant4Field(fld);
+
+    fieldManager->SetDetectorField(mag_field);
+    fieldManager->CreateChordFinder(mag_field);
 
 
 }

--- a/Simulation/DetSimGeom/src/AnExampleDetElemTool.cpp
+++ b/Simulation/DetSimGeom/src/AnExampleDetElemTool.cpp
@@ -19,6 +19,11 @@
 #include "G4PhysicalVolumeStore.hh"
 #include "G4OpticalSurface.hh"
 
+// Field
+#include "G4UniformMagField.hh"
+#include "G4FieldManager.hh"
+#include "G4TransportationManager.hh"
+
 #include "DD4hep/Detector.h"
 #include "DD4hep/Plugins.h"
 #include "DDG4/Geant4Converter.h"
@@ -142,6 +147,26 @@ AnExampleDetElemTool::ConstructSDandField() {
             g4v->SetSensitiveDetector(g4sd);
         }
     }
+
+    // =======================================================================
+    // Construct Field
+    // =======================================================================
+    // TODO: integrate the field between DD4hep and Geant4
+    // Note:
+    //   DD4hep provides the parameters of fields
+    //   Geant4 will setup the field based on the DD4hep fields
+    
+    // Related Examples:
+    // - G4: G4GlobalMagFieldMessenger.cc
+
+    G4FieldManager* fieldManager
+        = G4TransportationManager::GetTransportationManager()->GetFieldManager();
+
+    G4ThreeVector value(0,0,3.*tesla);
+    G4UniformMagField* aMagField = new G4UniformMagField(value);
+
+    fieldManager->SetDetectorField(aMagField);
+    fieldManager->CreateChordFinder(aMagField);
 
 
 }


### PR DESCRIPTION
As the B-field is missing in the CEPCSW, I add an example to setup a uniform B-field.

Ref:
* [DD4hep B-field example](https://github.com/AIDASoft/DD4hep/blob/master/examples/ClientTests/compact/MagnetFields.xml)
* [Geant4 uniform field](https://github.com/Geant4/geant4/blob/master/source/geometry/magneticfield/include/G4UniformMagField.hh)