### PR TITLE
WIP: Set the Random Seed in DetSimAlg

### DIFF
--- a/Examples/options/tut_detsim.py
+++ b/Examples/options/tut_detsim.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-print(os.environ["DD4HEP_LIBRARY_PATH"])
 import sys
 # sys.exit(0)
 
@@ -12,13 +11,15 @@ from Gaudi.Configuration import *
 ##############################################################################
 from Configurables import RndmGenSvc, HepRndm__Engine_CLHEP__RanluxEngine_
 
-# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
-rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_() # The default engine in Geant4
-rndmengine.SetSingleton = True
-rndmengine.Seeds = [42]
+seed = [42]
 
-# rndmgensvc = RndmGenSvc("RndmGenSvc")
-# rndmgensvc.Engine = rndmengine.name()
+# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
+rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_("RndmGenSvc.Engine") # The default engine in Geant4
+rndmengine.SetSingleton = True
+rndmengine.Seeds = seed
+
+rndmgensvc = RndmGenSvc("RndmGenSvc")
+rndmgensvc.Engine = rndmengine.name()
 
 
 ##############################################################################
@@ -100,6 +101,7 @@ detsimsvc = DetSimSvc("DetSimSvc")
 from Configurables import DetSimAlg
 
 detsimalg = DetSimAlg("DetSimAlg")
+detsimalg.RandomSeeds = seed
 
 # detsimalg.VisMacs = ["vis.mac"]
 
@@ -133,5 +135,5 @@ from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = [genalg, detsimalg, out],
                 EvtSel = 'NONE',
                 EvtMax = 10,
-                ExtSvc = [rndmengine, dsvc, geosvc],
+                ExtSvc = [rndmengine, rndmgensvc, dsvc, geosvc],
 )

--- a/Examples/options/tut_detsim_SDT.py
+++ b/Examples/options/tut_detsim_SDT.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-print(os.environ["DD4HEP_LIBRARY_PATH"])
 import sys
 # sys.exit(0)
 
@@ -12,13 +11,15 @@ from Gaudi.Configuration import *
 ##############################################################################
 from Configurables import RndmGenSvc, HepRndm__Engine_CLHEP__RanluxEngine_
 
-# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
-rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_() # The default engine in Geant4
-rndmengine.SetSingleton = True
-rndmengine.Seeds = [42]
+seed = [42]
 
-# rndmgensvc = RndmGenSvc("RndmGenSvc")
-# rndmgensvc.Engine = rndmengine.name()
+# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
+rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_("RndmGenSvc.Engine") # The default engine in Geant4
+rndmengine.SetSingleton = True
+rndmengine.Seeds = seed
+
+rndmgensvc = RndmGenSvc("RndmGenSvc")
+rndmgensvc.Engine = rndmengine.name()
 
 
 ##############################################################################
@@ -110,6 +111,7 @@ detsimsvc = DetSimSvc("DetSimSvc")
 from Configurables import DetSimAlg
 
 detsimalg = DetSimAlg("DetSimAlg")
+detsimalg.RandomSeeds = seed
 
 if int(os.environ.get("VIS", 0)):
     detsimalg.VisMacs = ["vis.mac"]
@@ -173,5 +175,5 @@ from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = [genalg, detsimalg, out],
                 EvtSel = 'NONE',
                 EvtMax = 10,
-                ExtSvc = [rndmengine, dsvc, geosvc],
+                ExtSvc = [rndmengine, rndmgensvc, dsvc, geosvc],
 )

--- a/Examples/options/tut_detsim_digi_SDT.py
+++ b/Examples/options/tut_detsim_digi_SDT.py
@@ -12,13 +12,15 @@ from Gaudi.Configuration import *
 ##############################################################################
 from Configurables import RndmGenSvc, HepRndm__Engine_CLHEP__RanluxEngine_
 
-# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
-rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_() # The default engine in Geant4
-rndmengine.SetSingleton = True
-rndmengine.Seeds = [42]
+seed = [42]
 
-# rndmgensvc = RndmGenSvc("RndmGenSvc")
-# rndmgensvc.Engine = rndmengine.name()
+# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
+rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_("RndmGenSvc.Engine") # The default engine in Geant4
+rndmengine.SetSingleton = True
+rndmengine.Seeds = seed
+
+rndmgensvc = RndmGenSvc("RndmGenSvc")
+rndmgensvc.Engine = rndmengine.name()
 
 
 ##############################################################################
@@ -112,6 +114,7 @@ detsimsvc = DetSimSvc("DetSimSvc")
 from Configurables import DetSimAlg
 
 detsimalg = DetSimAlg("DetSimAlg")
