### PR TITLE
clear temporary maps at the end of the algorithm

### DIFF
--- a/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
@@ -232,12 +232,6 @@ StatusCode ClupatraAlg::initialize() {
 
 StatusCode ClupatraAlg::execute() {
 
-	TrackInfo_of_edm4hepTrack.init();
-	MarTrk_of_edm4hepTrack.init();
-	CluTrk_of_MarTrack.init();
-	MarTrkof.init();
-	GHitof.init();
-
 
 	debug() << "Clupatra Algorithm started" << endmsg;
 
@@ -1266,6 +1260,12 @@ StatusCode ClupatraAlg::execute() {
         }
 
 	_nEvt++ ;
+
+	TrackInfo_of_edm4hepTrack.clear();
+	MarTrk_of_edm4hepTrack.clear();
+	CluTrk_of_MarTrack.clear();
+	MarTrkof.clear();
+	GHitof.clear();
 
 	return StatusCode::SUCCESS;
 }

--- a/Reconstruction/Tracking/src/Clupatra/RuntimeMap.h
+++ b/Reconstruction/Tracking/src/Clupatra/RuntimeMap.h
@@ -9,7 +9,7 @@ class RuntimeMap {
     V& operator()(const U& u) {
         return data[u];
     }
-    void init() {
+    void clear() {
         data.clear();
     }
 };


### PR DESCRIPTION
All data objects of a previous event are removed at the beginning of the next event. So we should clear the map as soon as possible, but not clear it until next event.