### PR TITLE
WIP: Create an example of fast simulation in CEPCSW

### DIFF
--- a/Detector/DetDriftChamber/compact/det.xml
+++ b/Detector/DetDriftChamber/compact/det.xml
@@ -50,8 +50,13 @@
     <vis name="VisibleGreen" alpha="1.0" r="0.0" g="1.0" b="0.0" drawingStyle="solid" lineStyle="solid" showDaughters="true" visible="true"/>
   </display>
 
+  <regions>
+    <region name="DriftChamberRegion">
+    </region>
+  </regions>
+
   <detectors>
-    <detector id="1" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="VisibleBlue" sensitive="true">
+    <detector id="1" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="VisibleBlue" sensitive="true" region="DriftChamberRegion">
       <envelope vis="SeeThrough">
         <shape type="BooleanShape" operation="Union" material="Air">
           <shape type="Tube" rmin="SDT_inner_chamber_radius_min" rmax="SDT_inner_chamber_radius_max" dz="SDT_half_length" />

--- a/Detector/DetSegmentation/src/GridDriftChamber.cpp
+++ b/Detector/DetSegmentation/src/GridDriftChamber.cpp
@@ -56,13 +56,13 @@ CellID GridDriftChamber::cellID(const Vector3D& /*localPosition*/, const Vector3
   _decoder->set(cID, m_phiID, lphi);
 
 
-std::cout << "#######################################: " 
-          <<  " offset : " << m_offset
-          << " offsetphi: " << offsetphi
-          << " layerID: " << layerID
-          << " r: " << _currentRadius
-          << " layerphi: " << _currentLayerphi
-          << std::endl;
+// std::cout << "#######################################: " 
+//           <<  " offset : " << m_offset
+//           << " offsetphi: " << offsetphi
+//           << " layerID: " << layerID
+//           << " r: " << _currentRadius
+//           << " layerphi: " << _currentLayerphi
+//           << std::endl;
 
   return cID;
 }

--- a/Examples/options/tut_detsim_SDT.py
+++ b/Examples/options/tut_detsim_SDT.py
@@ -117,6 +117,13 @@ if int(os.environ.get("VIS", 0)):
 detsimalg.RunCmds = [
 #    "/tracking/verbose 1",
 ]
