### PR TITLE
Add the instruction of Singularity container

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CEPC offline software prototype based on [Key4hep](https://github.com/key4hep).
 
 ## Quick start
 
-Start the container in lxslc7:
+Start the container in lxslc7 (OS: CentOS7):
 ```
 $ /cvmfs/container.ihep.ac.cn/bin/hep_container shell SL6
 ```


### PR DESCRIPTION
As the external LCG 97.0.2 is built with SL6, we need to start a container to run the current CEPCSW.