+detsimalg.RandomSeeds = seed
 
 if int(os.environ.get("VIS", 0)):
     detsimalg.VisMacs = ["vis.mac"]
@@ -183,7 +186,7 @@ from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = [genalg, detsimalg, dCHDigiAlg, out],
                 EvtSel = 'NONE',
                 EvtMax = 10,
-                ExtSvc = [rndmengine, dsvc, geosvc],
+                ExtSvc = [rndmengine, rndmgensvc, dsvc, geosvc],
                 HistogramPersistency = "ROOT",
                 OutputLevel=INFO
 )

--- a/Examples/options/tut_detsim_digi_fit_DC.py
+++ b/Examples/options/tut_detsim_digi_fit_DC.py
@@ -12,13 +12,15 @@ from Gaudi.Configuration import *
 ##############################################################################
 from Configurables import RndmGenSvc, HepRndm__Engine_CLHEP__RanluxEngine_
 
-# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
-rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_() # The default engine in Geant4
-rndmengine.SetSingleton = True
-rndmengine.Seeds = [42]
+seed = [42]
 
-# rndmgensvc = RndmGenSvc("RndmGenSvc")
-# rndmgensvc.Engine = rndmengine.name()
+# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
+rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_("RndmGenSvc.Engine") # The default engine in Geant4
+rndmengine.SetSingleton = True
+rndmengine.Seeds = seed
+
+rndmgensvc = RndmGenSvc("RndmGenSvc")
+rndmgensvc.Engine = rndmengine.name()
 
 
 ##############################################################################
@@ -112,6 +114,7 @@ detsimsvc = DetSimSvc("DetSimSvc")
 from Configurables import DetSimAlg
 
 detsimalg = DetSimAlg("DetSimAlg")
+detsimalg.RandomSeeds = seed
 
 if int(os.environ.get("VIS", 0)):
     detsimalg.VisMacs = ["vis.mac"]
@@ -193,7 +196,7 @@ ApplicationMgr( TopAlg = [genalg, detsimalg, dCHDigiAlg, truthTrackerAlg,
                           recGenfitAlgDC,out],
                 EvtSel = 'NONE',
                 EvtMax = 10,
-                ExtSvc = [rndmengine, dsvc, geosvc, ntsvc],
+                ExtSvc = [rndmengine, rndmgensvc, dsvc, geosvc, ntsvc],
                 HistogramPersistency = "ROOT",
                 OutputLevel=ERROR
 )

--- a/Examples/options/tut_detsim_digi_truthTracker_SDT.py
+++ b/Examples/options/tut_detsim_digi_truthTracker_SDT.py
@@ -12,13 +12,15 @@ from Gaudi.Configuration import *
 ##############################################################################
 from Configurables import RndmGenSvc, HepRndm__Engine_CLHEP__RanluxEngine_
 
-# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
-rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_() # The default engine in Geant4
-rndmengine.SetSingleton = True
-rndmengine.Seeds = [42]
+seed = [42]
 
-# rndmgensvc = RndmGenSvc("RndmGenSvc")
-# rndmgensvc.Engine = rndmengine.name()
+# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
+rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_("RndmGenSvc.Engine") # The default engine in Geant4
+rndmengine.SetSingleton = True
+rndmengine.Seeds = seed
+
+rndmgensvc = RndmGenSvc("RndmGenSvc")
+rndmgensvc.Engine = rndmengine.name()
 
 
 ##############################################################################
@@ -112,6 +114,7 @@ detsimsvc = DetSimSvc("DetSimSvc")
 from Configurables import DetSimAlg
 
 detsimalg = DetSimAlg("DetSimAlg")
+detsimalg.RandomSeeds = seed
 
 if int(os.environ.get("VIS", 0)):
     detsimalg.VisMacs = ["vis.mac"]
@@ -176,7 +179,7 @@ dCHDigiAlg.WriteAna  = True
 from Configurables import TruthTrackerAlg
 truthTrackerAlg = TruthTrackerAlg("TruthTrackerAlg")
 truthTrackerAlg.DCHitAssociationCollection="DCHAssociationCollectio"
-truthTrackerAlg.debug = 1
+# truthTrackerAlg.debug = 1
 
 ##############################################################################
 # POD I/O
@@ -194,7 +197,7 @@ from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = [genalg, detsimalg, dCHDigiAlg, truthTrackerAlg, out],
                 EvtSel = 'NONE',
                 EvtMax = 10,
-                ExtSvc = [rndmengine, dsvc, geosvc],
+                ExtSvc = [rndmengine, rndmgensvc, dsvc, geosvc],
                 HistogramPersistency = "ROOT",
                 OutputLevel=INFO
 )

