### PR TITLE
Fixed the phiFromXY() function to subtract a pai

### DIFF
--- a/Detector/DetDriftChamber/compact/det.xml
+++ b/Detector/DetDriftChamber/compact/det.xml
@@ -59,7 +59,7 @@
 
   <readouts>
     <readout name="DriftChamberHitsCollection">
-      <segmentation type="GridDriftChamber" cell_size="10*mm" offset_phi="0." epsilon0="Epsilon" detector_length="SDT_length" identifier_phi="cellID" />
+      <segmentation type="GridDriftChamber" cell_size="10*mm" epsilon0="Epsilon" detector_length="SDT_length" identifier_phi="cellID" />
 
       <id>system:8,chamber:1,layer:8,cellID:16</id>
     </readout>

--- a/Detector/DetDriftChamber/compact/det.xml
+++ b/Detector/DetDriftChamber/compact/det.xml
@@ -59,7 +59,7 @@
 
   <readouts>
     <readout name="DriftChamberHitsCollection">
-      <segmentation type="GridDriftChamber" cell_size="10*mm" offset_phi="0." epsilon0="Epsilon" detector_length="SDT_half_length" identifier_phi="cellID" />
+      <segmentation type="GridDriftChamber" cell_size="10*mm" offset_phi="0." epsilon0="Epsilon" detector_length="SDT_length" identifier_phi="cellID" />
 
       <id>system:8,chamber:1,layer:8,cellID:16</id>
     </readout>

--- a/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
+++ b/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
@@ -119,7 +119,7 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
         double layer_Phi = 2*M_PI / ncell_layer;
 
         if(layer_id %2 ==0){ offset = 0.; }
-        else { offset = 0.;}//0.5 * layer_Phi; }
+        else { offset = 0.5 * layer_Phi; }
 
         DCHseg->setGeomParams(layer_id, layer_Phi, rmid, epsilon, offset);
         DCHseg->setWiresInLayer(layer_id, numWire);

--- a/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
+++ b/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
@@ -114,11 +114,12 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
         double rmid = delta_a_func(rmin,rmax);
         double ilayer_cir = 2 * M_PI * rmid;
         double ncell = ilayer_cir / chamber_layer_width;
-        int ncell_layer = ceil(ncell);
+        int ncell_layer = floor(ncell);
         int numWire = ncell_layer;
         double layer_Phi = 2*M_PI / ncell_layer;
+
         if(layer_id %2 ==0){ offset = 0.; }
-        else { offset = 0.5 * layer_Phi; }
+        else { offset = 0.;}//0.5 * layer_Phi; }
 
         DCHseg->setGeomParams(layer_id, layer_Phi, rmid, epsilon, offset);
         DCHseg->setWiresInLayer(layer_id, numWire);

--- a/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
@@ -46,6 +46,7 @@ public:
                         const VolumeID& aVolumeID) const;
   virtual double distanceTrackWire(const CellID& cID, const TVector3& hit_start, const TVector3& hit_end) const;
 
+  double phi(const CellID& cID) const;
   inline double cell_Size() const { return m_cellSize; }
   inline double offset_phi() const { return m_offsetPhi; }
   inline double epsilon0() const { return m_epsilon0; }
@@ -54,10 +55,10 @@ public:
   // Setters
 
   inline double phiFromXY(const Vector3D& aposition) const {
-    return std::atan2(aposition.Y, aposition.X) + M_PI ;
+    return std::atan2(aposition.Y, aposition.X) ;
   }
 
-  inline void setGeomParams(int layer, double layerphi, double R, double eps, double offset ) {
+  inline void setGeomParams(int layer, double layerphi, double R, double eps, double offset) {
     // layer_params[layer] = {layerphi,R,eps};
     layer_params.insert(std::pair<int,LAYER>(layer,LAYER(layerphi,R,eps,offset)));
    }
@@ -72,9 +73,9 @@ public:
 //    else { phi0 = 0.5 * _currentLayerphi; }
       double phi0 = m_offset;
 
-      auto phi_start = _currentLayerphi * i + phi0;
+      auto phi_start = _currentLayerphi * (i + 0.5) + phi0;
       if(phi_start > 2 * M_PI) { phi_start = phi_start - 2 * M_PI; }
-      auto phi_end = phi_start + _currentLayerphi;
+      auto phi_end = phi_start;// + _currentLayerphi;
 
       TVector3 Wstart = returnWirePosition(phi_start, 1);
       TVector3 Wend = returnWirePosition(phi_end, -1);
@@ -117,14 +118,14 @@ public:
     m_offset = offset;
  }
 
