### PR TITLE
Fix bug for silicon-tracking

### DIFF
--- a/Detector/DetCEPCv4/compact/vxd07.xml
+++ b/Detector/DetCEPCv4/compact/vxd07.xml
@@ -62,7 +62,7 @@
 			    external_metal_thickness="0.009*mm"  />
   <!-- SQL command: "SELECT * FROM cryostat;"  -->
   <cryostat id="1" alu_skin_inner_radious="100*mm" alu_skin_tickness="0.5*mm" foam_inner_radious="90*mm" foam_tickness="10*mm" foam_half_z="166.6*mm" 
-	    endplate_inner_radious="VXD_inner_radius_1" 
+	    endplate_inner_radious="VXD_inner_radius_1+5.6*mm" 
 	    cryostat_option="1" cryostat_apperture="30*mm" cryostat_apperture_radius="1.5*mm"  />
   <!-- SQL command: "select * from support_shell;"  -->
   <support_shell id="0" inner_radious="65*mm" half_z="145*mm" thickess="0.49392*mm" endplate_inner_radious="30*mm" endplate_inner_radius_L1="15.7*mm" endplate_outer_radius_L1="20*mm" 
@@ -93,7 +93,7 @@
   <readouts>
     <readout name="VXDCollection">
       <!-- fixme: for now DD4hep cannot handle signed values - side should actually be "-2" -->
-      <id>system:5,side:-2,layer:9,module:8,sensor:8</id>
+      <id>system:5,side:-2,layer:9,module:8,sensor:8,barrelside:-2</id>
     </readout>
   </readouts>
 

--- a/Detector/DetCEPCv4/src/tracker/VXD04_geo.cpp
+++ b/Detector/DetCEPCv4/src/tracker/VXD04_geo.cpp
@@ -760,7 +760,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 	  
 	  //**fg: choose sensor 1 for sensitive electronics side band
 	  if(active_side_band_electronics_option==1)
-	    pv_el_band_pos.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(elec_loop)  ).addPhysVolID("sensor", 1 ).addPhysVolID("side", 1 )   ;
+	    pv_el_band_pos.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(elec_loop)  ).addPhysVolID("sensor", 1 ).addPhysVolID("side", 0 ).addPhysVolID("barrelside", 1 );
 
 	  PlacedVolume pv_el_band_neg = layer_assembly.placeVolume( ElectronicsBandLogical,
 				     Transform3D( rot, Position((layer_radius+(side_band_electronics_thickness/2.)+layer_gap)*sin(phirot2)+side_band_electronic_offset_phi*cos(phirot2),
@@ -768,7 +768,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 								-Z))  );
 
 	  if(active_side_band_electronics_option==1)
-	    pv_el_band_neg.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(elec_loop)  ).addPhysVolID("sensor", 1 ).addPhysVolID("side", -1 )   ;
+	    pv_el_band_neg.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(elec_loop)  ).addPhysVolID("sensor", 1 ).addPhysVolID("side", 0 ).addPhysVolID("barrelside", -1 );
 	  
 	}
 
@@ -791,14 +791,14 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 								Z))  );
 
 	  if(active_side_band_electronics_option==1)
-	    pv_el_band_pos.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(elec_loop)  ).addPhysVolID("sensor", 1 ).addPhysVolID("side", 1 )   ;
+	    pv_el_band_pos.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(elec_loop)  ).addPhysVolID("sensor", 1 ).addPhysVolID("side", 0 ).addPhysVolID("barrelside", 1 )   ;
 
 	  PlacedVolume pv_el_band_neg = layer_assembly.placeVolume( ElectronicsBandLogical,
 				     Transform3D( rot, Position((layer_radius-(side_band_electronics_thickness/2.))*sin(phirot2)+side_band_electronic_offset_phi*cos(phirot2),
 								-(layer_radius-(side_band_electronics_thickness/2.))*cos(phirot2)+side_band_electronic_offset_phi*sin(phirot2),
 								-Z))  );
 	  if(active_side_band_electronics_option==1)
-	    pv_el_band_neg.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(elec_loop)  ).addPhysVolID("sensor", 1 ).addPhysVolID("side", -1 )   ;
+	    pv_el_band_neg.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(elec_loop)  ).addPhysVolID("sensor", 1 ).addPhysVolID("side", 0 ).addPhysVolID("barrelside", -1 );
 	}
       }      
     }
@@ -1114,7 +1114,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 										     -(layer_radius+(active_silicon_thickness/2.)+layer_gap)*cos(phirot2)+active_offset_phi*sin(phirot2),
 										     Z)) ) ;
 	
