### PR TITLE
WIP: Support both LCG and k4spack stack for CEPCSW 

### DIFF
--- a/Detector/GeoSvc/CMakeLists.txt
+++ b/Detector/GeoSvc/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(ROOT COMPONENTS MathCore GenVector Geom Tree)
 find_package(DD4hep COMPONENTS DDG4 DDRec REQUIRED)
 find_package(GEAR REQUIRED)
 
+message("GEAR_LIBRARIES: ${GEAR_LIBRARIES}")
+
 gaudi_add_module(GeoSvc
                  src/GeoSvc.cpp
                  INCLUDE_DIRS
@@ -26,6 +28,6 @@ gaudi_add_module(GeoSvc
                    DD4hep 
                    ${DD4hep_COMPONENT_LIBRARIES} 
                    GaudiKernel 
-		   $ENV{GEAR}/lib/libgear.so
+		   ${GEAR_LIBRARIES}
                    # ROOT
 )

--- a/Detector/GeoSvc/CMakeLists.txt
+++ b/Detector/GeoSvc/CMakeLists.txt
@@ -27,7 +27,8 @@ gaudi_add_module(GeoSvc
                  LINK_LIBRARIES
                    DD4hep 
                    ${DD4hep_COMPONENT_LIBRARIES} 
-                   GaudiKernel 
-		   ${GEAR_LIBRARIES}
+                   GaudiKernel
+                   ${GEAR_LIBRARIES}
+                   ${ROOT_LIBRARIES}
                    # ROOT
 )

--- a/Digitisers/SimpleDigi/CMakeLists.txt
+++ b/Digitisers/SimpleDigi/CMakeLists.txt
@@ -19,5 +19,5 @@ set(SimpleDigi_srcs src/*.cpp)
 # Modules
 gaudi_add_module(SimpleDigi ${SimpleDigi_srcs}
     INCLUDE_DIRS K4FWCore GaudiKernel GaudiAlgLib CLHEP gear ${GSL_INCLUDE_DIRS} ${LCIO_INCLUDE_DIRS}
-    LINK_LIBRARIES K4FWCore GaudiKernel GaudiAlgLib CLHEP $ENV{GEAR}/lib/libgearsurf.so ${GSL_LIBRARIES} ${LCIO_LIBRARIES} EDM4HEP::edm4hep EDM4HEP::edm4hepDict
+    LINK_LIBRARIES K4FWCore GaudiKernel GaudiAlgLib CLHEP ${GEAR_LIBRARIES} ${GSL_LIBRARIES} ${LCIO_LIBRARIES} EDM4HEP::edm4hep EDM4HEP::edm4hepDict
 )

--- a/Reconstruction/PFA/Pandora/GaudiPandora/CMakeLists.txt
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/CMakeLists.txt
@@ -39,7 +39,7 @@ set(dir_include include)
 # Modules
 gaudi_add_module(GaudiPandora ${dir_srcs}
     INCLUDE_DIRS ${dir_include} GaudiKernel FWCore CLHEP  ${LCIO_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS} gear  
-    LINK_LIBRARIES GaudiKernel FWCore CLHEP ROOT ${LCIO_LIBRARIES} $ENV{GEAR}/lib/libgear.so $ENV{GEAR}/lib/libgearxml.so DataHelperLib 
+    LINK_LIBRARIES GaudiKernel FWCore CLHEP ROOT ${LCIO_LIBRARIES} ${GEAR_LIBRARIES} DataHelperLib 
       -Wl,--no-as-needed 
       EDM4HEP::edm4hep EDM4HEP::edm4hepDict
       -Wl,--as-needed 

--- a/Reconstruction/PFA/Pandora/MatrixPandora/CMakeLists.txt
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/CMakeLists.txt
@@ -38,7 +38,7 @@ set(dir_include include)
 # Modules
 gaudi_add_module(MatrixPandora ${dir_srcs}
     INCLUDE_DIRS ${dir_include} GaudiKernel FWCore CLHEP  ${LCIO_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS} gear DD4hep  
-    LINK_LIBRARIES GaudiKernel FWCore CLHEP ROOT ${LCIO_LIBRARIES} $ENV{GEAR}/lib/libgear.so $ENV{GEAR}/lib/libgearxml.so DD4hep ${DD4hep_COMPONENT_LIBRARIES} DDRec DataHelperLib
+    LINK_LIBRARIES GaudiKernel FWCore CLHEP ROOT ${LCIO_LIBRARIES} ${GEAR_LIBRARIES} DD4hep ${DD4hep_COMPONENT_LIBRARIES} DDRec DataHelperLib
       -Wl,--no-as-needed 
       EDM4HEP::edm4hep EDM4HEP::edm4hepDict
       -Wl,--as-needed 

--- a/Reconstruction/SiliconTracking/CMakeLists.txt
+++ b/Reconstruction/SiliconTracking/CMakeLists.txt
@@ -17,6 +17,6 @@ set(SiliconTracking_srcs src/*.cpp)
 
 # Modules
 gaudi_add_module(SiliconTracking ${SiliconTracking_srcs}
-    INCLUDE_DIRS GaudiKernel FWCore gear ${GSLx_INCLUDE_DIRS} ${LCIOx_INCLUDE_DIRS}
-    LINK_LIBRARIES TrackSystemSvcLib DataHelperLib KiTrackLib GaudiKernel FWCore $ENV{GEAR}/lib/libgearsurf.so ${GSL_LIBRARIES} ${LCIO_LIBRARIES} 
+    INCLUDE_DIRS GaudiKernel FWCore gear ${GSL_INCLUDE_DIRS} ${LCIO_INCLUDE_DIRS}
+    LINK_LIBRARIES TrackSystemSvcLib DataHelperLib KiTrackLib GaudiKernel FWCore ${GEAR_LIBRARIES} ${GSL_LIBRARIES} ${LCIO_LIBRARIES} 
 )

--- a/Service/GearSvc/CMakeLists.txt
+++ b/Service/GearSvc/CMakeLists.txt
@@ -10,5 +10,5 @@ gaudi_install_headers(GearSvc)
 
 gaudi_add_module(GearSvc ${GearSvc_srcs}
     INCLUDE_DIRS GaudiKernel gear
-    LINK_LIBRARIES GaudiKernel $ENV{GEAR}/lib/libgear.so $ENV{GEAR}/lib/libgearxml.so
+    LINK_LIBRARIES GaudiKernel ${GEAR_LIBRARIES}
 )

--- a/Service/TrackSystemSvc/CMakeLists.txt
+++ b/Service/TrackSystemSvc/CMakeLists.txt
@@ -21,7 +21,7 @@ gaudi_install_headers(TrackSystemSvc)
 gaudi_add_library(TrackSystemSvcLib ${TrackSystemSvcLib_srcs}
     PUBLIC_HEADERS TrackSystemSvc
     INCLUDE_DIRS GaudiKernel ROOT CLHEP gear ${LCIO_INCLUDE_DIRS} ${EDM4HEP_INCLUDE_DIRS}
-    LINK_LIBRARIES DataHelperLib KalTestLib KalDetLib GaudiKernel ROOT CLHEP $ENV{GEAR}/lib/libgear.so $ENV{GEAR}/lib/libgearsurf.so ${LCIO_LIBRARIES}
+    LINK_LIBRARIES DataHelperLib KalTestLib KalDetLib GaudiKernel ROOT CLHEP ${GEAR_LIBRARIES} ${LCIO_LIBRARIES}
      -Wl,--no-as-needed
      EDM4HEP::edm4hep EDM4HEP::edm4hepDict
      -Wl,--as-needed

--- a/Service/TrackSystemSvc/CMakeLists.txt
+++ b/Service/TrackSystemSvc/CMakeLists.txt
@@ -29,5 +29,5 @@ gaudi_add_library(TrackSystemSvcLib ${TrackSystemSvcLib_srcs}
 
 gaudi_add_module(TrackSystemSvc ${TrackSystemSvc_srcs}
 				INCLUDE_DIRS GaudiKernel gear 
-				LINK_LIBRARIES TrackSystemSvcLib GaudiKernel $ENV{GEAR}/lib/libgear.so
+				LINK_LIBRARIES TrackSystemSvcLib GaudiKernel ${GEAR_LIBRARIES}
 )

--- a/Utilities/KalDet/CMakeLists.txt
+++ b/Utilities/KalDet/CMakeLists.txt
@@ -76,5 +76,5 @@ set( KalDetLib_srcs ${LIB_SOURCES} ${COMMON_SOURCES} )
 
 gaudi_add_library(KalDetLib ${KalDetLib_srcs}
 		 PUBLIC_HEADERS kaldet
-                 LINK_LIBRARIES GaudiKernel ROOT CLHEP LCIO $ENV{GEAR}/lib/libgearsurf.so KalTestLib EDM4HEP::edm4hep EDM4HEP::edm4hepDict
+                 LINK_LIBRARIES GaudiKernel ROOT CLHEP LCIO ${GEAR_LIBRARIES} KalTestLib EDM4HEP::edm4hep EDM4HEP::edm4hepDict
 )

--- a/build-k4.sh
+++ b/build-k4.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+##############################################################################
+# Setup script for CEPCSW:
+# - build the cepcsw
+#
+# Usage:
+# $ bash build.sh
+# or:
+# $ 
+#
+# Author: Tao Lin <lintao@ihep.ac.cn>
+##############################################################################
+
+function info:() {
+    echo "INFO: $*" 1>&2
+}
+
+function error:() {
+    echo "ERROR: $*" 1>&2
+}
+
+function check-cepcsw-envvar() {
+    source /cvmfs/sw.hsf.org/key4hep/setup.sh
+}
+
+function build-dir() {
+    local blddir=build
+
+    # If detect the extra env var, append it to the build dir
+    if [ -n "${k4_version}" ]; then
+        blddir=${blddir}.${k4_version}
+    fi
+    if [ -n "${k4_platform}" ]; then
+        blddir=${blddir}.${k4_platform}
+    fi
+
+    echo $blddir
+}
+
+function check-working-builddir() {
+    local blddir=$(build-dir)
+    if [ ! -d "$blddir" ]; then
+        mkdir $blddir || {
+            error: "Failed to create $blddir"
+            return 1
+        }
+    fi
+}
+
+function run-cmake() {
+    local blddir=$(build-dir)
+
+    if [ ! -d "$blddir" ]; then
+        error: "Failed to create $blddir"
+        return 1
+    fi
+
+    cd $blddir
+
+    local clhep_prefix=$(clhep-config --prefix)
+    local clhep_include=${clhep_prefix}/include
+
+    # locate the pandorapfa
+    local pandorapfa=$(echo $CMAKE_PREFIX_PATH | tr ':' '\n' | grep pandorapfa | head -n1)
+    info: "Find PandoraPFA: $pandorapfa"
+    if [ -z "$pandorapfa" ]; then
+        error: "Failed to find the PandoraPFA"
+        return 1
+    fi
+    
+    local pandorapfa_cmake_modules=${pandorapfa}/cmakemodules
+    info: "Find PandoraPFA cmake: ${pandorapfa_cmake_modules}"
+    if [ ! -d "${pandorapfa_cmake_modules}" ]; then
+        error: "Failed to find the cmake modules for PandoraPFA: ${pandorapfa_cmake_modules}"
+        return 1
+    fi
+
+    local cmake_modules=${pandorapfa_cmake_modules}
+
+    cmake .. -DHOST_BINARY_TAG=${k4_platform} \
+          -DCLHEP_INCLUDE_DIR=${clhep_include} \
+          -DCMAKE_MODULE_PATH=${cmake_modules} || {
+        error: "Failed to cmake"
+        return 1
+    }
+
+}
+
+function run-make() {
+    make
+}
+
+##############################################################################
+# Parse the command line options
+##############################################################################
+
+# The current default platform
+k4_platform=x86_64-linux-gcc9-opt
+k4_version=master
+
+check-cepcsw-envvar || exit -1
+
+check-working-builddir || exit -1
+
+run-cmake || exit -1
+
+run-make || exit -1

--- a/build-k4.sh
+++ b/build-k4.sh
@@ -57,7 +57,7 @@ function run-cmake() {
 
     cd $blddir
 
-    local clhep_prefix=$(clhep-config --prefix)
+    local clhep_prefix=$(eval echo $(clhep-config --prefix))
     local clhep_include=${clhep_prefix}/include
 
     # locate the pandorapfa


### PR DESCRIPTION
This PR will fix the issue #53. 

BTW: The GEAR deployed at IHEP is modified a bit, adding following lines in `GEARConfig.cmake`:
```
set(GEAR_LIBRARIES)
list(APPEND GEAR_LIBRARIES ${GEAR_LIBRARY_DIR}/libgearsurf.so)
list(APPEND GEAR_LIBRARIES ${GEAR_LIBRARY_DIR}/libgear.so)
list(APPEND GEAR_LIBRARIES ${GEAR_LIBRARY_DIR}/libgearxml.so)
```