+
+from Configurables import DummyFastSimG4Tool
+dummy_fastsim_tool = DummyFastSimG4Tool("DummyFastSimG4Tool")
+
+detsimalg.FastSimG4Tools = [
+    "DummyFastSimG4Tool"
+]
 detsimalg.AnaElems = [
     # example_anatool.name()
     # "ExampleAnaElemTool"

--- a/Simulation/DetSimCore/src/DetSimAlg.cpp
+++ b/Simulation/DetSimCore/src/DetSimAlg.cpp
@@ -42,7 +42,12 @@ DetSimAlg::initialize() {
 
     // Detector Construction
     m_root_detelem = ToolHandle<IDetElemTool>(m_root_det_elem.value());
-    runmgr->SetUserInitialization(new DetectorConstruction(m_root_detelem));
+
+    for (auto fastsimname: m_fast_simtools) {
+        m_fast_simtools.push_back(fastsimname);
+    }
+
+    runmgr->SetUserInitialization(new DetectorConstruction(m_root_detelem, m_fast_simtools));
     // Physics List
     G4VUserPhysicsList *physicsList = nullptr;
     if (m_physics_lists_name.value() == "CEPC") {

--- a/Simulation/DetSimCore/src/DetSimAlg.cpp
+++ b/Simulation/DetSimCore/src/DetSimAlg.cpp
@@ -10,6 +10,7 @@
 
 #include "DetectorConstruction.h"
 #include "G4PhysListFactory.hh"
+#include "G4EmParameters.hh"
 #include "G4StepLimiterPhysics.hh"
 #include "G4FastSimulationPhysics.hh"
 #include "PrimaryGeneratorAction.h"
@@ -58,6 +59,10 @@ DetSimAlg::initialize() {
     } else {
         G4PhysListFactory *physListFactory = new G4PhysListFactory();
         G4VModularPhysicsList* modularPhysicsList = physListFactory->GetReferencePhysList(m_physics_lists_name.value());
+
+        // PAI model
+        G4EmParameters::Instance()->AddPAIModel("all","DriftChamberRegion","pai");
+        // G4EmParameters::Instance()->AddPAIModel("all","DriftChamberRegion","pai_photon");
 
         // register addition physics list
         modularPhysicsList->RegisterPhysics(new G4StepLimiterPhysics());

--- a/Simulation/DetSimCore/src/DetSimAlg.cpp
+++ b/Simulation/DetSimCore/src/DetSimAlg.cpp
@@ -43,7 +43,8 @@ DetSimAlg::initialize() {
     // Detector Construction
     m_root_detelem = ToolHandle<IDetElemTool>(m_root_det_elem.value());
 
-    for (auto fastsimname: m_fast_simtools) {
+    for (auto fastsimname: m_fast_simnames) {
+        info() << "Fast Sim Tool: " << fastsimname << endmsg;
         m_fast_simtools.push_back(fastsimname);
     }
 

--- a/Simulation/DetSimCore/src/DetSimAlg.cpp
+++ b/Simulation/DetSimCore/src/DetSimAlg.cpp
@@ -10,6 +10,8 @@
 
 #include "DetectorConstruction.h"
 #include "G4PhysListFactory.hh"
+#include "G4StepLimiterPhysics.hh"
+#include "G4FastSimulationPhysics.hh"
 #include "PrimaryGeneratorAction.h"
 
 #include "ActionInitialization.h"
@@ -55,7 +57,20 @@ DetSimAlg::initialize() {
 
     } else {
         G4PhysListFactory *physListFactory = new G4PhysListFactory();
-        physicsList = physListFactory->GetReferencePhysList(m_physics_lists_name.value());
+        G4VModularPhysicsList* modularPhysicsList = physListFactory->GetReferencePhysList(m_physics_lists_name.value());
+
+        // register addition physics list
+        modularPhysicsList->RegisterPhysics(new G4StepLimiterPhysics());
+
+        // register fastsim physics
+        G4FastSimulationPhysics* fastsim_physics = new G4FastSimulationPhysics();
+        fastsim_physics->BeVerbose();
+        fastsim_physics->ActivateFastSimulation("e-");
+        fastsim_physics->ActivateFastSimulation("e+");
+        fastsim_physics->ActivateFastSimulation("gamma");
+        modularPhysicsList->RegisterPhysics(fastsim_physics);
+
+        physicsList = modularPhysicsList;
     }
     assert(physicsList);
     runmgr->SetUserInitialization(physicsList);

--- a/Simulation/DetSimCore/src/DetSimAlg.h
+++ b/Simulation/DetSimCore/src/DetSimAlg.h
@@ -12,6 +12,7 @@
 #include <DetSimInterface/IG4PrimaryCnvTool.h>
 #include <DetSimInterface/IAnaElemTool.h>
 #include <DetSimInterface/IDetElemTool.h>
+#include <DetSimInterface/IFastSimG4Tool.h>
 
 class DetSimAlg: public Algorithm {
 public:
@@ -24,6 +25,7 @@ public:
 private:
     SmartIF<IDetSimSvc> m_detsimsvc;
     ToolHandleArray<IAnaElemTool> m_anaelemtools;
+    ToolHandleArray<IFastSimG4Tool> m_fast_simtools;
     ToolHandle<IDetElemTool> m_root_detelem;
     ToolHandle<IG4PrimaryCnvTool> m_prim_cnvtool{"G4PrimaryCnvTool", this};
 
@@ -36,6 +38,7 @@ private:
     Gaudi::Property<std::string> m_physics_lists_name{this, "PhysicsList", "QGSP_BERT"};
 
     Gaudi::Property<std::vector<std::string>> m_ana_elems{this, "AnaElems"};
+    Gaudi::Property<std::vector<std::string>> m_fast_simnames{this, "FastSimG4Tools"};
     Gaudi::Property<std::string> m_root_det_elem{this, "RootDetElem"};
 
 

--- a/Simulation/DetSimCore/src/DetectorConstruction.cpp
+++ b/Simulation/DetSimCore/src/DetectorConstruction.cpp
@@ -65,6 +65,8 @@ DetectorConstruction::Construct() {
     // Associate Fast Simulation Model and Regions
     // =======================================================================
     for (auto fastsimtool: m_fast_simtools) {
+        G4cout << "Invoke CreateFastSimulationModel of fastsimtool instance "
+               << m_fast_simtools << G4endl;
         fastsimtool->CreateFastSimulationModel();
     }
 

--- a/Simulation/DetSimCore/src/DetectorConstruction.cpp
+++ b/Simulation/DetSimCore/src/DetectorConstruction.cpp
@@ -25,8 +25,9 @@
 #include "G4ios.hh"
 
 
-DetectorConstruction::DetectorConstruction(ToolHandle<IDetElemTool>& root_elem) 
-    : m_root_detelem(root_elem) {
+DetectorConstruction::DetectorConstruction(ToolHandle<IDetElemTool>& root_elem,
+                                           ToolHandleArray<IFastSimG4Tool>& fast_simtools) 
+    : m_root_detelem(root_elem), m_fast_simtools(fast_simtools) {
 
 }
 
@@ -59,6 +60,13 @@ DetectorConstruction::Construct() {
                                                       0,               // its mother  volume
                                                       false,           // no boolean operations
                                                       0);              // no field specific to volume
+
+    // =======================================================================
+    // Associate Fast Simulation Model and Regions
+    // =======================================================================
+    for (auto fastsimtool: m_fast_simtools) {
+        fastsimtool->CreateFastSimulationModel();
+    }
 
     return physiWorld;
 

--- a/Simulation/DetSimCore/src/DetectorConstruction.h
+++ b/Simulation/DetSimCore/src/DetectorConstruction.h
@@ -3,6 +3,7 @@
 
 #include "GaudiKernel/ToolHandle.h"
 #include "DetSimInterface/IDetElemTool.h"
+#include "DetSimInterface/IFastSimG4Tool.h"
 
 #include "globals.hh"
 #include "G4VUserDetectorConstruction.hh"
@@ -16,7 +17,8 @@
 class DetectorConstruction: public G4VUserDetectorConstruction {
 
 public:
-    DetectorConstruction(ToolHandle<IDetElemTool>& root_elem);
+    DetectorConstruction(ToolHandle<IDetElemTool>& root_elem,
+                         ToolHandleArray<IFastSimG4Tool>& fast_simtools);
     ~DetectorConstruction();
 public:
     G4VPhysicalVolume* Construct() override;
@@ -24,6 +26,7 @@ public:
 
 private:
     ToolHandle<IDetElemTool>& m_root_detelem;
+    ToolHandleArray<IFastSimG4Tool>& m_fast_simtools;
 };
 
 #endif

--- a/Simulation/DetSimFastModel/CMakeLists.txt
+++ b/Simulation/DetSimFastModel/CMakeLists.txt
@@ -1,0 +1,24 @@
+gaudi_subdir(DetSimFastModel v0r0)
+
+gaudi_depends_on_subdirs(
+    k4FWCore
+    Simulation/DetSimInterface
+)
+
+find_package(Geant4 REQUIRED ui_all vis_all)
+include(${Geant4_USE_FILE})
+find_package(DD4hep COMPONENTS DDG4 REQUIRED)
+
+set(DetSimFastModel_srcs
+    src/DummyFastSimG4Tool.cpp
+    src/DummyFastSimG4Model.cpp
+)
+
+gaudi_add_module(DetSimFastModel ${DetSimFastModel_srcs}
+    INCLUDE_DIRS
+    LINK_LIBRARIES
+        DD4hep
+        ${DD4hep_COMPONENT_LIBRARIES}
+        GaudiKernel
+)
+

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Model.cpp
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Model.cpp
@@ -17,7 +17,7 @@ G4bool DummyFastSimG4Model::IsApplicable(const G4ParticleDefinition& aParticle) 
 }
 
 G4bool DummyFastSimG4Model::ModelTrigger(const G4FastTrack& aFastTrack) {
-    G4cout << __FILE__ << __LINE__ << ": ModelTrigger." << G4endl;
+    // G4cout << __FILE__ << __LINE__ << ": ModelTrigger." << G4endl;
 
     bool istrigged = false;
 
@@ -31,7 +31,7 @@ G4bool DummyFastSimG4Model::ModelTrigger(const G4FastTrack& aFastTrack) {
 }
 
 void DummyFastSimG4Model::DoIt(const G4FastTrack& aFastTrack, G4FastStep& aFastStep) {
-    G4cout << __FILE__ << __LINE__ << ": DoIt." << G4endl;
+    // G4cout << __FILE__ << __LINE__ << ": DoIt." << G4endl;
 
     aFastStep.ProposeTrackStatus(fStopAndKill);
 }

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Model.cpp
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Model.cpp
@@ -1,1 +1,22 @@
 #include "DummyFastSimG4Model.h"
+
+DummyFastSimG4Model::DummyFastSimG4Model(G4String aModelName, G4Region* aEnvelope)
+    : G4VFastSimulationModel(aModelName, aEnvelope) {
+
+}
+
+DummyFastSimG4Model::~DummyFastSimG4Model() {
+
+}
+
+G4bool DummyFastSimG4Model::IsApplicable(const G4ParticleDefinition& aParticle) {
+    return true;
+}
+
+G4bool DummyFastSimG4Model::ModelTrigger(const G4FastTrack& aFastTrack) {
+    return true;
+}
+
+void DummyFastSimG4Model::DoIt(const G4FastTrack& aFastTrack, G4FastStep& aFastStep) {
+
+}

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Model.cpp
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Model.cpp
@@ -1,5 +1,8 @@
 #include "DummyFastSimG4Model.h"
 
+#include "G4Track.hh"
+#include "G4FastTrack.hh"
+
 DummyFastSimG4Model::DummyFastSimG4Model(G4String aModelName, G4Region* aEnvelope)
     : G4VFastSimulationModel(aModelName, aEnvelope) {
 
@@ -10,13 +13,25 @@ DummyFastSimG4Model::~DummyFastSimG4Model() {
 }
 
 G4bool DummyFastSimG4Model::IsApplicable(const G4ParticleDefinition& aParticle) {
-    return true;
+    return aParticle.GetPDGCharge() != 0;
 }
 
 G4bool DummyFastSimG4Model::ModelTrigger(const G4FastTrack& aFastTrack) {
-    return true;
+    G4cout << __FILE__ << __LINE__ << ": ModelTrigger." << G4endl;
+
+    bool istrigged = false;
+
+    // only select the secondaries
+    const G4Track* track = aFastTrack.GetPrimaryTrack();
+    // secondaries
+    if (track->GetParentID() != 0) {
+        istrigged = true;
+    }
+    return istrigged;
 }
 
 void DummyFastSimG4Model::DoIt(const G4FastTrack& aFastTrack, G4FastStep& aFastStep) {
+    G4cout << __FILE__ << __LINE__ << ": DoIt." << G4endl;
 
+    aFastStep.ProposeTrackStatus(fStopAndKill);
 }

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Model.cpp
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Model.cpp
@@ -1,0 +1,1 @@
+#include "DummyFastSimG4Model.h"

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Model.h
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Model.h
@@ -1,0 +1,7 @@
+#ifndef DummyFastSimG4Model_h
+#define DummyFastSimG4Model_h
+
+
+
+#endif
+

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Model.h
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Model.h
@@ -1,7 +1,19 @@
 #ifndef DummyFastSimG4Model_h
 #define DummyFastSimG4Model_h
 
+#include "G4VFastSimulationModel.hh"
 
+class DummyFastSimG4Model: public G4VFastSimulationModel {
+public:
+
+    DummyFastSimG4Model(G4String aModelName, G4Region* aEnvelope);
+    ~DummyFastSimG4Model();
+
+    virtual G4bool IsApplicable( const G4ParticleDefinition& aParticle );
+    virtual G4bool ModelTrigger( const G4FastTrack& aFastTrack );
+    virtual void DoIt( const G4FastTrack& aFastTrack, G4FastStep& aFastStep );
+
+};
 
 #endif
 

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.cpp
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.cpp
@@ -1,1 +1,20 @@
 #include "DummyFastSimG4Tool.h"
+
+#include "G4VFastSimulationModel.hh"
+
+StatusCode DummyFastSimG4Tool::initialize() {
+    StatusCode sc;
+
+    return sc;
+}
+
+StatusCode DummyFastSimG4Tool::finalize() {
+    StatusCode sc;
+
+    return sc;
+}
+
+bool DummyFastSimG4Tool::CreateFastSimulationModel() {
+
+    return true;
+}

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.cpp
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.cpp
@@ -1,0 +1,1 @@
+#include "DummyFastSimG4Tool.h"

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.cpp
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.cpp
@@ -1,6 +1,12 @@
 #include "DummyFastSimG4Tool.h"
 
+#include "G4Region.hh"
+#include "G4RegionStore.hh"
+
 #include "G4VFastSimulationModel.hh"
+#include "DummyFastSimG4Model.h"
+
+DECLARE_COMPONENT(DummyFastSimG4Tool);
 
 StatusCode DummyFastSimG4Tool::initialize() {
     StatusCode sc;
@@ -15,6 +21,20 @@ StatusCode DummyFastSimG4Tool::finalize() {
 }
 
 bool DummyFastSimG4Tool::CreateFastSimulationModel() {
+    // In this method:
+    // * Retrieve the G4Region
+    // * Create Model
+    // * Associate model and region
 
+    G4String model_name = "DummyFastSimG4Model";
+    G4String region_name = "DriftChamberRegion";
+    G4Region* aEnvelope = G4RegionStore::GetInstance()->GetRegion(region_name);
+    if (!aEnvelope) {
+        error() << "Failed to find G4Region '" << region_name << "'" << endmsg;
+        return false;
+    }
+
+    DummyFastSimG4Model* model = new DummyFastSimG4Model(model_name, aEnvelope);
+    info() << "Create Model " << model_name << " for G4Region " << region_name << endmsg;
     return true;
 }

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.h
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.h
@@ -1,6 +1,20 @@
 #ifndef DummyFastSimG4Tool_h
 #define DummyFastSimG4Tool_h
 
+#include "GaudiKernel/AlgTool.h"
+#include "DetSimInterface/IFastSimG4Tool.h"
 
+class DummyFastSimG4Tool: public extends<AlgTool, IFastSimG4Tool> {
+public:
+    using extends::extends;
+
+    StatusCode initialize() override;
+    StatusCode finalize() override;
+
+    bool CreateFastSimulationModel() override;
+
+private:
+
+};
 
 #endif

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.h
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.h
@@ -1,0 +1,6 @@
+#ifndef DummyFastSimG4Tool_h
+#define DummyFastSimG4Tool_h
+
+
+
+#endif

--- a/Simulation/DetSimInterface/DetSimInterface/IFastSimG4Tool.h
+++ b/Simulation/DetSimInterface/DetSimInterface/IFastSimG4Tool.h
@@ -1,0 +1,20 @@
+#ifndef IFastSimG4Tool_h
+#define IFastSimG4Tool_h
+
+// IFastSimG4Tool is to associate the G4Region and Fast simulation model in G4.
+// It is recommended to create one fast simulation model in one tool.
+// -- Tao Lin <lintao@ihep.ac.cn>, 7 Dec 2020
+
+#include "GaudiKernel/IAlgTool.h"
+
+class IFastSimG4Tool: virtual public IAlgTool {
+public:
+    DeclareInterfaceID(IFastSimG4Tool, 0, 1);
+
+    virtual ~IFastSimG4Tool() {}
+
+    // Build the association between G4Region and G4 Fast simulation model
+    virtual bool CreateFastSimulationModel() = 0;
+};
+
+#endif


### PR DESCRIPTION
This PR contains
* Introduce a new interface for the fast simulation based on the Geant4 fast/parameterization simulation model.
* A dummy fast simulation model
  * The dummy tool is used to associate Region and Fast simulation model
  * The dummy model will kill all the charged secondaries in DriftChamberRegion.
* Prepare for the Garfield integration. 
  * The dedicated region "DriftChamberRegion" is created. 
  * The region will be used both for the fast simulation model and the PAI model in EM.
  * In DD4hep, the limits could be also set for the region. But in this PR, the limits are not set.
* The additional physics list are registered into DetSimCore.
  * In the future, maybe introduce an interface to manage the physics list.