### PR TITLE
Using CONFIG option in find_package for the package CLHEP

### DIFF
--- a/Digitisers/DCHDigi/CMakeLists.txt
+++ b/Digitisers/DCHDigi/CMakeLists.txt
@@ -1,5 +1,6 @@
 gaudi_subdir(DCHDigi v0r0)
 
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(DD4hep COMPONENTS DDG4 REQUIRED)
 find_package(EDM4HEP REQUIRED )
 message("EDM4HEP_INCLUDE_DIRS: ${EDM4HEP_INCLUDE_DIR}")
@@ -18,8 +19,8 @@ gaudi_depends_on_subdirs(
 )
 ## Modules
 gaudi_add_module(DCHDigi ${srcs}
-    INCLUDE_DIRS FWCore GaudiKernel GaudiAlgLib CLHEP DD4hep 
-    LINK_LIBRARIES FWCore GaudiKernel GaudiAlgLib CLHEP DD4hep ${DD4hep_COMPONENT_LIBRARIES} DDRec
+    INCLUDE_DIRS FWCore GaudiKernel GaudiAlgLib ${CLHEP_INCLUDE_DIR} DD4hep 
+    LINK_LIBRARIES FWCore GaudiKernel GaudiAlgLib ${CLHEP_LIBRARIES} DD4hep ${DD4hep_COMPONENT_LIBRARIES} DDRec
     -Wl,--no-as-needed 
     EDM4HEP::edm4hep EDM4HEP::edm4hepDict
 )

--- a/Digitisers/DCHDigi/CMakeLists.txt
+++ b/Digitisers/DCHDigi/CMakeLists.txt
@@ -7,7 +7,6 @@ message("EDM4HEP_INCLUDE_DIRS: ${EDM4HEP_INCLUDE_DIR}")
 message("EDM4HEP_LIB: ${EDM4HEP_LIBRARIES}")
 include_directories(${EDM4HEP_INCLUDE_DIR})
 
