### PR TITLE
WIP: the FindCLHEP from Gaudi is used when using spack. Just remove the explict dependencies on CLHEP.

### DIFF
--- a/Digitisers/SimpleDigi/CMakeLists.txt
+++ b/Digitisers/SimpleDigi/CMakeLists.txt
@@ -1,6 +1,5 @@
 gaudi_subdir(SimpleDigi v0r0)
 
-find_package(CLHEP REQUIRED)
 find_package(GEAR REQUIRED)
 find_package(GSL REQUIRED ) 
 find_package(LCIO REQUIRED ) 

--- a/Reconstruction/PFA/Pandora/GaudiPandora/CMakeLists.txt
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/CMakeLists.txt
@@ -1,6 +1,5 @@
 gaudi_subdir(GaudiPandora v0r0)
 
-find_package(CLHEP REQUIRED)
 find_package(LCIO REQUIRED ) 
 find_package(GEAR REQUIRED)
 message("ENV GEAR: $ENV{GEAR}")

--- a/Service/TrackSystemSvc/CMakeLists.txt
+++ b/Service/TrackSystemSvc/CMakeLists.txt
@@ -1,7 +1,6 @@
 gaudi_subdir(TrackSystemSvc v0r0)
 
 find_package(ROOT 6.14 REQUIRED COMPONENTS Matrix Physics)
-find_package(CLHEP REQUIRED)
 find_package(GEAR REQUIRED)
 find_package(LCIO REQUIRED)
 find_package(EDM4HEP REQUIRED)

--- a/Utilities/KalDet/CMakeLists.txt
+++ b/Utilities/KalDet/CMakeLists.txt
@@ -5,7 +5,6 @@
 
 gaudi_subdir(KalDet v0r0)
 
-find_package(CLHEP REQUIRED)
 find_package(LCIO)
 find_package(GEAR)
 find_package(ROOT COMPONENTS MathCore)

--- a/Utilities/KiTrack/CMakeLists.txt
+++ b/Utilities/KiTrack/CMakeLists.txt
@@ -1,7 +1,6 @@
 gaudi_subdir(KiTrack v0r0)
 
 find_package(ROOT REQUIRED)
-find_package(CLHEP REQUIRED)
 #find_package(DD4hep REQUIRED)
 find_package(GSL REQUIRED)
 find_package(EDM4HEP REQUIRED)

--- a/build-k4.sh
+++ b/build-k4.sh
@@ -78,7 +78,6 @@ function run-cmake() {
     local cmake_modules=${pandorapfa_cmake_modules}
 
     cmake .. -DHOST_BINARY_TAG=${k4_platform} \
-          -DCLHEP_INCLUDE_DIR=${clhep_include} \
           -DCMAKE_MODULE_PATH=${cmake_modules} || {
         error: "Failed to cmake"
         return 1


### PR DESCRIPTION
This should fix the problem mentioned in https://github.com/key4hep/k4-spack/pull/73#discussion_r503340120. The solution is remove explict dependencies.