--- a/Examples/options/tut_detsim_digi_truthTracker_SDT_dedx.py
+++ b/Examples/options/tut_detsim_digi_truthTracker_SDT_dedx.py
@@ -12,13 +12,15 @@ from Gaudi.Configuration import *
 ##############################################################################
 from Configurables import RndmGenSvc, HepRndm__Engine_CLHEP__RanluxEngine_
 
-# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
-rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_() # The default engine in Geant4
-rndmengine.SetSingleton = True
-rndmengine.Seeds = [42]
+seed = [42]
 
-# rndmgensvc = RndmGenSvc("RndmGenSvc")
-# rndmgensvc.Engine = rndmengine.name()
+# rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
+rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_("RndmGenSvc.Engine") # The default engine in Geant4
+rndmengine.SetSingleton = True
+rndmengine.Seeds = seed
+
+rndmgensvc = RndmGenSvc("RndmGenSvc")
+rndmgensvc.Engine = rndmengine.name()
 
 
 ##############################################################################
@@ -113,6 +115,7 @@ detsimsvc = DetSimSvc("DetSimSvc")
 from Configurables import DetSimAlg
 
 detsimalg = DetSimAlg("DetSimAlg")
+detsimalg.RandomSeeds = seed
 #detsimalg.RunMacs = ["Examples/options/noDecay.mac"]
 #detsimalg.RunCmds = ["Examples/options/noDecay.mac"]
 
@@ -216,7 +219,7 @@ from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = [genalg, detsimalg, dCHDigiAlg, truthTrackerAlg, dedxAlg],
                 EvtSel = 'NONE',
                 EvtMax = 10,
-                ExtSvc = [rndmengine, dsvc, geosvc],
+                ExtSvc = [rndmengine, rndmgensvc, dsvc, geosvc],
                 HistogramPersistency = "ROOT",
                 OutputLevel=INFO
 )

--- a/Examples/options/tut_detsim_pan_matrix.py
+++ b/Examples/options/tut_detsim_pan_matrix.py
@@ -11,9 +11,14 @@ from Gaudi.Configuration import *
 ##############################################################################
 from Configurables import RndmGenSvc, HepRndm__Engine_CLHEP__RanluxEngine_
 
-rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_() # The default engine in Geant4
+seed = [42]
+
+rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_("RndmGenSvc.Engine") # The default engine in Geant4
 rndmengine.SetSingleton = True
-rndmengine.Seeds = [42]
+rndmengine.Seeds = seed
+
+rndmgensvc = RndmGenSvc("RndmGenSvc")
+rndmgensvc.Engine = rndmengine.name()
 
 ##############################################################################
 # Event Data Svc
@@ -87,7 +92,9 @@ from Configurables import DetSimSvc
 detsimsvc = DetSimSvc("DetSimSvc")
 from Configurables import DetSimAlg
 detsimalg = DetSimAlg("DetSimAlg")
-detsimalg.VisMacs = ["Examples/options/vis.mac"]
+detsimalg.RandomSeeds = seed
+
+# detsimalg.VisMacs = ["Examples/options/vis.mac"]
 detsimalg.RunCmds = [
 #    "/tracking/verbose 1",
 ]
@@ -173,6 +180,6 @@ ApplicationMgr(
         #TopAlg = [genalg, detsimalg, example_CaloDigiAlg, pandoralg],
         EvtSel = 'NONE',
         EvtMax = 50,
-        ExtSvc = [rndmengine, dsvc, geosvc, gearSvc,detsimsvc],
+        ExtSvc = [rndmengine, rndmgensvc, dsvc, geosvc, gearSvc,detsimsvc],
         OutputLevel=INFO
 )

--- a/Examples/options/tut_detsim_pandora.py
+++ b/Examples/options/tut_detsim_pandora.py
@@ -11,10 +11,15 @@ from Gaudi.Configuration import *
 ##############################################################################
 from Configurables import RndmGenSvc, HepRndm__Engine_CLHEP__RanluxEngine_
 
+seed = [42]
+
 # rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
-rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_() # The default engine in Geant4
+rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_("RndmGenSvc.Engine") # The default engine in Geant4
 rndmengine.SetSingleton = True
-rndmengine.Seeds = [42]
+rndmengine.Seeds = seed
+
+rndmgensvc = RndmGenSvc("RndmGenSvc")
+rndmgensvc.Engine = rndmengine.name()
 
 ##############################################################################
 # Event Data Svc
