### PR TITLE
Fix tracking error

### DIFF
--- a/Digitisers/SimpleDigi/src/PlanarDigiAlg.cpp
+++ b/Digitisers/SimpleDigi/src/PlanarDigiAlg.cpp
@@ -91,10 +91,10 @@ StatusCode PlanarDigiAlg::initialize()
     return StatusCode::FAILURE;
   }
   
-  MarlinTrk::IMarlinTrkSystem* _trksystem =  _trackSystemSvc->getTrackSystem();
+  MarlinTrk::IMarlinTrkSystem* _trksystem =  _trackSystemSvc->getTrackSystem(this);
   _trksystem->init();
   
-  _trackSystemSvc->removeTrackSystem();
+  _trackSystemSvc->removeTrackSystem(this);
   
   return GaudiAlgorithm::initialize();
 }
@@ -338,8 +338,8 @@ StatusCode PlanarDigiAlg::execute()
     float weight = 1.0;
 
     debug() <<" Set relation between "
-            << " sim hit " << SimTHit 
-            << " to tracker hit " << trkHit
+            << " sim hit " << SimTHit.id() 
+            << " to tracker hit " << trkHit.id()
             << " with a weight of " << weight 
             << endmsg;
     trkHit.addToRawHits(SimTHit.getObjectID());

--- a/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
@@ -137,7 +137,7 @@ StatusCode ForwardTrackingAlg::initialize(){
     error() << "Failed to find TrackSystemSvc ..." << endmsg;
     return StatusCode::FAILURE;
   }