-  inline double returnAlpha() const {
-    double alpha = 2 * std::asin(m_detectorLength * std::tan(m_epsilon0)/(2 * _currentRadius));
-    return alpha;
+ inline double returnAlpha() const {
+   double alpha = 2 * std::asin(m_detectorLength * std::tan(m_epsilon0)/(2 * _currentRadius));
+   return alpha;
  }
 
 protected:
   /* *** nalipour *** */
-  double phi(const CellID& cID) const;
+//  double phi(const CellID& cID) const;
   std::map<int,LAYER> layer_params; // <layer, {layerphi, R, eps, offset}>
   std::map<int, std::vector<std::pair<TVector3, TVector3> >> m_wiresPositions; // < layer, vec<WireMidpoint, WireDirection> >
 

--- a/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
@@ -124,8 +124,7 @@ public:
  }
 
 protected:
-  /* *** nalipour *** */
-//  double phi(const CellID& cID) const;
+
   std::map<int,LAYER> layer_params; // <layer, {layerphi, R, eps, offset}>
   std::map<int, std::vector<std::pair<TVector3, TVector3> >> m_wiresPositions; // < layer, vec<WireMidpoint, WireDirection> >
 

--- a/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
@@ -23,7 +23,7 @@ typedef struct Layer
    double eps;
    double offset;
    Layer(){};
-   Layer(double x, double y, double z, double k):layerphi(x),R(y),eps(z),offset(k){};
+   Layer(double x, double y, double z, double k):layerphi(x),R(y),eps(z),offset(k){}
    bool operator < (const Layer &a) const
    {
       return layerphi < a.layerphi;
@@ -46,7 +46,7 @@ public:
                         const VolumeID& aVolumeID) const;
   virtual double distanceTrackWire(const CellID& cID, const TVector3& hit_start/*, const TVector3& hit_end*/) const;
 
-  double phi(const CellID& cID) const;
+//  double phi(const CellID& cID) const;
   inline double cell_Size() const { return m_cellSize; }
   inline double epsilon0() const { return m_epsilon0; }
   inline double detectorLength() const { return m_detectorLength; }
@@ -122,6 +122,7 @@ public:
 
 protected:
 
+  double phi(const CellID& cID) const;
   std::map<int,LAYER> layer_params; // <layer, {layerphi, R, eps, offset}>
   std::map<int, std::vector<std::pair<TVector3, TVector3> >> m_wiresPositions; // < layer, vec<WireMidpoint, WireDirection> >
 

--- a/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
@@ -44,7 +44,7 @@ public:
   virtual Vector3D position(const CellID& aCellID) const;
   virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
                         const VolumeID& aVolumeID) const;
-  virtual double distanceTrackWire(const CellID& cID, const TVector3& hit_start, const TVector3& hit_end) const;
+  virtual double distanceTrackWire(const CellID& cID, const TVector3& hit_start/*, const TVector3& hit_end*/) const;
 
   double phi(const CellID& cID) const;
   inline double cell_Size() const { return m_cellSize; }
