### PR TITLE
WIP: set envvar to be compatible with LCG 97 and Gaudi v33/34.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
 
 project(CEPCSW)
 
+# setup some necessary envvar
+include(cmake/CEPCSWEnv.cmake)
+#
+
 find_package(ROOT COMPONENTS RIO Tree)
 
 find_package(Gaudi)

--- a/cmake/CEPCSWEnv.cmake
+++ b/cmake/CEPCSWEnv.cmake
@@ -1,0 +1,9 @@
+# This variable will be used by GaudiToolbox.cmake to generate the cepcswenv.sh
+
+set(RUN_SCRIPT_EXTRA_COMMANDS "${RUN_SCRIPT_EXTRA_COMMANDS}
+export CEPCSW_ROOT=${CMAKE_SOURCE_DIR}
+
+export DETCEPCV4ROOT=${CMAKE_SOURCE_DIR}/Detector/DetCEPCv4
+export DETCRDROOT=${CMAKE_SOURCE_DIR}/Detector/DetCRD
+export DETDRIFTCHAMBERROOT=${CMAKE_SOURCE_DIR}/Detector/DetDriftChamber
+")


### PR DESCRIPTION
Because the Gaudi v35 removes the feature to create envvar for each package, this PR provides a solution to setup some necessary envvar. The cmake variable `RUN_SCRIPT_EXTRA_COMMANDS` could refer to https://twikiro.cern.ch/twiki/bin/view/LHCb/MaintainGaudiCMake315Configuration