-  _trkSystem =  _trackSystemSvc->getTrackSystem();
+  _trkSystem =  _trackSystemSvc->getTrackSystem(this);
 
   if( _trkSystem == 0 ){
     error() << "Cannot initialize MarlinTrkSystem of Type: KalTest" <<endmsg;
@@ -150,7 +150,7 @@ StatusCode ForwardTrackingAlg::initialize(){
   _trkSystem->setOption( MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing,  _SmoothOn) ;    //smoothing
 
   // initialise the tracking system
-  //_trkSystem->init() ;
+  _trkSystem->init() ;
 
   /**********************************************************************************************/
   /*       Do a few checks, if the set parameters are right                                     */

--- a/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
@@ -64,7 +64,7 @@ DECLARE_COMPONENT( SiliconTrackingAlg )
 
 SiliconTrackingAlg::SiliconTrackingAlg(const std::string& name, ISvcLocator* svcLoc)
 : GaudiAlgorithm(name, svcLoc) {
-  
+
   //_description = "Pattern recognition in silicon trackers";
   
   _fastfitter = new MarlinTrk::HelixFit();
@@ -111,7 +111,7 @@ StatusCode  SiliconTrackingAlg::initialize() {
     error() << "Failed to find TrackSystemSvc ..." << endmsg;
     return StatusCode::FAILURE;
   }
-  _trksystem =  _trackSystemSvc->getTrackSystem();
+  _trksystem =  _trackSystemSvc->getTrackSystem(this);
   
   if( _trksystem == 0 ){
     error() << "Cannot initialize MarlinTrkSystem of Type: KalTest" <<endmsg;
@@ -448,12 +448,12 @@ int SiliconTrackingAlg::InitialiseFTD() {
       const float eps = 1.0e-07;
       // V must be the global z axis 
       if( fabs(V.dot(Z)) > eps ) {
-	error() << "SiliconTrackingAlg: VXD Hit measurment vectors V is not in the global X-Y plane. \n\n  exit(1) called from file " << __FILE__ << " and line " << __LINE__ << endmsg;
+	error() << "SiliconTrackingAlg: FTD Hit measurment vectors V is not in the global X-Y plane. \n\n  exit(1) called from file " << __FILE__ << " and line " << __LINE__ << endmsg;
 	exit(1);
       }
       
       if( fabs(U.dot(Z)) > eps ) {
-	error() << "SiliconTrackingAlg: VXD Hit measurment vectors U is not in the global X-Y plane. \n\n exit(1) called from file " << __FILE__ << " and line " << __LINE__ << endmsg;
+	error() << "SiliconTrackingAlg: FTD Hit measurment vectors U is not in the global X-Y plane. \n\n exit(1) called from file " << __FILE__ << " and line " << __LINE__ << endmsg;
 	exit(1);
       }
       // SJA:FIXME Here dU and dV are almost certainly dX and dY ... should test ...
@@ -491,7 +491,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
 	else {
 	  layer = 2*layer + 1;
 	}
-	
+	//debug() << "_petalBasedFTDWithOverlaps = true layer->2*layer,2layer+1 according to petalIndex = " << petalIndex << endmsg;
       }
       if (layer >= _nlayersFTD) {
 	fatal() << "SiliconTrackingAlg => fatal error in FTD : layer is outside allowed range : " << layer << " number of layers = " << _nlayersFTD <<  endmsg;
@@ -509,7 +509,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
       int iCode = iSemiSphere + 2*layer + 2*_nlayersFTD*iPhi;
       _sectorsFTD[iCode].push_back( hitExt );
       
-      debug() << " FTD Pixel Hit added : @ " << pos[0] << " " << pos[1] << " " << pos[2] << " drphi " << hitExt->getResolutionRPhi() << " dz " << hitExt->getResolutionZ() << "  iPhi = " << iPhi <<  " iSemiSphere "  << iSemiSphere << " iCode = " << iCode << "  layer = " << layer << endmsg;  
+      debug() << " FTD Pixel Hit added : @ " << pos[0] << " " << pos[1] << " " << pos[2] << " drphi " << hitExt->getResolutionRPhi() << " dz " << hitExt->getResolutionZ() << "  iPhi = " << iPhi << " iSemiSphere "  << iSemiSphere << " iCode = " << iCode << " layer = " << layer << " cellID = " << hit.getCellID() << endmsg;  
     }
   }
   // Reading out FTD SpacePoint Collection
@@ -579,7 +579,6 @@ int SiliconTrackingAlg::InitialiseFTD() {
       unsigned int petalIndex = static_cast<unsigned int>(getModuleID(hit));
       
       if ( _petalBasedFTDWithOverlaps == true ) {
-        
         // as we are dealing with staggered petals we will use 2*nlayers in each directions +/- z
         // the layers will follow the even odd numbering of the petals 
         if ( petalIndex % 2 == 0 ) {
@@ -588,7 +587,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
         else {
           layer = 2*layer + 1;
         }
-        
+        //debug() << "_petalBasedFTDWithOverlaps = true layer->2*layer,2layer+1 according to petalIndex = " << petalIndex << endmsg;
       }
       
       if (layer >= _nlayersFTD) {
@@ -607,7 +606,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
       int iCode = iSemiSphere + 2*layer + 2*_nlayersFTD*iPhi;
       _sectorsFTD[iCode].push_back( hitExt );
       
-      debug() << " FTD SpacePoint Hit added : @ " << pos[0] << " " << pos[1] << " " << pos[2] << " drphi " << hitExt->getResolutionRPhi() << " dz " << hitExt->getResolutionZ() << "  iPhi = " << iPhi <<  " iSemiSphere "  << iSemiSphere << " iCode = " << iCode << "  layer = " << layer << endmsg;  
+      debug() << " FTD SpacePoint Hit added : @ " << pos[0] << " " << pos[1] << " " << pos[2] << " drphi " << hitExt->getResolutionRPhi() << " dz " << hitExt->getResolutionZ() << "  iPhi = " << iPhi << " iSemiSphere "  << iSemiSphere << " iCode = " << iCode << " layer = " << layer << " cellID = " << hit.getCellID() << endmsg;  
       
     }
   }
@@ -677,7 +676,7 @@ int SiliconTrackingAlg::InitialiseVTX() {
         exit(1);
       }
       TrackerHitExtended * hitExt = new TrackerHitExtended(hit);
-      debug() << "Saved TrackerHit pointer in TrackerHitExtended " << ielem << ": " << hitExt->getTrackerHit() << std::endl;
+      //debug() << "Saved TrackerHit id in TrackerHitExtended " << ielem << ": " << hitExt->getTrackerHit().id() << std::endl;
             
       // SJA:FIXME: just use planar res for now
       hitExt->setResolutionRPhi(hit.getCovMatrix()[2]);
@@ -799,7 +798,7 @@ int SiliconTrackingAlg::InitialiseVTX() {
         // or a PIXEL based SIT, using 2D TrackerHitPlane like the VXD above
 	// by fucd
         //else if ( ( trkhit_P = dynamic_cast<TrackerHitPlane*>( hitCollection->getElementAt( ielem ) ) ) )  {
-	else if( UTIL::BitSet32( trkhit.getType() )[ 31 ]){
+	else if( UTIL::BitSet32( trkhit.getType() )[ 3 ]){
           // first we need to check if the measurement vectors are aligned with the global coordinates 
           //gear::Vector3D U(1.0,trkhit_P->getU()[1],trkhit_P->getU()[0],gear::Vector3D::spherical);
           //gear::Vector3D V(1.0,trkhit_P->getV()[1],trkhit_P->getV()[0],gear::Vector3D::spherical);
@@ -907,6 +906,7 @@ StatusCode  SiliconTrackingAlg::finalize(){
   //delete _trksystem ; _trksystem = 0;
   //delete _histos ; _histos = 0;
   info() << "Processed " << _nEvt << " events " << endmsg;
+  info() << lcio::ILDCellID0::encoder_string << " " << UTIL::ILDCellID0::encoder_string << endmsg;
   return GaudiAlgorithm::finalize();
 }
 
@@ -2052,7 +2052,7 @@ void SiliconTrackingAlg::AttachRemainingVTXHitsSlow() {
             // Here we are trying to find if a hits are too close i.e. closer than _minDistToDelta
 	    edm4hep::ConstTrackerHit trkhit1 = hit->getTrackerHit();
 	    edm4hep::ConstTrackerHit trkhit2 = hitVector[IHIT]->getTrackerHit();                  
-            
+	    
             if ( trkhit1.getCellID() == trkhit2.getCellID() ){ // i.e. they are in the same sensor
               
               float distance = 0.;
@@ -2691,9 +2691,9 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
         continue ; 
       }
       //TrackImpl* Track = new TrackImpl ;
-      auto track = trk_col->create();
+      //auto track = trk_col->create();
       //fucd
-      //edm4hep::Track track;// = new edm4hep::Track;
+      edm4hep::Track track;// = new edm4hep::Track;
       // setup initial dummy covariance matrix
       //std::vector<float> covMatrix;
       //covMatrix.resize(15);
@@ -2840,7 +2840,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       
       //trk_col->addElement(Track);     
       //fucd
-      //trk_col->push_back(track);
+      trk_col->push_back(track);
       for(int i=0;i<track.trackStates_size();i++){
 	// 1 = lcio::EVENT::TrackState::AtIP
 	edm4hep::TrackState trkStateIP = track.getTrackStates(i);

--- a/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.cpp
@@ -59,10 +59,10 @@ StatusCode SpacePointBuilderAlg::initialize() {
     return StatusCode::FAILURE;
   }
 
-  MarlinTrk::IMarlinTrkSystem* _trksystem =  _trackSystemSvc->getTrackSystem();
+  MarlinTrk::IMarlinTrkSystem* _trksystem =  _trackSystemSvc->getTrackSystem(this);
   _trksystem->init();
 
-  _trackSystemSvc->removeTrackSystem();
+  _trackSystemSvc->removeTrackSystem(this);
   
   return GaudiAlgorithm::initialize();
 }
@@ -204,7 +204,8 @@ StatusCode SpacePointBuilderAlg::execute(){
 
               spacePoint.setType( UTIL::set_bit( spacePoint.getType() ,  UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT ) ) ;
 
-              spCol->push_back( spacePoint ); 
+              spCol->push_back( spacePoint );
+	      debug() << "Hit accepted id = " << spacePoint.id() << " cellID = " << spacePoint.getCellID() << endmsg;
 	      //debug() << "push_back space point's id=" << spCol->at(spCol->size()-1).id() << endmsg;
               createdSpacePoints++;
               
@@ -433,12 +434,12 @@ edm4hep::TrackerHit SpacePointBuilderAlg::createSpacePoint( edm4hep::ConstTracke
   cov_plane(1,1) = (0.5 * du2) / cos2_alpha;
   cov_plane(2,2) = (0.5 * du2) / sin2_alpha;
   
-  debug() << "\t cov_plane  = " << cov_plane << endmsg;  
-  debug() << "\tstrip_angle = " << VA.angle(VB)/(M_PI/180) / 2.0 << " degrees " << endmsg;
+  debug() << "cov_plane  = " << cov_plane << endmsg;  
+  debug() << "strip_angle = " << VA.angle(VB)/(M_PI/180) / 2.0 << " degrees " << endmsg;
   
   CLHEP::HepSymMatrix cov_xyz= cov_plane.similarity(rot_sensor_matrix);
   
-  debug() << "\t cov_xyz  = " << cov_xyz << endmsg;
+  debug() << "cov_xyz  = " << cov_xyz << endmsg;
   
   std::array<float, 6> cov;
   //EVENT::FloatVec cov( 9 )  ; 
@@ -453,9 +454,7 @@ edm4hep::TrackerHit SpacePointBuilderAlg::createSpacePoint( edm4hep::ConstTracke
   }
   
   spacePoint.setCovMatrix(cov);
-  
-  debug() << "\tHit accepted id=" << spacePoint.id() << endmsg;
-  
+    
   return spacePoint;
 }
 /*

--- a/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
@@ -63,7 +63,7 @@ StatusCode TrackSubsetAlg::initialize() {
     error() << "Failed to find TrackSystemSvc ..." << endmsg;
     return StatusCode::FAILURE;
   }
-  _trkSystem =  _trackSystemSvc->getTrackSystem();
+  _trkSystem =  _trackSystemSvc->getTrackSystem(this);
 
   if( _trkSystem == 0 ){
     error() << "Cannot initialize MarlinTrkSystem of Type: KalTest" <<endmsg;
@@ -76,7 +76,7 @@ StatusCode TrackSubsetAlg::initialize() {
   _trkSystem->setOption( MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing,  _SmoothOn) ;    //smoothing
   
   // initialise the tracking system
-  //_trkSystem->init() ;
+  _trkSystem->init() ;
 
   return GaudiAlgorithm::initialize();
 }

--- a/Service/TrackSystemSvc/TrackSystemSvc/ITrackSystemSvc.h
+++ b/Service/TrackSystemSvc/TrackSystemSvc/ITrackSystemSvc.h
@@ -13,9 +13,9 @@ class ITrackSystemSvc: virtual public IService {
   virtual ~ITrackSystemSvc() = default;
   
   //Get the track manager
-  virtual MarlinTrk::IMarlinTrkSystem* getTrackSystem() = 0;
+  virtual MarlinTrk::IMarlinTrkSystem* getTrackSystem(void* address=0) = 0;
   
-  virtual void removeTrackSystem() = 0;
+  virtual void removeTrackSystem(void* address=0) = 0;
 };
 
 #endif

--- a/Service/TrackSystemSvc/src/TrackSystemSvc.cpp
+++ b/Service/TrackSystemSvc/src/TrackSystemSvc.cpp
@@ -26,15 +26,15 @@ MarlinTrk::IMarlinTrkSystem* TrackSystemSvc::getTrackSystem(void* address){
       mgr = _gear->getGearMgr();
     }
 
-    auto _geoSvc = service<IGeoSvc>("GeoSvc");
+    auto _geoSvc = service<IGeomSvc>("GeomSvc");
     if ( !_geoSvc ) {
-      info() << "Failed to find GeoSvc ..." << endmsg;
+      info() << "Failed to find GeomSvc ..." << endmsg;
     }
     if(mgr==0&&_geoSvc==0){
-      fatal() << "Both GearSvc and GeoSvc invalid!" << endmsg;
+      fatal() << "Both GearSvc and GeomSvc invalid!" << endmsg;
       return 0;
     }
-    debug() << "GearMgr=" << mgr << " GeoSvc=" << _geoSvc << endmsg;
+    debug() << "GearMgr=" << mgr << " GeomSvc=" << _geoSvc << endmsg;
     MarlinTrk::IMarlinTrkSystem* sys = new MarlinTrk::MarlinKalTest( *mgr, _geoSvc );
     m_trackSystems[address] = sys;
     debug() << "Track system created successfully for " << address << endmsg;

--- a/Service/TrackSystemSvc/src/TrackSystemSvc.h
+++ b/Service/TrackSystemSvc/src/TrackSystemSvc.h
@@ -9,14 +9,14 @@ class TrackSystemSvc : public extends<Service, ITrackSystemSvc>{
   TrackSystemSvc(const std::string& name, ISvcLocator* svc);
   ~TrackSystemSvc();
 
-  MarlinTrk::IMarlinTrkSystem* getTrackSystem() override;
-  void removeTrackSystem() override;
+  MarlinTrk::IMarlinTrkSystem* getTrackSystem(void* address=0) override;
+  void removeTrackSystem(void* address=0) override;
 
   StatusCode initialize() override;
   StatusCode finalize() override;
 
  private:
-  MarlinTrk::IMarlinTrkSystem* m_trackSystem;
+  std::map<void*, MarlinTrk::IMarlinTrkSystem*> m_trackSystems;
 };
 
 #endif

--- a/Utilities/DataHelper/src/TrackExtended.cc
+++ b/Utilities/DataHelper/src/TrackExtended.cc
@@ -33,7 +33,11 @@ TrackExtended::TrackExtended( TrackerHitExtended * trackerhit) {
 TrackExtended::~TrackExtended() {}
 
 ConstTrack TrackExtended::getTrack() {
-    return _track;
+  if(!_track.isAvailable()){
+    std::cout << "Error: track not available" << _track.isAvailable() << " id= " << _track.id() << std::endl;
+    throw std::runtime_error("Error: track not available");
+  }
+  return _track;
 }
 
 const float * TrackExtended::getSeedPosition() {

--- a/Utilities/KalDet/src/ild/common/MaterialDataBase.cc
+++ b/Utilities/KalDet/src/ild/common/MaterialDataBase.cc
@@ -204,36 +204,25 @@ void MaterialDataBase::createMaterials(const gear::GearMgr& gearMgr, IGeoSvc* ge
 
   
   // VXD Support Material
-  
-  try{
-  
-    //const gear::SimpleMaterial& vxd_sup_mat = gearMgr.getSimpleMaterial("VXDSupportMaterial");
-    /*
-    const gear::GearParametersImpl* vxd_sup_mat = geoSvc->getDetParameters("VXDSupportMaterial");
-    
-    A = vxd_sup_mat->getDoubleVal("A");
-    Z = vxd_sup_mat->getDoubleVal("Z");
-    density = vxd_sup_mat->getDoubleVal("Density");
-    radlen  = vxd_sup_mat->getDoubleVal("RadL");
-    name    = vxd_sup_mat->getStringVal("Name");
-    */
-    //A       = vxd_sup_mat.getA();
-    //Z       = vxd_sup_mat.getZ();
-    //density = vxd_sup_mat.getDensity() * (1000.0/ 1000000.0); // kg/m^3 -> g/cm^3
-    //radlen  = vxd_sup_mat.getRadLength() / 10.0 ; // mm -> cm
-    //name    = vxd_sup_mat.getName() ;
-    //std::cout << "debug fucd: " << "==================" << geoSvc << std::endl;
-    //TMaterial &vxdsupport = *new TMaterial(name.c_str(), "", A, Z, density, radlen, 0.);
-    //this->addMaterial(&vxdsupport, name);
+  if(geoSvc){
     TMaterial* vxdsupport = geoSvc->getMaterial("VXDSupportMaterial");
-    //std::cout << "debug fucd: " << "==================" << std::endl;
     if(vxdsupport) this->addMaterial(vxdsupport, "VXDSupportMaterial");
-    else std::cout << "Material VXDSupportMaterial not found" << std::endl; 
+    else std::cout << "Material VXDSupportMaterial not found" << std::endl;
   }
-  catch( gear::UnknownParameterException& e){   
-    std::cout << "Error while read material from GeoSvc!" << std::endl;
+  else{
+    try{
+      const gear::SimpleMaterial& vxd_sup_mat = gearMgr.getSimpleMaterial("VXDSupportMaterial");
+      A       = vxd_sup_mat.getA();
+      Z       = vxd_sup_mat.getZ();
+      density = vxd_sup_mat.getDensity() * (1000.0/ 1000000.0); // kg/m^3 -> g/cm^3
+      radlen  = vxd_sup_mat.getRadLength() / 10.0 ; // mm -> cm
+      name    = vxd_sup_mat.getName() ;
+      TMaterial &vxdsupport = *new TMaterial(name.c_str(), "", A, Z, density, radlen, 0.);
+      this->addMaterial(&vxdsupport, name);
+    }
+    catch( gear::UnknownParameterException& e){   
+      std::cout << "Error while read material from GeoSvc!" << std::endl;
+    }
   }
-  
-  
 }
 

--- a/Utilities/KalDet/src/ild/common/MaterialDataBase.cc
+++ b/Utilities/KalDet/src/ild/common/MaterialDataBase.cc
@@ -9,7 +9,7 @@
 #include "gearimpl/Util.h"
 #include <gear/SimpleMaterial.h>
 #include <gearimpl/GearParametersImpl.h>
-#include "DetInterface/IGeoSvc.h"
+#include "DetInterface/IGeomSvc.h"
 
 #include "TMaterial.h"
 
@@ -47,7 +47,7 @@ TMaterial* MaterialDataBase::getMaterial(std::string mat_name){
   
 }
 
-void MaterialDataBase::initialise( const gear::GearMgr& gearMgr, IGeoSvc* geoSvc ){
+void MaterialDataBase::initialise( const gear::GearMgr& gearMgr, IGeomSvc* geoSvc ){
   
   if( !_isInitialised ){
     this->createMaterials(gearMgr, geoSvc); 
@@ -57,7 +57,7 @@ void MaterialDataBase::initialise( const gear::GearMgr& gearMgr, IGeoSvc* geoSvc
   
 }
 
-void MaterialDataBase::registerForService(const gear::GearMgr& gearMgr, IGeoSvc* geoSvc ) {
+void MaterialDataBase::registerForService(const gear::GearMgr& gearMgr, IGeomSvc* geoSvc ) {
   
   if( !_isInitialised ){
     //std::cout << "debug fucd: " << "--------------------" << std::endl;
@@ -91,7 +91,7 @@ void MaterialDataBase::addMaterial(TMaterial* mat, std::string name) {
 }
 
 
-void MaterialDataBase::createMaterials(const gear::GearMgr& gearMgr, IGeoSvc* geoSvc ){
+void MaterialDataBase::createMaterials(const gear::GearMgr& gearMgr, IGeomSvc* geoSvc ){
   
   Double_t A, Z, density, radlen ;
   std::string name;
@@ -221,7 +221,7 @@ void MaterialDataBase::createMaterials(const gear::GearMgr& gearMgr, IGeoSvc* ge
       this->addMaterial(&vxdsupport, name);
     }
     catch( gear::UnknownParameterException& e){   
-      std::cout << "Error while read material from GeoSvc!" << std::endl;
+      std::cout << "Error while read material from GeomSvc!" << std::endl;
     }
   }
 }

--- a/Utilities/KalDet/src/ild/ftd/ILDFTDKalDetector.cc
+++ b/Utilities/KalDet/src/ild/ftd/ILDFTDKalDetector.cc
@@ -8,6 +8,7 @@
 #include "DetInterface/IGeoSvc.h"
 #include "DD4hep/Detector.h"
 #include "DDRec/DetectorData.h"
+#include "DD4hep/DD4hepUnits.h"
 
 #include "gear/GEAR.h"
 #include "gear/BField.h"
@@ -29,7 +30,6 @@
 ILDFTDKalDetector::ILDFTDKalDetector( const gear::GearMgr& gearMgr, IGeoSvc* geoSvc ) : 
 TVKalDetector(300), _nDisks(0) // SJA:FIXME initial size, 300 looks reasonable for ILD, though this would be better stored as a const somewhere
 {
-  
   // streamlog_out(DEBUG1) << "ILDFTDKalDetector building FTD detector using GEAR " << std::endl ;
   
   MaterialDataBase::Instance().registerForService(gearMgr, geoSvc);
@@ -41,14 +41,10 @@ TVKalDetector(300), _nDisks(0) // SJA:FIXME initial size, 300 looks reasonable f
   }
 
   this->build_staggered_design();
-
   
   SetOwner();
   
 }
-
-
-
 
 void ILDFTDKalDetector::build_staggered_design() {
   
@@ -532,7 +528,7 @@ void ILDFTDKalDetector::setupGearGeom( IGeoSvc* geoSvc ){
   }
   
   const dd4hep::Direction& field = geoSvc->lcdd()->field().magneticField(dd4hep::Position(0,0,0));
-  _bZ = field.z();
+  _bZ = field.z()/dd4hep::tesla;
 
   double strip_angle_deg = ftdData->angleStrip/CLHEP::degree;
   bool strip_angle_present = true;

--- a/Utilities/KalDet/src/ild/set/ILDSETKalDetector.cc
+++ b/Utilities/KalDet/src/ild/set/ILDSETKalDetector.cc
@@ -20,6 +20,7 @@
 #include "gearimpl/Util.h"
 
 #include "CLHEP/Units/SystemOfUnits.h"
+#include "DD4hep/DD4hepUnits.h"
 #include "TMath.h"
 
 #include "math.h"
@@ -46,7 +47,7 @@ ILDSETKalDetector::ILDSETKalDetector( const gear::GearMgr& gearMgr, IGeoSvc* geo
   else{
     setupGearGeom( gearMgr );
   }
-  
+
   if (_isStripDetector) {
     // streamlog_out(DEBUG4) << "\t\t building SET detector as STRIP Detector." << std::endl ;
   } else {
@@ -311,7 +312,7 @@ void ILDSETKalDetector::setupGearGeom( IGeoSvc* geoSvc ){
   }
 
   const dd4hep::Direction& field = geoSvc->lcdd()->field().magneticField(dd4hep::Position(0,0,0));
-  _bZ = field.z();
+  _bZ = field.z()/dd4hep::tesla;
 
   std::vector<dd4hep::rec::ZPlanarData::LayerLayout>& setlayers = setData->layers;
   _nLayers = setlayers.size();

--- a/Utilities/KalDet/src/ild/sit/ILDSITKalDetector.cc
+++ b/Utilities/KalDet/src/ild/sit/ILDSITKalDetector.cc
@@ -13,6 +13,7 @@
 #include "DD4hep/Detector.h"
 #include "DDRec/DetectorData.h"
 #include "CLHEP/Units/SystemOfUnits.h"
+#include "DD4hep/DD4hepUnits.h"
 
 #include <gear/GEAR.h>
 #include "gear/BField.h"
@@ -30,28 +31,26 @@
 ILDSITKalDetector::ILDSITKalDetector( const gear::GearMgr& gearMgr, IGeoSvc* geoSvc )
 : TVKalDetector(300) // SJA:FIXME initial size, 300 looks reasonable for ILD, though this would be better stored as a const somewhere
 {
+  // std::cout << "ILDSITKalDetector building SIT detector using GEAR " << std::endl ;
   
-  
-  // streamlog_out(DEBUG4) << "ILDSITKalDetector building SIT detector using GEAR " << std::endl ;
-
   MaterialDataBase::Instance().registerForService(gearMgr, geoSvc);
   
   TMaterial & air       = *MaterialDataBase::Instance().getMaterial("air");
   TMaterial & silicon   = *MaterialDataBase::Instance().getMaterial("silicon");
   TMaterial & carbon    = *MaterialDataBase::Instance().getMaterial("carbon");
+
   if(geoSvc){
     this->setupGearGeom(geoSvc);
   }
   else{
     this->setupGearGeom(gearMgr) ;
   }
-
+  
   if (_isStripDetector) {
     // streamlog_out(DEBUG4) << "\t\t building SIT detector as STRIP Detector." << std::endl ;    
   } else {
     // streamlog_out(DEBUG4) << "\t\t building SIT detector as PIXEL Detector." << std::endl ;    
   }
-
   
   //--The Ladder structure (realistic ladder)--
   int nLadders;
@@ -141,9 +140,7 @@ ILDSITKalDetector::ILDSITKalDetector( const gear::GearMgr& gearMgr, IGeoSvc* geo
           }
           
           
-          // streamlog_out(DEBUG0) << "ILDSITKalDetector add surface with CellID = "
-          // << CellID
-          // << std::endl ;
+	  //std::cout << "ILDSITKalDetector add surface with CellID = " << CellID << std::endl ;
           
         }
         
@@ -187,10 +184,8 @@ ILDSITKalDetector::ILDSITKalDetector( const gear::GearMgr& gearMgr, IGeoSvc* geo
             Add(new ILDParallelPlanarMeasLayer(silicon, silicon, sensitive_distance+sensitive_thickness*0.5, currPhi, _bZ, measurement_plane_sorting_policy, width, sensor_length, offset, z_centre_sensor, offset, true, CellID, "SITMeaslayer" )) ;
           }
 
-                                    
-          // streamlog_out(DEBUG0) << "ILDSITKalDetector add surface with CellID = "
-          // << CellID
-          // << std::endl ;
+	  
+	  //std::cout << "ILDSITKalDetector add surface with CellID = " << CellID << std::endl ;
 
           
         }
@@ -312,7 +307,7 @@ void ILDSITKalDetector::setupGearGeom( IGeoSvc* geoSvc ){
   }
 
   const dd4hep::Direction& field = geoSvc->lcdd()->field().magneticField(dd4hep::Position(0,0,0));
-  _bZ = field.z();
+  _bZ = field.z()/dd4hep::tesla;
 
   std::vector<dd4hep::rec::ZPlanarData::LayerLayout>& sitlayers = sitData->layers;
   _nLayers = sitlayers.size();

--- a/Utilities/KalDet/src/ild/support/ILDSupportKalDetector.cc
+++ b/Utilities/KalDet/src/ild/support/ILDSupportKalDetector.cc
@@ -19,6 +19,7 @@
 #include "DD4hep/Detector.h"
 #include "DDRec/DetectorData.h"
 #include "CLHEP/Units/SystemOfUnits.h"
+#include "DD4hep/DD4hepUnits.h"
 
 #include "gear/GEAR.h"
 #include "gear/BField.h"
@@ -37,11 +38,11 @@ TVKalDetector(10)
     const dd4hep::rec::ConicalSupportData* pBeamPipeData = geoSvc->getBeamPipeData();
     const std::vector<dd4hep::rec::ConicalSupportData::Section>& sections = pBeamPipeData->sections;
     const dd4hep::Direction& field = geoSvc->lcdd()->field().magneticField(dd4hep::Position(0,0,0));
-    bz = field.z();
+    bz = field.z()/dd4hep::tesla;
     for(int i=0;i<sections.size();i++){
-      z.push_back(sections[i].zPos);
-      rInner.push_back(sections[i].rInner);
-      rOuter.push_back(sections[i].rOuter);
+      z.push_back(sections[i].zPos*CLHEP::cm  );
+      rInner.push_back(sections[i].rInner*CLHEP::cm );
+      rOuter.push_back(sections[i].rOuter*CLHEP::cm );
     }
   }
   else{
@@ -54,8 +55,8 @@ TVKalDetector(10)
     rInner = pBeamPipe.getDoubleVals("RInner"); //inner radius of the cone
     rOuter = pBeamPipe.getDoubleVals("ROuter"); //outer radius of the cone
   }
-  //for(int i=0;i<sections.size();i++){
-  //  std::cout << z[i] << " " << rInner[i] << " " << rOuter[i] << std::endl;
+  //for(int i=0;i<z.size();i++){
+  //std::cout << z[i] << " " << rInner[i] << " " << rOuter[i] << std::endl;
   //}
   MaterialDataBase::Instance().registerForService(gearMgr, geoSvc);
   TMaterial & beam      = *MaterialDataBase::Instance().getMaterial("beam");

--- a/Utilities/KalDet/src/ild/tpc/ILDTPCKalDetector.cc
+++ b/Utilities/KalDet/src/ild/tpc/ILDTPCKalDetector.cc
@@ -14,6 +14,7 @@
 #include "DD4hep/Detector.h"
 #include "DDRec/DetectorData.h"
 #include "CLHEP/Units/SystemOfUnits.h"
+#include "DD4hep/DD4hepUnits.h"
 
 #include "gear/GEAR.h"
 #include "gear/BField.h"
@@ -52,7 +53,7 @@ TVKalDetector(250) // SJA:FIXME initial size, 250 looks reasonable for ILD, thou
     }
 
     const dd4hep::Direction& field = geoSvc->lcdd()->field().magneticField(dd4hep::Position(0,0,0));
-    bz = field.z();
+    bz = field.z()/dd4hep::tesla;
     nlayers = tpcData->maxRow;
     lhalf = tpcData->driftLength*CLHEP::cm;
     rstep = tpcData->padHeight*CLHEP::cm;

--- a/Utilities/KalDet/src/ild/vxd/ILDVXDKalDetector.cc
+++ b/Utilities/KalDet/src/ild/vxd/ILDVXDKalDetector.cc
@@ -14,6 +14,7 @@
 #include "DD4hep/Detector.h"
 #include "DDRec/DetectorData.h"
 #include "CLHEP/Units/SystemOfUnits.h"
+#include "DD4hep/DD4hepUnits.h"
 
 #include <gear/GEAR.h>
 #include "gear/BField.h"
@@ -48,13 +49,14 @@ ILDVXDKalDetector::ILDVXDKalDetector( const gear::GearMgr& gearMgr, IGeoSvc* geo
   TMaterial & aluminium = *MaterialDataBase::Instance().getMaterial("aluminium");
   
   _vxd_Cryostat.exists = false;
-  
+
   if(geoSvc){
     this->setupGearGeom(geoSvc) ;
   }
   else{
     this->setupGearGeom(gearMgr) ;
   }
+
   //--The Ladder structure (realistic ladder)--
   int nLadders;
   
@@ -398,7 +400,7 @@ void ILDVXDKalDetector::setupGearGeom( IGeoSvc* geoSvc){
   }
   */
   const dd4hep::Direction& field = geoSvc->lcdd()->field().magneticField(dd4hep::Position(0,0,0));
-  _bZ = field.z();
+  _bZ = field.z()/dd4hep::tesla;
   
   const gear::ZPlanarParametersImpl* pVXDDetMain = geoSvc->getVXDParameters();
   const gear::VXDLayerLayout& pVXDLayerLayout = pVXDDetMain->getVXDLayerLayout();


### PR DESCRIPTION
* separate common track system by oneself
     * Issue: options are covered with each other in algorithms, because of using a common track system `_trksystem =  _trackSystemSvc->getTrackSystem();`
     * create special track system according ptr now: `_trksystem =  _trackSystemSvc->getTrackSystem(this);`; accordingly, insert ptr of track system into map in TrackSystemSvc
     * additional fix:
           * `UTIL::BitSet32( trkhit.getType() )[ ]` here should be bit order, 31->3, since 8 denotes LCIO's TrackerHitPlane now, it will be updated a common constant.
           * if `auto track = trk_col->create()` used, a null track will create although no track found, fix by `trk_col->push_back(track)` method
* fix error to return unavaible TrackerHit
     * Issue: unavailble Track cause crash sometime while testing FullLDCTrackingAlg [Utilities/DataHelper/src/TrackExtended.cc](Utilities/DataHelper/src/TrackExtended.cc)
     * add protection and throw exception, `try{}catch(std::runtime_error& e){}` is safe method to get Track from TrackExtended
*  add GeoSvc and GearMgr choice for [Utilities/KalDet/src/ild/common/MaterialDataBase.cc](Utilities/KalDet/src/ild/common/MaterialDataBase.cc) like others
* fix error on field unit
     * Issue: without field unit, the vaule will be e-13 level
     * fixed and note: dd4hep::tesla = 1e-13, CLHEP::tesla = 1e-3