### PR TITLE
Remove default argument values from friend member functions

### DIFF
--- a/Reconstruction/RecGenfitAlg/src/GenfitTrack.h
+++ b/Reconstruction/RecGenfitAlg/src/GenfitTrack.h
@@ -55,26 +55,26 @@ namespace dd4hep {
 
 class GenfitTrack {
     friend int GenfitFitter::processTrack(
-            GenfitTrack* track, bool resort=false);
+            GenfitTrack* track, bool resort);
 
     friend int GenfitFitter::processTrackWithRep(
-            GenfitTrack* track, int repID=0, bool resort=false);
+            GenfitTrack* track, int repID, bool resort);
 
     friend double GenfitFitter::extrapolateToHit(TVector3& poca,
             TVector3& pocaDir,
             TVector3& pocaOnWire, double& doca, const GenfitTrack* track,
             TVector3 pos, TVector3 mom, TVector3 end0, TVector3 end1, int debug,
-            int repID=0, bool stopAtBoundary=false, bool calcJacobianNoise=false);
+            int repID, bool stopAtBoundary, bool calcJacobianNoise);
 
     friend double GenfitFitter::extrapolateToCylinder(TVector3& pos,
             TVector3& mom,
             GenfitTrack* track, double radius, const TVector3 linePoint,
-            const TVector3 lineDirection, int hitID =0, int repID=0,
-            bool stopAtBoundary=false, bool calcJacobianNoise=false);
+            const TVector3 lineDirection, int hitID, int repID,
+            bool stopAtBoundary, bool calcJacobianNoise);
 
     friend double GenfitFitter::extrapolateToPoint(TVector3& pos, TVector3& mom,
-            const GenfitTrack* genfitTrack, const TVector3& point, int repID=0,
-            bool stopAtBoundary = false, bool calcJacobianNoise = false) const;
+            const GenfitTrack* genfitTrack, const TVector3& point, int repID,
+            bool stopAtBoundary, bool calcJacobianNoise) const;
 
     public:
     GenfitTrack(const GenfitField* field,


### PR DESCRIPTION
gcc 9.3.0 flags these as errors (-fpermissive), because a friend declaration with default arguments must also be a definition.

I suppose gcc has become less forgiving between gcc8 and gcc9, because everything still works with gcc8. Also simply removing the default arguments here doesn't break anything in the build, so I think they are provided on the call sites in any case.

Fixes key4hep/key4hep-spack#157