### PR TITLE
SIM: fix on option of CEPCv4 Hcal

### DIFF
--- a/Detector/DetCEPCv4/compact/SHcalRpc01_Barrel_01.xml
+++ b/Detector/DetCEPCv4/compact/SHcalRpc01_Barrel_01.xml
@@ -33,8 +33,8 @@
 
   <readouts>
     <readout name="HcalBarrelCollection">
-      <segmentation type="CartesianGridXY" grid_size_x="Hcal_cells_size" grid_size_y="Hcal_cells_size"/>
-      <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,x:32:-16,y:-16</id>
+      <segmentation type="CartesianGridYZ" grid_size_y="Hcal_cells_size" grid_size_z="Hcal_cells_size"/>
+      <id>system:5,module:3,stave:3,tower:5,layer:6,slice:4,y:32:-16,z:-16</id>
     </readout>
   </readouts>
 


### PR DESCRIPTION
Wenxing reported a bug on the difference of position between SimHit.getPosition() and
CellIDPositionConverter::position(Simhit.getCellID()). 

Through check, It is found that this is caused by the unmatched usage of segmentation
with geometry. This commit can fix this bug.