### PR TITLE
Add SimHitMergeAlg and update G2CDArborAlg

### DIFF
--- a/Digitisers/G2CDArbor/src/G2CDArborAlg.cpp
+++ b/Digitisers/G2CDArbor/src/G2CDArborAlg.cpp
@@ -211,26 +211,16 @@ StatusCode G2CDArborAlg::initialize() {
        error() << "failed to retrieve dd4hep_geo: " << m_dd4hep_geo << endmsg;
        return StatusCode::FAILURE;
      }
-     /*
-     // get the DD4hep readout
-     const std::string name_readout = "EcalBarrelCollection";
-     m_decoder = m_geosvc->getDecoder(name_readout);
-     if (!m_decoder) {
-       error() << "Failed to get the decoder. " << endmsg;
-       return StatusCode::FAILURE;
-     }
-     */
 
      m_encoder_str = "M:3,S-1:3,I:9,J:9,K-1:6";
 
-     // printParameters();
-     // WeightVector.clear();
-     for(unsigned int i = 0; i < m_ecalReadoutNames.value().size(); i++){
-         m_col_readout_map[m_ecalColNames.value().at(i)] = m_ecalReadoutNames.value().at(i);
-         //std::cout<<"name="<<m_ecalColNames.value().at(i)<<",readout="<<m_ecalReadoutNames.value().at(i)<<std::endl;
-     }
-     for(unsigned int i = 0; i < m_hcalReadoutNames.value().size(); i++){
-         m_col_readout_map[m_hcalColNames.value().at(i)] = m_hcalReadoutNames.value().at(i);
+     if(m_readLCIO==false){
+         for(unsigned int i = 0; i < m_ecalReadoutNames.value().size(); i++){
+             m_col_readout_map[m_ecalColNames.value().at(i)] = m_ecalReadoutNames.value().at(i);
+         }
+         for(unsigned int i = 0; i < m_hcalReadoutNames.value().size(); i++){
+             m_col_readout_map[m_hcalColNames.value().at(i)] = m_hcalReadoutNames.value().at(i);
+         }
      }
 
      for (auto& ecal : m_ecalColNames) {
@@ -499,12 +489,14 @@ StatusCode G2CDArborAlg::execute()
 
 	  // for(int k1 = 0; k1 < NumEcalhit; k1++)
 	  // {	
-	  std::string tmp_readout = m_col_readout_map[m_ecalColNames.value().at(k0)];
-          // get the DD4hep readout
-          m_decoder = m_geosvc->getDecoder(tmp_readout);
-          if (!m_decoder) {
-            error() << "Failed to get the decoder. " << endmsg;
-            return StatusCode::FAILURE;
+	  if(m_readLCIO==false){
+	      std::string tmp_readout = m_col_readout_map[m_ecalColNames.value().at(k0)];
+              // get the DD4hep readout
+              m_decoder = m_geosvc->getDecoder(tmp_readout);
+              if (!m_decoder) {
+                error() << "Failed to get the decoder. " << endmsg;
+                return StatusCode::FAILURE;
+              }
           }
 
 	  edm4hep::CalorimeterHitCollection* ecalcol = _outputEcalCollections[k0]->createAndPut();

--- a/Digitisers/G2CDArbor/src/G2CDArborAlg.h
+++ b/Digitisers/G2CDArbor/src/G2CDArborAlg.h
@@ -71,6 +71,9 @@ protected:
      Gaudi::Property<std::vector<std::string>> m_hcalColNames{this, "HCALCollections", {"HcalBarrelRegCollection", "HcalEndcapsCollection", "HcalEndcapRingsCollection"}, "HCAL Collection Names"};
      std::vector<SimCaloType*> _hcalCollections;
 
+     Gaudi::Property<std::vector<std::string>> m_ecalReadoutNames{this, "ECALReadOutNames", {"EcalBarrelCollection", "EcalEndcapsCollection","EcalEndcapRingCollection"}, "Name of readouts"};
+     Gaudi::Property<std::vector<std::string>> m_hcalReadoutNames{this, "HCALReadOutNames", {"HcalBarrelCollection", "HcalEndcapsCollection","HcalEndcapRingCollection"}, "Name of readouts"};
+     std::map<std::string, std::string> m_col_readout_map;
 
      // Output collections
      typedef DataHandle<edm4hep::CalorimeterHitCollection>  CaloHitType;

--- a/Digitisers/SimHitMerge/CMakeLists.txt
+++ b/Digitisers/SimHitMerge/CMakeLists.txt
@@ -1,0 +1,20 @@
+gaudi_subdir(SimHitMergeAlg v0r0)
+
+find_package(DD4hep COMPONENTS DDG4 REQUIRED)
+find_package(EDM4HEP REQUIRED)
+find_package(podio REQUIRED ) 
+find_package(K4FWCore REQUIRED)
+
+include_directories(${EDM4HEP_INCLUDE_DIR})
+
+gaudi_depends_on_subdirs(
+    Detector/DetInterface
+)
+set(SimHitMergeAlg_srcs src/*.cpp)
+
+# Modules
+gaudi_add_module(SimHitMerge ${SimHitMergeAlg_srcs}
+    INCLUDE_DIRS K4FWCore GaudiKernel GaudiAlgLib DD4hep  
+    LINK_LIBRARIES K4FWCore GaudiKernel GaudiAlgLib DD4hep DDRec
+    EDM4HEP::edm4hep EDM4HEP::edm4hepDict
+)

--- a/Digitisers/SimHitMerge/CMakeLists.txt
+++ b/Digitisers/SimHitMerge/CMakeLists.txt
@@ -3,7 +3,7 @@ gaudi_subdir(SimHitMergeAlg v0r0)
 find_package(DD4hep COMPONENTS DDG4 REQUIRED)
 find_package(EDM4HEP REQUIRED)
 find_package(podio REQUIRED ) 
-find_package(K4FWCore REQUIRED)
+find_package(k4FWCore REQUIRED)
 
 include_directories(${EDM4HEP_INCLUDE_DIR})
 
@@ -14,7 +14,7 @@ set(SimHitMergeAlg_srcs src/*.cpp)
 
 # Modules
 gaudi_add_module(SimHitMerge ${SimHitMergeAlg_srcs}
-    INCLUDE_DIRS K4FWCore GaudiKernel GaudiAlgLib DD4hep  
-    LINK_LIBRARIES K4FWCore GaudiKernel GaudiAlgLib DD4hep DDRec
+    INCLUDE_DIRS k4FWCore GaudiKernel GaudiAlgLib DD4hep  
+    LINK_LIBRARIES k4FWCore GaudiKernel GaudiAlgLib DD4hep DDRec
     EDM4HEP::edm4hep EDM4HEP::edm4hepDict
 )

--- a/Digitisers/SimHitMerge/src/SimHitMergeAlg.cpp
+++ b/Digitisers/SimHitMerge/src/SimHitMergeAlg.cpp
@@ -1,0 +1,118 @@
+#include "SimHitMergeAlg.h"
+
+#include "edm4hep/SimCalorimeterHit.h"
+#include "edm4hep/Vector3f.h"
+
+#include "DD4hep/Detector.h"
+#include "DD4hep/IDDescriptor.h"
+#include "DD4hep/Plugins.h"
+
+#include <string>
+#include <iostream>
+#include <cmath>
+#include <stdexcept>
+#include <sstream>
+
+
+
+DECLARE_COMPONENT( SimHitMergeAlg )
+
+
+
+
+
+
+SimHitMergeAlg::SimHitMergeAlg(const std::string& name, ISvcLocator* svcLoc)
+     : GaudiAlgorithm(name, svcLoc)
+      
+{
+}
+
+StatusCode SimHitMergeAlg::initialize() {
+     m_geosvc = service<IGeomSvc>("GeomSvc");
+     if (!m_geosvc) {
+       error() << "Failed to find GeomSvc." << endmsg;
+       return StatusCode::FAILURE;
+     }
+     m_dd4hep_geo = m_geosvc->lcdd();
+     if (!m_dd4hep_geo) {
+       error() << "failed to retrieve dd4hep_geo: " << m_dd4hep_geo << endmsg;
+       return StatusCode::FAILURE;
+     }
+     m_cellIDConverter = new dd4hep::rec::CellIDPositionConverter(*m_dd4hep_geo);
+
+     if(m_inputColNames.size() != m_outputColNames.size() ) throw ("Error input size != output size");
+     for (auto& input : m_inputColNames) {
+	  m_InputCollections.push_back( new SimCaloType(input, Gaudi::DataHandle::Reader, this) );
+     }
+
+     for (auto& output : m_outputColNames) {
+	  m_OutputCollections.push_back( new SimCaloType(output, Gaudi::DataHandle::Writer, this) );
+     }
+     
+
+     return GaudiAlgorithm::initialize();
+}
+
+StatusCode SimHitMergeAlg::execute()
+{
+
+     for (unsigned int k0 = 0; k0 < m_inputColNames.size(); k0++)
+     {
+          std::map<unsigned long long, edm4hep::SimCalorimeterHit> id_hit_map;
+          std::map<unsigned long long, std::vector<edm4hep::ConstCaloHitContribution> > id_vconb_map;
+	  edm4hep::SimCalorimeterHitCollection* mergedCol = m_OutputCollections[k0]->createAndPut();
+	  auto col = m_InputCollections[k0]->get();
+          //std::cout<<"input="<<m_InputCollections[k0]->objKey()<<",size="<<col->size()<<std::endl;
+	  for (auto Simhit: *col){
+              auto id = Simhit.getCellID();
+              if(Simhit.getEnergy() <=0 ) continue; 
+              if ( id_hit_map.find(id) != id_hit_map.end()) id_hit_map[id].setEnergy(id_hit_map[id].getEnergy() + Simhit.getEnergy());
+              else id_hit_map[id] = Simhit;
+              std::vector<edm4hep::ConstCaloHitContribution> tmp_vconb ;
+              for(int kk=0; kk<Simhit.contributions_size(); kk++){
+                  tmp_vconb.push_back(Simhit.getContributions(kk));
+              }
+              
+              if( id_vconb_map.find(id) != id_vconb_map.end()){
+                  for(int kk=0; kk<tmp_vconb.size();kk++){
+                      id_vconb_map[id].push_back(tmp_vconb.at(kk));
+                  }
+              }
+              else id_vconb_map[id] = tmp_vconb;
+                  
+          }
+        
+          for(std::map<unsigned long long, edm4hep::SimCalorimeterHit>::iterator iter = id_hit_map.begin(); iter != id_hit_map.end(); iter++)
+          {
+	       edm4hep::SimCalorimeterHit Simhit = iter->second ;
+               dd4hep::Position position = m_cellIDConverter->position(Simhit.getCellID());//cm
+	       edm4hep::Vector3f hitPos(position.x()*10, position.y()*10, position.z()*10);//to mm
+               //std::cout<<"id="<<Simhit.getCellID()<<",hitPos.x="<<hitPos[0]<<",y="<<hitPos[1]<<",z="<<hitPos[2]<<",ori x="<<Simhit.getPosition()[0]<<",y="<<Simhit.getPosition()[1]<<",z="<<Simhit.getPosition()[2]<<std::endl;
+	       auto Mergedhit = mergedCol->create();
+	       Mergedhit.setCellID  (Simhit.getCellID());
+	       Mergedhit.setPosition(hitPos);
+	       Mergedhit.setEnergy  (Simhit.getEnergy());
+               for(int ii=0; ii<id_vconb_map[iter->first].size(); ii++){
+	           Mergedhit.addToContributions(id_vconb_map[iter->first].at(ii));
+               }
+          }
+          /*
+          std::cout<<"output="<<m_OutputCollections[k0]->objKey()<<",size="<<mergedCol->size()<<std::endl;
+          for(int ii=0; ii<mergedCol->size(); ii++){
+              auto tmp_hit = mergedCol->at(ii); 
+              std::cout<<"id="<<tmp_hit.getCellID()<<",E="<<tmp_hit.getEnergy()<<",conb size="<<tmp_hit.contributions_size()<<std::endl;
+          }
+          */
+          
+     }     
+     return StatusCode::SUCCESS;
+}
+
+StatusCode SimHitMergeAlg::finalize()
+{
+     std::cout<<"SimHitMergeAlg FINISHED"<<std::endl;
+
+
+     return GaudiAlgorithm::finalize();
+}

--- a/Digitisers/SimHitMerge/src/SimHitMergeAlg.h
+++ b/Digitisers/SimHitMerge/src/SimHitMergeAlg.h
@@ -1,0 +1,55 @@
+#ifndef SimHitMergeAlg_H
+#define SimHitMergeAlg_H
+
+#include "k4FWCore/DataHandle.h"
+#include "GaudiAlg/GaudiAlgorithm.h"
+#include "GaudiKernel/Property.h"
+#include "edm4hep/EventHeader.h"
+#include "edm4hep/EventHeaderCollection.h"
+#include "edm4hep/SimCalorimeterHitConst.h"
+#include "edm4hep/SimCalorimeterHit.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/MCRecoCaloAssociationCollection.h"
+#include "edm4hep/MCParticleCollection.h"
+
+#include <DDRec/DetectorData.h>
+#include <DDRec/CellIDPositionConverter.h>
+#include "DetInterface/IGeomSvc.h"
+
+#include <string>
+#include <iostream>
+#include <fstream>
+
+
+class SimHitMergeAlg  : public GaudiAlgorithm
+{
+public:
+
+     SimHitMergeAlg(const std::string& name, ISvcLocator* svcLoc);
+
+     virtual StatusCode initialize() ;
+
+     virtual StatusCode execute() ;
+
+     virtual StatusCode finalize() ;
+
+protected:
+     std::string GetLayerCoding(const std::string &encodingString) const;
+
+
+
+     typedef DataHandle<edm4hep::SimCalorimeterHitCollection>  SimCaloType;
+
+     Gaudi::Property<std::vector<std::string>> m_inputColNames{this, "InputCollections", {"EcalBarrelSiliconCollection", "EcalEndcapSiliconCollection", "EcalEndcapRingCollection"}, "Input Hit collection Names"};
+     Gaudi::Property<std::vector<std::string>> m_outputColNames{this, "OutputCollections", {"ECALBarrel", "ECALEndcap", "ECALOther"}, "Name of merged Hit Collections"};
+     std::vector<SimCaloType*> m_InputCollections;
+     std::vector<SimCaloType*> m_OutputCollections;
+
+     SmartIF<IGeomSvc> m_geosvc;
+     dd4hep::Detector* m_dd4hep_geo;
+     dd4hep::rec::CellIDPositionConverter* m_cellIDConverter;
+};
+
+#endif
+
+

--- a/Examples/options/LCIO_read_G2CD.py
+++ b/Examples/options/LCIO_read_G2CD.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+from Gaudi.Configuration import *
+from Configurables import K4DataSvc
+dsvc = K4DataSvc("EventDataSvc")
+
+# read LCIO files
+from Configurables import LCIOInput
+read = LCIOInput("read")
+read.inputs = [
+"/cefs/higgs/wxfang/cepc/FS/FS_Barrel_Mom150_1000MeV_x_theta_phi_mom_bin_resVsMom_Etuning/sim_111_0830.slcio"
+]
+read.collections = [
+        "MCParticle:MCParticle",
+        "SimCalorimeterHit:EcalBarrelSiliconCollection",
+        #"CalorimeterHit:ECALBarrel",
+        #"CalorimeterHit:ECALEndcap",
+        #"CalorimeterHit:ECALOther" ,
+        ########## HCAL will effect the reco efficiency close to gap region ######
+        #"CalorimeterHit:HCALBarrel",
+        #"CalorimeterHit:HCALEndcap",
+        #"CalorimeterHit:HCALOther",
+        ##"TrackerHit:VXDTrackerHits",
+        ##"TrackerHit:SITTrackerHits",
+        #"TrackerHit:SITSpacePoints",
+        #"TrackerHit:TPCTrackerHits",
+        ##"TrackerHit:SETTrackerHits",
+        #"TrackerHit:SETSpacePoints",
+        ##"TrackerHit:FTDStripTrackerHits",
+        #"TrackerHit:FTDSpacePoints",
+        ##"TrackerHit:FTDPixelTrackerHits",
+        #"Track:ClupatraTrackSegments", 
+        #"Track:ClupatraTracks", 
+        #"Track:ForwardTracks", 
+        #"Track:SiTracks", 
+        #"Track:SubsetTracks",
+        #"Track:MarlinTrkTracks", 
+        #"Vertex:KinkVertices",
+        #"Vertex:ProngVertices",
+        #"Vertex:V0Vertices",
+        #"ReconstructedParticle:KinkRecoParticles",
+        #"ReconstructedParticle:ProngRecoParticles",
+        #"ReconstructedParticle:V0RecoParticles"
+]
+#########################################################################
+geometry_option = "CepC_v4-onlyECAL.xml"
+
+if not os.getenv("DETCEPCV4ROOT"):
+    print("Can't find the geometry. Please setup envvar DETCEPCV4ROOT." )
+    sys.exit(-1)
+
+geometry_path = os.path.join(os.getenv("DETCEPCV4ROOT"), "compact", geometry_option)
+if not os.path.exists(geometry_path):
+    print("Can't find the compact geometry file: %s"%geometry_path)
+    sys.exit(-1)
+
+from Configurables import GeomSvc
+geosvc = GeomSvc("GeomSvc")
+geosvc.compact = geometry_path
+########################################################################
+from Configurables import GearSvc
+gearSvc  = GearSvc("GearSvc")
+gearSvc.GearXMLFile = "Detector/DetCEPCv4/compact/FullDetGear.xml"
+##############################################################################
+from Configurables import G2CDArborAlg
+caloDigi = G2CDArborAlg("G2CDArborAlg")
+caloDigi.ReadLCIO = True 
+caloDigi.CalibrECAL = [48.16, 96.32]
+caloDigi.ECALCollections = ["EcalBarrelSiliconCollection"]
+caloDigi.DigiECALCollection = ["EcalBarrel"]
+caloDigi.HCALCollections = []
+caloDigi.EventReportEvery = 1
+
+##############################################################################
+
+# write PODIO file
+from Configurables import PodioOutput
+write = PodioOutput("write")
+write.filename = "test.root"
+write.outputCommands = ["keep *"]
+
+# ApplicationMgr
+from Configurables import ApplicationMgr
+ApplicationMgr(
+        #TopAlg = [read, caloDigi, write],
+        TopAlg = [read, caloDigi],
+        EvtSel = 'NONE',
+        EvtMax = 10,
+        ExtSvc = [dsvc, geosvc, gearSvc],
+        OutputLevel=INFO
+)

--- a/Examples/options/LCIO_read_G2CD.py
+++ b/Examples/options/LCIO_read_G2CD.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 from Gaudi.Configuration import *
-from Configurables import K4DataSvc
-dsvc = K4DataSvc("EventDataSvc")
+from Configurables import k4DataSvc
+dsvc = k4DataSvc("EventDataSvc")
 
 # read LCIO files
 from Configurables import LCIOInput

--- a/Examples/options/tut_detsim_G2CD.py
+++ b/Examples/options/tut_detsim_G2CD.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+from Gaudi.Configuration import *
+from Configurables import K4DataSvc
+#dsvc = K4DataSvc("EventDataSvc", input="detsim_ECAL_gamma_10000evt.root")
+dsvc = K4DataSvc("EventDataSvc", input="ECALonly_gamma_30degree_10000evt.root")
+
+#########################################################################
+geometry_option = "CepC_v4-onlyECAL.xml"
+
+if not os.getenv("DETCEPCV4ROOT"):
+    print("Can't find the geometry. Please setup envvar DETCEPCV4ROOT." )
+    sys.exit(-1)
+
+geometry_path = os.path.join(os.getenv("DETCEPCV4ROOT"), "compact", geometry_option)
+if not os.path.exists(geometry_path):
+    print("Can't find the compact geometry file: %s"%geometry_path)
+    sys.exit(-1)
+
+from Configurables import GeomSvc
+geosvc = GeomSvc("GeomSvc")
+geosvc.compact = geometry_path
+########################################################################
+
+from Configurables import PodioInput
+podioinput = PodioInput("PodioReader", collections=[
+    "MCParticle",
+    "EcalBarrelCollection",
+    "EcalEndcapsCollection"
+])
+
+
+############################################################
+from Configurables import GearSvc
+gearSvc  = GearSvc("GearSvc")
+gearSvc.GearXMLFile = "Detector/DetCEPCv4/compact/FullDetGear.xml"
+
+############################################################
+from Configurables import SimHitMergeAlg
+simHitMerge = SimHitMergeAlg("SimHitMergeAlg")
+simHitMerge.InputCollections=["EcalBarrelCollection", "EcalEndcapsCollection"]
+simHitMerge.OutputCollections=["EcalBarrelCollectionMerged", "EcalEndcapsCollectionMerged"]
+############################################################
+
+from Configurables import G2CDArborAlg
+caloDigi = G2CDArborAlg("G2CDArborAlg")
+caloDigi.ReadLCIO = False 
+#caloDigi.CalibrECAL = [48.16, 96.32]
+caloDigi.CalibrECAL = [46.538, 93.0769]
+caloDigi.ECALCollections = ["EcalBarrelCollectionMerged", "EcalEndcapsCollectionMerged"]
+caloDigi.ECALReadOutNames= ["EcalBarrelCollection", "EcalEndcapsCollection"]
+caloDigi.DigiECALCollection = ["EcalBarrel", "EcalEndcaps"]
+caloDigi.HCALCollections = []
+caloDigi.HCALReadOutNames= []
+caloDigi.DigiHCALCollection = []
+caloDigi.EventReportEvery = 100
+##############################################################################
+
+
+#from Configurables import DumpDigiIDAlgv1
+#dumpIDAlg = DumpDigiIDAlgv1("DumpDigiIDAlgv1")
+#dumpIDAlg.ColName = "EcalEndcaps"
+#dumpIDAlg.Readout = "EcalEndcapsCollection"
+##dumpIDAlg.Output = "id_ECAL_gamma_digi_10000evt_newCalibv2_fromMergedSimHit.root"
+#dumpIDAlg.Output = "id_ECALonly_30degree.root"
+##############################################################################
+
+from Configurables import PodioOutput
+out = PodioOutput("outputalg")
+out.filename = "digi_fix5GeV_EcalOnlyBF.root"
+out.outputCommands = ["keep *"]
+
+# ApplicationMgr
+from Configurables import ApplicationMgr
+ApplicationMgr(
+TopAlg = [podioinput, simHitMerge, caloDigi, out],
+    EvtSel = 'NONE',
+    EvtMax = -1,
+    ExtSvc = [dsvc, gearSvc],
+    OutputLevel=INFO
+)


### PR DESCRIPTION
Hi @mirguest @LinghuiWuIHEP

I add one alg (SimHitMergeAlg) for merging simcalorimeterhit from simulation by cell id. Now the G2CDArborAlg can use the data after SimHitMergeAlg for processing digitization for CEPCSW simulated data, just like processing simulation data produced by Mokka.
Besides, I correct the G2CDArborAlg a bit (mainly add a selection of readout, modify the layer number). Could you review the changes?

Best,
Wenxing