-find_package(CLHEP REQUIRED)
 find_package(podio REQUIRED )
 
 set(srcs

--- a/Digitisers/G2CDArbor/CMakeLists.txt
+++ b/Digitisers/G2CDArbor/CMakeLists.txt
@@ -1,5 +1,6 @@
 gaudi_subdir(G2CDArbor v0r0)
 
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(DD4hep COMPONENTS DDG4 REQUIRED)
 find_package(EDM4HEP REQUIRED)
 find_package(GEAR REQUIRED)
@@ -21,7 +22,7 @@ set(G2CDArbor_srcs src/*.cpp)
 
 # Modules
 gaudi_add_module(G2CDArbor ${G2CDArbor_srcs}
-    INCLUDE_DIRS K4FWCore GaudiKernel GaudiAlgLib CLHEP DD4hep gear ${GSL_INCLUDE_DIRS} ${LCIO_INCLUDE_DIRS}
-    LINK_LIBRARIES K4FWCore GaudiKernel GaudiAlgLib CLHEP DD4hep ${GEAR_LIBRARIES} ${GSL_LIBRARIES} ${LCIO_LIBRARIES}
+    INCLUDE_DIRS K4FWCore GaudiKernel GaudiAlgLib ${CLHEP_INCLUDE_DIR} DD4hep gear ${GSL_INCLUDE_DIRS} ${LCIO_INCLUDE_DIRS}
+    LINK_LIBRARIES K4FWCore GaudiKernel GaudiAlgLib ${CLHEP_LIBRARIES} DD4hep ${GEAR_LIBRARIES} ${GSL_LIBRARIES} ${LCIO_LIBRARIES}
     EDM4HEP::edm4hep EDM4HEP::edm4hepDict
 )

--- a/Digitisers/SimpleDigi/CMakeLists.txt
+++ b/Digitisers/SimpleDigi/CMakeLists.txt
@@ -1,5 +1,6 @@
 gaudi_subdir(SimpleDigi v0r0)
 
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(GEAR REQUIRED)
 find_package(GSL REQUIRED ) 
 find_package(LCIO REQUIRED ) 
@@ -17,6 +18,6 @@ set(SimpleDigi_srcs src/*.cpp)
 
 # Modules
 gaudi_add_module(SimpleDigi ${SimpleDigi_srcs}
-    INCLUDE_DIRS K4FWCore GaudiKernel GaudiAlgLib CLHEP gear ${GSL_INCLUDE_DIRS} ${LCIO_INCLUDE_DIRS}
-    LINK_LIBRARIES K4FWCore GaudiKernel GaudiAlgLib CLHEP ${GEAR_LIBRARIES} ${GSL_LIBRARIES} ${LCIO_LIBRARIES} EDM4HEP::edm4hep EDM4HEP::edm4hepDict
+    INCLUDE_DIRS K4FWCore GaudiKernel GaudiAlgLib ${CLHEP_INCLUDE_DIR} gear ${GSL_INCLUDE_DIRS} ${LCIO_INCLUDE_DIRS}
+    LINK_LIBRARIES K4FWCore GaudiKernel GaudiAlgLib ${CLHEP_LIBRARIES} ${GEAR_LIBRARIES} ${GSL_LIBRARIES} ${LCIO_LIBRARIES} EDM4HEP::edm4hep EDM4HEP::edm4hepDict
 )

--- a/Generator/CMakeLists.txt
+++ b/Generator/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(LCIO)
 find_package(podio)
 find_package(EDM4HEP)
 find_package(HepMC)
-find_package(CLHEP)
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(K4FWCore REQUIRED)
 
 if(ROOT_FOUND)

--- a/Reconstruction/Digi_Calo/CMakeLists.txt
+++ b/Reconstruction/Digi_Calo/CMakeLists.txt
@@ -1,5 +1,6 @@
 gaudi_subdir(Digi_Calo v0r0)
 
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(DD4hep COMPONENTS DDG4 REQUIRED)
 find_package(EDM4HEP REQUIRED )
 message("EDM4HEP_INCLUDE_DIRS: ${EDM4HEP_INCLUDE_DIR}")
@@ -18,8 +19,8 @@ gaudi_depends_on_subdirs(
 )
 ## Modules
 gaudi_add_module(Digi_Calo ${srcs}
-    INCLUDE_DIRS FWCore GaudiKernel GaudiAlgLib CLHEP DD4hep 
-    LINK_LIBRARIES FWCore GaudiKernel GaudiAlgLib CLHEP DD4hep ${DD4hep_COMPONENT_LIBRARIES} DDRec
+    INCLUDE_DIRS FWCore GaudiKernel GaudiAlgLib ${CLHEP_INCLUDE_DIR} DD4hep 
+    LINK_LIBRARIES FWCore GaudiKernel GaudiAlgLib ${CLHEP_LIBRARIES} DD4hep ${DD4hep_COMPONENT_LIBRARIES} DDRec
     -Wl,--no-as-needed 
     EDM4HEP::edm4hep EDM4HEP::edm4hepDict
 )

--- a/Reconstruction/PFA/Pandora/GaudiPandora/CMakeLists.txt
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(LCIO REQUIRED )
 find_package(GEAR REQUIRED)
 message("ENV GEAR: $ENV{GEAR}")
 
-
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(EDM4HEP REQUIRED )
 include_directories(${EDM4HEP_INCLUDE_DIR})
 
@@ -37,8 +37,8 @@ set(dir_srcs
 set(dir_include include)
 # Modules
 gaudi_add_module(GaudiPandora ${dir_srcs}
-    INCLUDE_DIRS ${dir_include} GaudiKernel FWCore CLHEP  ${LCIO_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS} gear  
-    LINK_LIBRARIES GaudiKernel FWCore CLHEP ROOT ${LCIO_LIBRARIES} ${GEAR_LIBRARIES} DataHelperLib 
+    INCLUDE_DIRS ${dir_include} GaudiKernel FWCore ${CLHEP_INCLUDE_DIR}  ${LCIO_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS} gear  
+    LINK_LIBRARIES GaudiKernel FWCore ${CLHEP_LIBRARIES} ROOT ${LCIO_LIBRARIES} ${GEAR_LIBRARIES} DataHelperLib 
       -Wl,--no-as-needed 
       EDM4HEP::edm4hep EDM4HEP::edm4hepDict
       -Wl,--as-needed 

--- a/Reconstruction/PFA/Pandora/MatrixPandora/CMakeLists.txt
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/CMakeLists.txt
@@ -1,7 +1,7 @@
 gaudi_subdir(MatrixPandora v0r0)
 
 find_package(DD4hep COMPONENTS DDG4 REQUIRED)
-find_package(CLHEP REQUIRED)
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(LCIO REQUIRED ) 
 find_package(GEAR REQUIRED)
 find_package(EDM4HEP REQUIRED ) 
@@ -37,8 +37,8 @@ set(dir_srcs
 set(dir_include include)
 # Modules
 gaudi_add_module(MatrixPandora ${dir_srcs}
-    INCLUDE_DIRS ${dir_include} GaudiKernel FWCore CLHEP  ${LCIO_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS} gear DD4hep  
-    LINK_LIBRARIES GaudiKernel FWCore CLHEP ROOT ${LCIO_LIBRARIES} ${GEAR_LIBRARIES} DD4hep ${DD4hep_COMPONENT_LIBRARIES} DDRec DataHelperLib
+    INCLUDE_DIRS ${dir_include} GaudiKernel FWCore ${CLHEP_INCLUDE_DIR}  ${LCIO_INCLUDE_DIRS} ${ROOT_INCLUDE_DIRS} gear DD4hep  
+    LINK_LIBRARIES GaudiKernel FWCore ${CLHEP_LIBRARIES} ROOT ${LCIO_LIBRARIES} ${GEAR_LIBRARIES} DD4hep ${DD4hep_COMPONENT_LIBRARIES} DDRec DataHelperLib
       -Wl,--no-as-needed 
       EDM4HEP::edm4hep EDM4HEP::edm4hepDict
       -Wl,--as-needed 

--- a/Service/TrackSystemSvc/CMakeLists.txt
+++ b/Service/TrackSystemSvc/CMakeLists.txt
@@ -1,5 +1,6 @@
 gaudi_subdir(TrackSystemSvc v0r0)
 
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(ROOT 6.14 REQUIRED COMPONENTS Matrix Physics)
 find_package(GEAR REQUIRED)
 find_package(LCIO REQUIRED)
@@ -20,8 +21,8 @@ gaudi_install_headers(TrackSystemSvc)
 
 gaudi_add_library(TrackSystemSvcLib ${TrackSystemSvcLib_srcs}
     PUBLIC_HEADERS TrackSystemSvc
-    INCLUDE_DIRS GaudiKernel ROOT CLHEP gear ${LCIO_INCLUDE_DIRS} ${EDM4HEP_INCLUDE_DIRS}
-    LINK_LIBRARIES DataHelperLib KalTestLib KalDetLib GaudiKernel ROOT CLHEP ${GEAR_LIBRARIES} ${LCIO_LIBRARIES}
+    INCLUDE_DIRS GaudiKernel ROOT ${CLHEP_INCLUDE_DIR} gear ${LCIO_INCLUDE_DIRS} ${EDM4HEP_INCLUDE_DIRS}
+    LINK_LIBRARIES DataHelperLib KalTestLib KalDetLib GaudiKernel ROOT ${CLHEP_LIBRARIES} ${GEAR_LIBRARIES} ${LCIO_LIBRARIES}
      -Wl,--no-as-needed
      EDM4HEP::edm4hep EDM4HEP::edm4hepDict
      -Wl,--as-needed

--- a/Utilities/KalDet/CMakeLists.txt
+++ b/Utilities/KalDet/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 gaudi_subdir(KalDet v0r0)
 
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(LCIO)
 find_package(GEAR)
 find_package(ROOT COMPONENTS MathCore)
@@ -76,5 +77,5 @@ set( KalDetLib_srcs ${LIB_SOURCES} ${COMMON_SOURCES} )
 
 gaudi_add_library(KalDetLib ${KalDetLib_srcs}
 		 PUBLIC_HEADERS kaldet
-                 LINK_LIBRARIES GaudiKernel ROOT CLHEP LCIO ${GEAR_LIBRARIES} KalTestLib EDM4HEP::edm4hep EDM4HEP::edm4hepDict ${DD4hep_COMPONENT_LIBRARIES}
+                 LINK_LIBRARIES GaudiKernel ROOT ${CLHEP_LIBRARIES} LCIO ${GEAR_LIBRARIES} KalTestLib EDM4HEP::edm4hep EDM4HEP::edm4hepDict ${DD4hep_COMPONENT_LIBRARIES}
 )

--- a/Utilities/KiTrack/CMakeLists.txt
+++ b/Utilities/KiTrack/CMakeLists.txt
@@ -1,5 +1,6 @@
 gaudi_subdir(KiTrack v0r0)
 
+find_package(CLHEP REQUIRED;CONFIG)
 find_package(ROOT REQUIRED)
 #find_package(DD4hep REQUIRED)
 find_package(GSL REQUIRED)
@@ -16,6 +17,6 @@ include_directories(src)
 
 gaudi_add_library(KiTrackLib ${KiTrackLib_srcs}
     PUBLIC_HEADERS KiTrack 
-    LINK_LIBRARIES DataHelperLib TrackSystemSvcLib ROOT CLHEP GSL EDM4HEP::edm4hep LCIO
+    LINK_LIBRARIES DataHelperLib TrackSystemSvcLib ROOT ${CLHEP_LIBRARIES} GSL EDM4HEP::edm4hep LCIO
     #              DD4hep
 )


### PR DESCRIPTION
In previous PR #55, I remove the dependencies on CLHEP. However, some developers still need to use the CLHEP. Current solution is using CONFIG file instead of FindCLHEP.