@@ -55,7 +55,9 @@ public:
   // Setters
 
   inline double phiFromXY(const Vector3D& aposition) const {
-    return std::atan2(aposition.Y, aposition.X) ;
+    double beta =  std::atan2(aposition.Y, aposition.X) ;
+    if( beta < 0 ) { beta = beta + 2 * M_PI; }
+    return beta;
   }
 
   inline void setGeomParams(int layer, double layerphi, double R, double eps, double offset) {

--- a/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
@@ -44,7 +44,7 @@ public:
   virtual Vector3D position(const CellID& aCellID) const;
   virtual CellID cellID(const Vector3D& aLocalPosition, const Vector3D& aGlobalPosition,
                         const VolumeID& aVolumeID) const;
-  virtual double distanceTrackWire(const CellID& cID, const TVector3& hit_start/*, const TVector3& hit_end*/) const;
+  virtual double distanceTrackWire(const CellID& cID, const TVector3& hit_start, const TVector3& hit_end) const;
 
 //  double phi(const CellID& cID) const;
   inline double cell_Size() const { return m_cellSize; }

--- a/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
+++ b/Detector/DetSegmentation/DetSegmentation/GridDriftChamber.h
@@ -48,20 +48,18 @@ public:
 
   double phi(const CellID& cID) const;
   inline double cell_Size() const { return m_cellSize; }
-  inline double offset_phi() const { return m_offsetPhi; }
   inline double epsilon0() const { return m_epsilon0; }
   inline double detectorLength() const { return m_detectorLength; }
   inline const std::string& fieldNamePhi() const { return m_phiID; }
   // Setters
 
   inline double phiFromXY(const Vector3D& aposition) const {
-    double beta =  std::atan2(aposition.Y, aposition.X) ;
-    if( beta < 0 ) { beta = beta + 2 * M_PI; }
-    return beta;
+    double hit_phi =  std::atan2(aposition.Y, aposition.X) ;
+    if( hit_phi < 0 ) { hit_phi += 2 * M_PI; }
+    return hit_phi;
   }
 
   inline void setGeomParams(int layer, double layerphi, double R, double eps, double offset) {
-    // layer_params[layer] = {layerphi,R,eps};
     layer_params.insert(std::pair<int,LAYER>(layer,LAYER(layerphi,R,eps,offset)));
    }
 
@@ -71,13 +69,10 @@ public:
     updateParams(layer);
     for (int i = 0; i<numWires; ++i) {
 
-//    if(layer % 2 == 0) { phi0 = 0.; }
-//    else { phi0 = 0.5 * _currentLayerphi; }
       double phi0 = m_offset;
 
-      auto phi_start = _currentLayerphi * (i + 0.5) + phi0;
-      if(phi_start > 2 * M_PI) { phi_start = phi_start - 2 * M_PI; }
-      auto phi_end = phi_start;// + _currentLayerphi;
+      auto phi_start = _currentLayerphi * i + phi0;
+      auto phi_end = phi_start + _currentLayerphi;
 
       TVector3 Wstart = returnWirePosition(phi_start, 1);
       TVector3 Wend = returnWirePosition(phi_end, -1);
@@ -131,7 +126,6 @@ protected:
   std::map<int, std::vector<std::pair<TVector3, TVector3> >> m_wiresPositions; // < layer, vec<WireMidpoint, WireDirection> >
 
   double m_cellSize;
-  double m_offsetPhi;
   double m_epsilon0;
   double m_detectorLength;
   std::string m_phiID;

--- a/Detector/DetSegmentation/src/GridDriftChamber.cpp
+++ b/Detector/DetSegmentation/src/GridDriftChamber.cpp
@@ -11,7 +11,6 @@ GridDriftChamber::GridDriftChamber(const std::string& cellEncoding) : Segmentati
   _description = "Drift chamber segmentation in the global coordinates";
 
   registerParameter("cell_size", "cell size", m_cellSize, 0., SegmentationParameter::LengthUnit);
-  registerParameter("offset_phi", "offset in phi", m_offsetPhi, 0., SegmentationParameter::LengthUnit, true);
   registerParameter("detector_length", "Length of the wire", m_detectorLength, 1., SegmentationParameter::LengthUnit);
   registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "cellID");
 }
@@ -22,7 +21,6 @@ GridDriftChamber::GridDriftChamber(const BitFieldCoder* decoder) : Segmentation(
   _description = "Drift chamber segmentation in the global coordinates";
 
   registerParameter("cell_size", "cell size", m_cellSize, 1., SegmentationParameter::LengthUnit);
-  registerParameter("offset_phi", "offset in phi", m_offsetPhi, 0., SegmentationParameter::LengthUnit, true);
   registerParameter("epsilon0", "epsilon", m_epsilon0, 0., SegmentationParameter::AngleUnit, true);
   registerParameter("detector_length", "Length of the wire", m_detectorLength, 1., SegmentationParameter::LengthUnit);
   registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "cellID");
