### PR TITLE
WIP: Set flag when primary particle is decayed.

### DIFF
--- a/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
+++ b/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
@@ -356,7 +356,8 @@ Edm4hepWriterAnaElemTool::PostUserTrackingAction(const G4Track* track) {
                            << " trkid: " << sectrk->GetTrackID() // not valid until track
                            << " particle: " << secparticle->GetParticleName()
                            << " pdg: " << secparticle->GetPDGEncoding()
-                           << " at position: " << sectrk->GetPosition() // 
+                           << " at position: " << sectrk->GetPosition() //
+                           << " time: " << sectrk->GetGlobalTime()
                            << " momentum: " << sectrk->GetMomentum() // 
                            << endmsg;
                     is_decay = true;
@@ -369,7 +370,7 @@ Edm4hepWriterAnaElemTool::PostUserTrackingAction(const G4Track* track) {
                     mcp.setGeneratorStatus(0); // not created by Generator
                     mcp.setCreatedInSimulation(1);
                     mcp.setCharge(secparticle->GetPDGCharge());
-                    mcp.setTime(0.0); // todo
+                    mcp.setTime(sectrk->GetGlobalTime()/CLHEP::ns); // todo
                     mcp.setMass(secparticle->GetPDGMass());
 
                     const G4ThreeVector& sec_init_pos = sectrk->GetPosition();

--- a/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
+++ b/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
@@ -353,8 +353,11 @@ Edm4hepWriterAnaElemTool::PostUserTrackingAction(const G4Track* track) {
                 if (creatorProcess==proc_decay) {
                     info() << "Creator Process is Decay for secondary particle: "
                            << " idx: " << i
+                           << " trkid: " << sectrk->GetTrackID() // not valid until track
                            << " particle: " << secparticle->GetParticleName()
                            << " pdg: " << secparticle->GetPDGEncoding()
+                           << " at position: " << sectrk->GetPosition() // 
+                           << " momentum: " << sectrk->GetMomentum() // 
                            << endmsg;
                     is_decay = true;
 
@@ -368,8 +371,16 @@ Edm4hepWriterAnaElemTool::PostUserTrackingAction(const G4Track* track) {
                     mcp.setCharge(secparticle->GetPDGCharge());
                     mcp.setTime(0.0); // todo
                     mcp.setMass(secparticle->GetPDGMass());
-                    double x=0, y=0, z=0;
-                    double px=0, py=0, pz=0;
+
+                    const G4ThreeVector& sec_init_pos = sectrk->GetPosition();
+                    double x=sec_init_pos.x()/CLHEP::mm;
+                    double y=sec_init_pos.y()/CLHEP::mm;
+                    double z=sec_init_pos.z()/CLHEP::mm;
+
+                    const G4ThreeVector& sec_init_mom = sectrk->GetMomentum();
+                    double px=sec_init_mom.x()/CLHEP::GeV;
+                    double py=sec_init_mom.y()/CLHEP::GeV;
+                    double pz=sec_init_mom.z()/CLHEP::GeV;
                     mcp.setVertex(edm4hep::Vector3d(x,y,z)); // todo
                     mcp.setEndpoint(edm4hep::Vector3d(x,y,z)); // todo
                     mcp.setMomentum(edm4hep::Vector3f(px,py,pz)); // todo

--- a/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
+++ b/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
@@ -357,6 +357,26 @@ Edm4hepWriterAnaElemTool::PostUserTrackingAction(const G4Track* track) {
                            << " pdg: " << secparticle->GetPDGEncoding()
                            << endmsg;
                     is_decay = true;
+
+                    // create secondaries in MC particles
+                    // todo: convert the const collection to non-const
+                    auto mcCol = const_cast<edm4hep::MCParticleCollection*>(m_mcParCol.get());
+                    edm4hep::MCParticle mcp = mcCol->create();
+                    mcp.setPDG(secparticle->GetPDGEncoding());
+                    mcp.setGeneratorStatus(0); // not created by Generator
+                    mcp.setCreatedInSimulation(1);
+                    mcp.setCharge(secparticle->GetPDGCharge());
+                    mcp.setTime(0.0); // todo
+                    mcp.setMass(secparticle->GetPDGMass());
+                    double x=0, y=0, z=0;
+                    double px=0, py=0, pz=0;
+                    mcp.setVertex(edm4hep::Vector3d(x,y,z)); // todo
+                    mcp.setEndpoint(edm4hep::Vector3d(x,y,z)); // todo
+                    mcp.setMomentum(edm4hep::Vector3f(px,py,pz)); // todo
+                    mcp.setMomentumAtEndpoint(edm4hep::Vector3f(px,py,pz)); //todo
+
+                    mcp.addToParents(primary_particle);
+                    primary_particle.addToDaughters(mcp);
                 }
             }
         }

--- a/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
+++ b/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
@@ -207,6 +207,11 @@ Edm4hepWriterAnaElemTool::EndOfEventAction(const G4Event* anEvent) {
                     }
 
                     edm_trk_hit.setMCParticle(mcCol->at(pritrkid-1));
+
+                    if (pritrkid != trackID) {
+                        // If the track is a secondary, then the primary track id and current track id is different
+                        edm_trk_hit.setProducedBySecondary(true);
+                    }
                 }
 
                 dd4hep::sim::Geant4CalorimeterHit* cal_hit = dynamic_cast<dd4hep::sim::Geant4CalorimeterHit*>(h);


### PR DESCRIPTION
Flag in particles:
* [x] select "Decay" process
* [ ] decay at tracker or calorimeter
  * This feature is not implemented yet. If particle is decayed, then both bits are marked as 1.
* [x] create secondaries of decay into MC particle collections
  * [ ] The endpoint and momentum at endpoint is not saved yet.

Flag in hits:
* [x] If the tracker hit is created by secondaries, set flag 