@@ -90,6 +95,7 @@ detsimsvc = DetSimSvc("DetSimSvc")
 from Configurables import DetSimAlg
 
 detsimalg = DetSimAlg("DetSimAlg")
+detsimalg.RandomSeeds = seed
 
 # detsimalg.VisMacs = ["vis.mac"]
 
@@ -217,7 +223,7 @@ ApplicationMgr(
         TopAlg = [genalg, detsimalg, simHitMerge, caloDigi, pandoralg, write],
         EvtSel = 'NONE',
         EvtMax = 10,
-        ExtSvc = [rndmengine, dsvc, geosvc, gearSvc,detsimsvc],
+        ExtSvc = [rndmengine, rndmgensvc, dsvc, geosvc, gearSvc,detsimsvc],
         HistogramPersistency = "ROOT",
         OutputLevel=INFO
 )

--- a/Simulation/DetSimCore/src/DetSimAlg.cpp
+++ b/Simulation/DetSimCore/src/DetSimAlg.cpp
@@ -39,7 +39,7 @@ DetSimAlg::initialize() {
 
     info() << "Random Seed is initialized to "
            << G4Random::getTheSeed()
-           << " in Geant4" << std::endl;
+           << " in Geant4" << endmsg;
 
     m_detsimsvc = service("DetSimSvc");
     if (!m_detsimsvc) {

--- a/Simulation/DetSimCore/src/DetSimAlg.cpp
+++ b/Simulation/DetSimCore/src/DetSimAlg.cpp
@@ -2,12 +2,14 @@
 #include "GaudiKernel/IEventProcessor.h"
 #include "GaudiKernel/IAppMgrUI.h"
 #include "GaudiKernel/GaudiException.h"
+#include "GaudiKernel/IRndmEngine.h"
 
 #include "G4RunManager.hh"
 #include "G4UImanager.hh"
 #include "G4VisExecutive.hh"
 #include "G4UIExecutive.hh"
 
+#include "Randomize.hh"
 #include "DetectorConstruction.h"
 #include "G4PhysListFactory.hh"
 #include "G4EmParameters.hh"
@@ -29,6 +31,15 @@ DetSimAlg::initialize() {
     StatusCode sc;
 
     info() << "Initialize DetSimAlg... " << endmsg;
+
+    // Initialize random seed
+    if (not m_randomSeeds.empty()) {
+        randSvc()->engine()->setSeeds( m_randomSeeds );
+    }
+
+    info() << "Random Seed is initialized to "
+           << G4Random::getTheSeed()
+           << " in Geant4" << std::endl;
 
     m_detsimsvc = service("DetSimSvc");
     if (!m_detsimsvc) {

--- a/Simulation/DetSimCore/src/DetSimAlg.h
+++ b/Simulation/DetSimCore/src/DetSimAlg.h
@@ -31,6 +31,8 @@ private:
 
 private:
 
+    Gaudi::Property<std::vector<long>> m_randomSeeds{this, "RandomSeeds", {}};
+
     Gaudi::Property<std::vector<std::string>> m_run_macs{this, "RunMacs"};
     Gaudi::Property<std::vector<std::string>> m_run_cmds{this, "RunCmds"};
     Gaudi::Property<std::vector<std::string>> m_vis_macs{this, "VisMacs"};


### PR DESCRIPTION
In https://gitlab.cern.ch/gaudi/Gaudi/-/issues/165, I report the seed is clear in Gaudi. So the current solution is to set the seed in DetSimAlg.

The major changes in Python script:
- define a seed
- Create the Random Engine with name "RndmGenSvc.Engine"
- Create the RndmGenSvc
- Set the `detsimalg.RandomSeeds = seed`
- add the RndmGenSvc in the ExtSvc

```diff
+seed = [42]
+
 # rndmengine = HepRndm__Engine_CLHEP__RanluxEngine_() # The default engine in Gaudi
-rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_() # The default engine in Geant4
+rndmengine = HepRndm__Engine_CLHEP__HepJamesRandom_("RndmGenSvc.Engine") # The default engine in Geant4
 rndmengine.SetSingleton = True
-rndmengine.Seeds = [42]
+rndmengine.Seeds = seed
+
+rndmgensvc = RndmGenSvc("RndmGenSvc")
+rndmgensvc.Engine = rndmengine.name()

 detsimalg = DetSimAlg("DetSimAlg")
+detsimalg.RandomSeeds = seed

-        ExtSvc = [rndmengine, dsvc, geosvc, gearSvc,detsimsvc],
+        ExtSvc = [rndmengine, rndmgensvc, dsvc, geosvc, gearSvc,detsimsvc],

```