-	pv_layer_pos.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(active_loop)  ).addPhysVolID("sensor", 0 ).addPhysVolID("side", 1 )   ;
+	pv_layer_pos.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(active_loop)  ).addPhysVolID("sensor", 0 ).addPhysVolID("side", 0 ).addPhysVolID("barrelside", 1 )   ;
 
 	DetElement   ladderDEposZ( vxd ,  ladderNameP , x_det.id() );
 	ladderDEposZ.setPlacement( pv_layer_pos ) ;
@@ -1125,7 +1125,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 										     -(layer_radius+(active_silicon_thickness/2.)+layer_gap)*cos(phirot2)+active_offset_phi*sin(phirot2),
 										     -Z)) );
 	
-	pv_layer_neg.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(active_loop)  ).addPhysVolID("sensor", 0 ).addPhysVolID("side", -1 )   ;
+	pv_layer_neg.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(active_loop)  ).addPhysVolID("sensor", 0 ).addPhysVolID("side", 0 ).addPhysVolID("barrelside", -1 )   ;
 
 	DetElement   ladderDEnegZ( vxd ,   ladderNameN , x_det.id() );
 	ladderDEnegZ.setPlacement( pv_layer_neg ) ;
@@ -1138,7 +1138,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 										     -(layer_radius-(active_silicon_thickness/2.))*cos(phirot2)+active_offset_phi*sin(phirot2),
 										     Z)) ) ;
 	
-	pv_layer_pos.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(active_loop)  ).addPhysVolID("sensor", 0 ).addPhysVolID("side", 1 )   ;
+	pv_layer_pos.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(active_loop)  ).addPhysVolID("sensor", 0 ).addPhysVolID("side", 0 ).addPhysVolID("barrelside", 1 )   ;
 	
 	DetElement   ladderDEposZ( vxd ,  ladderNameP , x_det.id() );
 	ladderDEposZ.setPlacement( pv_layer_pos ) ;
@@ -1152,7 +1152,7 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 	ladderDEnegZ.setPlacement( pv_layer_neg ) ;
 	volSurfaceList( ladderDEnegZ )->push_back( surf ) ;
 	
-	pv_layer_neg.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(active_loop)  ).addPhysVolID("sensor", 0 ).addPhysVolID("side", -1 )   ;
+	pv_layer_neg.addPhysVolID("layer", LayerId ).addPhysVolID( "module" , int(active_loop)  ).addPhysVolID("sensor", 0 ).addPhysVolID("side", 0 ).addPhysVolID("barrelside", -1 )    ;
 	
       }		  
 