@@ -46,37 +44,32 @@ CellID GridDriftChamber::cellID(const Vector3D& /*localPosition*/, const Vector3
   double posy = globalPosition.Y;
   double offsetphi= m_offset;
   int _lphi;
-//  if(layerID % 2 == 0) {
-//      offsetphi = 0.;
-//     _lphi = (int) (phi_hit / _currentLayerphi);
-//   }
-//  else {
-//    offsetphi = _currentLayerphi / 2.;
-    if(phi_hit >= offsetphi) {
-      _lphi = (int) ((phi_hit - offsetphi)/ _currentLayerphi);
-    }
-    else {
-      _lphi = (int) ((phi_hit - offsetphi + 2 * M_PI)/ _currentLayerphi);
-    }
-// }
+
+  if(phi_hit >= offsetphi) {
+    _lphi = (int) ((phi_hit - offsetphi)/ _currentLayerphi);
+  }
+  else {
+    _lphi = (int) ((phi_hit - offsetphi + 2 * M_PI)/ _currentLayerphi);
+  }
+
   int lphi = _lphi;
   _decoder->set(cID, m_phiID, lphi);
 
 
-//std::cout << "#######################################: " 
-//          <<  " offset : " << m_offset
-//          << " offsetphi: " << offsetphi
-//          << " layerID: " << layerID
-//          << " r: " << _currentRadius
-//          << " layerphi: " << _currentLayerphi
-//          << std::endl;
+std::cout << "#######################################: " 
+          <<  " offset : " << m_offset
+          << " offsetphi: " << offsetphi
+          << " layerID: " << layerID
+          << " r: " << _currentRadius
+          << " layerphi: " << _currentLayerphi
+          << std::endl;
 
   return cID;
 }
 
 double GridDriftChamber::phi(const CellID& cID) const {
   CellID phiValue = _decoder->get(cID, m_phiID);
-  return (_currentLayerphi * 0.5) + binToPosition(phiValue, _currentLayerphi, m_offsetPhi);
+  return binToPosition(phiValue, _currentLayerphi, m_offset);
 }
 
 double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hit_start/*,

--- a/Detector/DetSegmentation/src/GridDriftChamber.cpp
+++ b/Detector/DetSegmentation/src/GridDriftChamber.cpp
@@ -72,8 +72,8 @@ double GridDriftChamber::phi(const CellID& cID) const {
   return binToPosition(phiValue, _currentLayerphi, m_offset);
 }
 
-double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hit_start/*,
-                                           const TVector3& hit_end*/) const {
+double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hit_start,
+                                           const TVector3& hit_end) const {
 
   auto layerIndex = _decoder->get(cID, "layer");
   updateParams(layerIndex);
@@ -84,14 +84,14 @@ double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hi
   TVector3 Wstart = returnWirePosition(phi_start, -1); // The default centimeter unit in DD4hep
   TVector3 Wend = returnWirePosition(phi_end, 1);   // The default centimeter unit in DD4hep
 
-//  TVector3 a = hit_end - hit_start;
+  TVector3 a = hit_end - hit_start;
   TVector3 b = Wend - Wstart;
   TVector3 c = Wstart - hit_start;
 
-//  double num = std::abs(c.Dot(a.Cross(b)));
-//  double denum = (a.Cross(b)).Mag();
-  double num = (b.Cross(c)).Mag();
-  double denum = b.Mag();
+  double num = std::abs(c.Dot(a.Cross(b)));
+  double denum = (a.Cross(b)).Mag();
+//  double num = (b.Cross(c)).Mag();
+//  double denum = b.Mag();
 
   double DCA = 0;
 

--- a/Detector/DetSegmentation/src/GridDriftChamber.cpp
+++ b/Detector/DetSegmentation/src/GridDriftChamber.cpp
@@ -58,8 +58,10 @@ CellID GridDriftChamber::cellID(const Vector3D& /*localPosition*/, const Vector3
     else {
       _lphi = (int) ((phi_hit - offsetphi + 2 * M_PI)/ _currentLayerphi);
     }
+// }
   int lphi = _lphi;
   _decoder->set(cID, m_phiID, lphi);
+
 
 //std::cout << "#######################################: " 
 //          <<  " offset : " << m_offset
@@ -74,7 +76,7 @@ CellID GridDriftChamber::cellID(const Vector3D& /*localPosition*/, const Vector3
 
 double GridDriftChamber::phi(const CellID& cID) const {
   CellID phiValue = _decoder->get(cID, m_phiID);
-  return binToPosition(phiValue, _currentLayerphi, m_offsetPhi);
+  return (_currentLayerphi * 0.5) + binToPosition(phiValue, _currentLayerphi, m_offsetPhi);
 }
 
 double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hit_start,
@@ -93,8 +95,10 @@ double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hi
   TVector3 b = Wend - Wstart;
   TVector3 c = Wstart - hit_start;
 
-  double num = std::abs(c.Dot(a.Cross(b)));
-  double denum = (a.Cross(b)).Mag();
+//  double num = std::abs(c.Dot(a.Cross(b)));
+//  double denum = (a.Cross(b)).Mag();
+  double num = (b.Cross(c)).Mag();
+  double denum = b.Mag();
 
   double DCA = 0;
 

--- a/Detector/DetSegmentation/src/GridDriftChamber.cpp
+++ b/Detector/DetSegmentation/src/GridDriftChamber.cpp
@@ -81,8 +81,8 @@ double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hi
   double phi_start = phi(cID);
   double phi_end = phi_start + returnAlpha();
 
-  TVector3 Wstart = 10*returnWirePosition(phi_start, -1); // Convert from cm to mm
-  TVector3 Wend = 10*returnWirePosition(phi_end, 1);   // Convert from cm to mm
+  TVector3 Wstart = returnWirePosition(phi_start, -1); // The default centimeter unit in DD4hep
+  TVector3 Wend = returnWirePosition(phi_end, 1);   // The default centimeter unit in DD4hep
 
 //  TVector3 a = hit_end - hit_start;
   TVector3 b = Wend - Wstart;

--- a/Detector/DetSegmentation/src/GridDriftChamber.cpp
+++ b/Detector/DetSegmentation/src/GridDriftChamber.cpp
@@ -79,8 +79,8 @@ double GridDriftChamber::phi(const CellID& cID) const {
   return (_currentLayerphi * 0.5) + binToPosition(phiValue, _currentLayerphi, m_offsetPhi);
 }
 
-double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hit_start,
-                                           const TVector3& hit_end) const {
+double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hit_start/*,
+                                           const TVector3& hit_end*/) const {
 
   auto layerIndex = _decoder->get(cID, "layer");
   updateParams(layerIndex);
@@ -88,10 +88,10 @@ double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hi
   double phi_start = phi(cID);
   double phi_end = phi_start + returnAlpha();
 
-  TVector3 Wstart = returnWirePosition(phi_start, 1);
-  TVector3 Wend = returnWirePosition(phi_end, -1);
+  TVector3 Wstart = 10*returnWirePosition(phi_start, -1); // Convert from cm to mm
+  TVector3 Wend = 10*returnWirePosition(phi_end, 1);   // Convert from cm to mm
 
-  TVector3 a = hit_end - hit_start;
+//  TVector3 a = hit_end - hit_start;
   TVector3 b = Wend - Wstart;
   TVector3 c = Wstart - hit_start;
 


### PR DESCRIPTION
In the process of digitization, it was discovered that the wire position was incorrectly obtained, which caused the DCA to be too large.
![微信图片_20201028155109](https://user-images.githubusercontent.com/59731907/97407405-96dda000-1935-11eb-987d-a21bc1aa5772.png)

After modifying phiFromXY(), the DCA value is normal.
![DCA](https://user-images.githubusercontent.com/59731907/97407773-1ff4d700-1936-11eb-9dbd-73713353105f.png)
