### PR TITLE
WIP: allow to associate a fastsim model with multiple regions

### DIFF
--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.cpp
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.cpp
@@ -27,14 +27,15 @@ bool DummyFastSimG4Tool::CreateFastSimulationModel() {
     // * Associate model and region
 
     G4String model_name = "DummyFastSimG4Model";
-    G4String region_name = "DriftChamberRegion";
-    G4Region* aEnvelope = G4RegionStore::GetInstance()->GetRegion(region_name);
-    if (!aEnvelope) {
-        error() << "Failed to find G4Region '" << region_name << "'" << endmsg;
-        return false;
-    }
+    for (auto region_name: m_regions.value()) {
+        G4Region* aEnvelope = G4RegionStore::GetInstance()->GetRegion(region_name);
+        if (!aEnvelope) {
+            error() << "Failed to find G4Region '" << region_name << "'" << endmsg;
+            return false;
+        }
 
-    DummyFastSimG4Model* model = new DummyFastSimG4Model(model_name, aEnvelope);
-    info() << "Create Model " << model_name << " for G4Region " << region_name << endmsg;
+        DummyFastSimG4Model* model = new DummyFastSimG4Model(model_name+region_name, aEnvelope);
+        info() << "Create Model " << model_name << " for G4Region " << region_name << endmsg;
+    }
     return true;
 }

--- a/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.h
+++ b/Simulation/DetSimFastModel/src/DummyFastSimG4Tool.h
@@ -14,7 +14,8 @@ public:
     bool CreateFastSimulationModel() override;
 
 private:
-
+    // the regions will be associated with the fast sim model
+    Gaudi::Property<std::vector<std::string>> m_regions{this, "Regions"};
 };
 
 #endif


### PR DESCRIPTION
In the previous implementation, one fast sim model is only associated with one region and the region name is hard-coded. In this PR, users are allowed to set the region names as following:
```python
from Configurables import DummyFastSimG4Tool
dummy_fastsim_tool = DummyFastSimG4Tool("DummyFastSimG4Tool")
dummy_fastsim_tool.Regions = [
    "DriftChamberRegion",
]

detsimalg.FastSimG4Tools = [
    "DummyFastSimG4Tool"
]
```