--- a/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
@@ -180,7 +180,8 @@ StatusCode ForwardTrackingAlg::initialize(){
 
 StatusCode ForwardTrackingAlg::execute(){
   debug() << " processing event number " << _nEvt << endmsg;
-   
+
+  auto trkCol = _outColHdl.createAndPut();
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //                                                                                                              //
   //                                 ForwardTracking                                                              //
@@ -626,7 +627,7 @@ StatusCode ForwardTrackingAlg::execute(){
     /**********************************************************************************************/
     debug() << "\t\t---Save Tracks---" << endmsg ;
       
-    auto trkCol = _outColHdl.createAndPut();
+    //auto trkCol = _outColHdl.createAndPut();
     
     for (unsigned int i=0; i < tracks.size(); i++){
       FTDTrack* myTrack = dynamic_cast< FTDTrack* >( tracks[i] );
@@ -906,7 +907,14 @@ void ForwardTrackingAlg::finaliseTrack( edm4hep::Track* trackImpl ){
   Fitter fitter( trackImpl , _trkSystem );
    
   //trackImpl->trackStates().clear();
-  debug() << "Track has " << trackImpl->trackStates_size() << " TrackState now, should be cleared but not supported by EDM4hep" << endmsg;
+  int nState = trackImpl->trackStates_size();
+  if(nState>0){
+    debug() << "Track has " << nState << " TrackState now, should be cleared but not supported by EDM4hep" << endmsg;
+    for(int i=0;i<nState;i++){
+      debug() << trackImpl->getTrackStates(i).location << " ";
+    }
+    debug() << endmsg;
+  }
   
   edm4hep::TrackState trkStateIP( *fitter.getTrackState( 1/*lcio::TrackState::AtIP*/ ) ) ;
   trkStateIP.location = 1;

--- a/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
@@ -159,6 +159,7 @@ StatusCode SiliconTrackingAlg::execute(){
   Navigation::Instance()->Initialize();
   //_current_event = evt;
   //_allHits.reserve(1000);
+  auto trkCol = _outColHdl.createAndPut();
 
   _output_track_col_quality = _output_track_col_quality_GOOD;
   
@@ -238,7 +239,7 @@ StatusCode SiliconTrackingAlg::execute(){
 
     //edm4hep::TrackCollection* trkCol = nullptr; 
     //edm4hep::LCRelationCollection* relCol = nullptr;
-    auto trkCol = _outColHdl.createAndPut();
+    //auto trkCol = _outColHdl.createAndPut();
     //auto relCol = _outRelColHdl.createAndPut();
     /*
     LCCollectionVec * trkCol = new LCCollectionVec(LCIO::TRACK);

--- a/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.cpp
@@ -69,6 +69,9 @@ StatusCode SpacePointBuilderAlg::initialize() {
 
 StatusCode SpacePointBuilderAlg::execute(){
   StatusCode sc;
+  auto spCol = _outSPColHdl.createAndPut();
+  auto relCol = _outSPAssColHdl.createAndPut();
+
   const edm4hep::TrackerHitCollection* hitCol = nullptr;
   try {
     hitCol = _inHitColHdl.get();
@@ -95,8 +98,8 @@ StatusCode SpacePointBuilderAlg::execute(){
     _nStripsTooParallel = 0;
     _nPlanesNotParallel = 0;
     
-    edm4hep::TrackerHitCollection* spCol = new edm4hep::TrackerHitCollection();    // output spacepoint collection
-    edm4hep::MCRecoTrackerAssociationCollection* relCol = new edm4hep::MCRecoTrackerAssociationCollection();    // output relation collection
+    //edm4hep::TrackerHitCollection* spCol = new edm4hep::TrackerHitCollection();    // output spacepoint collection
+    //edm4hep::MCRecoTrackerAssociationCollection* relCol = new edm4hep::MCRecoTrackerAssociationCollection();    // output relation collection
     
     // to store the weights
     //LCFlagImpl lcFlag(0) ;
@@ -235,10 +238,10 @@ StatusCode SpacePointBuilderAlg::execute(){
       }
     }
     
-    if(spCol->size()!=0) _outSPColHdl.put(spCol);
-    else                 delete spCol;
-    if(relCol->size()!=0) _outSPAssColHdl.put(relCol);
-    else                  delete relCol;
+    //if(spCol->size()!=0) _outSPColHdl.put(spCol);
+    //else                 delete spCol;
+    //if(relCol->size()!=0) _outSPAssColHdl.put(relCol);
+    //else                  delete relCol;
     
     debug() << "\nCreated " << createdSpacePoints << " space points ( raw strip hits: " << rawStripHits << ")\n"
 	    << "  There were " << rawStripHits << " strip hits available, giving " 

--- a/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.h
+++ b/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.h
@@ -78,6 +78,11 @@ class SpacePointBuilderAlg : public GaudiAlgorithm {
   // Output collection
   DataHandle<edm4hep::TrackerHitCollection> _outSPColHdl{"FTDSpacePoints", Gaudi::DataHandle::Writer, this};
   DataHandle<edm4hep::MCRecoTrackerAssociationCollection> _outSPAssColHdl{"FTDSpacePointsAssociation", Gaudi::DataHandle::Writer, this};
+
+  Gaudi::Property<float> _nominal_vertex_x{this, "NominalVertexX", 0.0};
+  Gaudi::Property<float> _nominal_vertex_y{this, "NominalVertexY", 0.0};
+  Gaudi::Property<float> _nominal_vertex_z{this, "NominalVertexZ", 0.0};
+  Gaudi::Property<float> _striplength_tolerance{this, "StriplengthTolerance", 0.1};
   /** Calculates the 2 dimensional crossing point of two lines.
    * Each line is specified by a point (x,y) and a direction vector (ex,ey).
    * 
@@ -169,14 +174,7 @@ class SpacePointBuilderAlg : public GaudiAlgorithm {
   unsigned _nStripsTooParallel;
   unsigned _nPlanesNotParallel;
 
-  float _nominal_vertex_x;
-  float _nominal_vertex_y;
-  float _nominal_vertex_z;
-
   CLHEP::Hep3Vector _nominal_vertex;
-
-  float _striplength_tolerance;
-  
 } ;
 
 #endif

--- a/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
@@ -97,7 +97,8 @@ StatusCode TrackSubsetAlg::finalize(){
 
 StatusCode TrackSubsetAlg::execute(){ 
   std::vector<edm4hep::Track> tracks;
-  
+
+  auto trkCol = _outColHdl.createAndPut();
   /**********************************************************************************************/
   /*       Read in the collections                                                              */
   /**********************************************************************************************/
@@ -197,7 +198,7 @@ StatusCode TrackSubsetAlg::execute(){
   /**********************************************************************************************/
   debug() << "Fitting and saving of the tracks" << endmsg;
 
-  auto trkCol = _outColHdl.createAndPut();
+  //auto trkCol = _outColHdl.createAndPut();
 
   for( unsigned i=0; i < accepted.size(); i++ ){
     edm4hep::Track trackImpl;
@@ -326,6 +327,8 @@ StatusCode TrackSubsetAlg::execute(){
   }
 
   debug() << "Saving " << trkCol->size() << " tracks" << endmsg;
+  
+  Navigation::Instance()->Initialize();
 
   _nEvt ++ ;
   return StatusCode::SUCCESS;

--- a/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
+++ b/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
@@ -110,8 +110,14 @@ namespace MarlinTrk {
   
   
   int MarlinKalTestTrack::addHit( edm4hep::TrackerHit* trkhit) {
-    
-    return this->addHit( trkhit, _ktest->findMeasLayer( trkhit )) ;
+    const ILDVMeasLayer* ml = 0;
+    try{
+      ml = _ktest->findMeasLayer( trkhit );
+    }
+    catch(MarlinTrk::Exception& e){
+      std::cout << e.what() << std::endl;
+    }
+    return this->addHit( trkhit, ml) ;
     
   } 
   
@@ -122,8 +128,7 @@ namespace MarlinTrk {
       return this->addHit( trkhit, ml->ConvertLCIOTrkHit(trkhit), ml) ;
     }
     else {
-      std::cout << "MarlinKalTestTrack::addHit: trkhit = "  << trkhit->id() << " addr: " << trkhit << " ml = " << ml << std::endl ;
-      //streamlog_out( ERROR ) << " MarlinKalTestTrack::addHit - bad inputs " <<  trkhit << " ml : " << ml << std::endl ;
+      //std::cout << "MarlinKalTestTrack::addHit: trkhit = "  << trkhit->id() << " addr: " << trkhit << " ml = " << ml << std::endl ;
       return bad_intputs ;
     }
     return bad_intputs ;
@@ -609,21 +614,21 @@ namespace MarlinTrk {
       // get the measurement layer of the current hit
       const ILDVMeasLayer* ml =  dynamic_cast<const ILDVMeasLayer*>( &(kalhit->GetMeasLayer() ) ) ;
       TVector3 pos = ml->HitToXv(*kalhit);
+      /*
       std::cout << "debug: Kaltrack::addAndFit : site discarded! at index : " << ml->GetIndex()
-      << " for type " << ml->GetName() 
-      << " chi2increment = " << chi2increment
-      << " maxChi2Increment = " << maxChi2Increment
-      << " x = " << pos.x()
-      << " y = " << pos.y()
-      << " z = " << pos.z()
-      << " with CellIDs: " << std::endl;
-      
+	<< " for type " << ml->GetName() 
+	<< " chi2increment = " << chi2increment
+	<< " maxChi2Increment = " << maxChi2Increment
+	<< " x = " << pos.x()
+	<< " y = " << pos.y()
+	<< " z = " << pos.z()
+	<< " with CellIDs: " << std::endl;
       for (unsigned int i = 0; i < (dynamic_cast<const ILDVMeasLayer*>( &(kalhit->GetMeasLayer() ) )->getNCellIDs());++i) {
 	std::cout << "debug: CellID = " 
         << dynamic_cast<const ILDVMeasLayer*>( &(kalhit->GetMeasLayer() ) )->getCellIDs()[i] 
         << std::endl ;
       }
-      
+      */
 
 #ifdef MARLINTRK_DIAGNOSTICS_ON
       _ktest->_diagnostics.record_rejected_site(kalhit, temp_site); 


### PR DESCRIPTION
* Detector
   * add barrelside region into cellID (compact file and geo file)
      * in MokkaC and Marlin version of CEPC_v4, VXD's side fixed as 0, in order to let digitization and reconstruction algorithms compatible to old data, change side value to 0 too. So, additional id region (barrelside) needs to distinct the two placed volumes (side=+1,-1 before modification), to avoid crash caused by same cellID for two placed volumes.  
   * change endplate_inner_radius to let CryostatAlInnerR equal to Mokka's CEPC_v4 (compact file)
* SiliconTracking
   * move createAndPut to begin of execute() (*.cpp )
   * change type of parameters (SpacePointBuilderAlg.h)
* TrackSystemSvc
   * change debug message (MarlinKalTestTrack.cc)