### PR TITLE
REC: add optional control for cov matrix

### DIFF
--- a/Digitisers/SimpleDigi/src/PlanarDigiAlg.h
+++ b/Digitisers/SimpleDigi/src/PlanarDigiAlg.h
@@ -79,6 +79,9 @@ protected:
   Gaudi::Property<FloatVec> _resV{ this, "ResolutionV", {0.0040} };
   // whether hits are 1D strip hits
   Gaudi::Property<bool> _isStrip{ this, "IsStrip", false };
+  // whether use Planar tag for type and cov, if true, CEPCConf::TrkHitTypeBit::PLANAR bit is set as true
+  // cov[0]=thetaU, cov[1]=phiU, cov[2]=resU, cov[0]=thetaV, cov[1]=phiV, cov[2]=resV
+  Gaudi::Property<bool> _usePlanarTag{ this, "UsePlanarTag", true };
 
   // Input collections
   DataHandle<edm4hep::EventHeaderCollection> _headerCol{"EventHeaderCol", Gaudi::DataHandle::Reader, this};

--- a/Utilities/DataHelper/include/DataHelper/TrackerHitHelper.h
+++ b/Utilities/DataHelper/include/DataHelper/TrackerHitHelper.h
@@ -8,6 +8,7 @@ namespace CEPC{
   std::array<float, 6> GetCovMatrix(edm4hep::TrackerHit& hit, bool useSpacePointerBuilderMethod = false);
   float                GetResolutionRPhi(edm4hep::TrackerHit& hit);
   float                GetResolutionZ(edm4hep::TrackerHit& hit);
+  std::array<float, 6> ConvertToCovXYZ(float dU, float thetaU, float phiU, float dV, float thetaV, float phiV, bool useSpacePointBuilderMethod = false);
 }
 
 #endif

--- a/Utilities/DataHelper/src/TrackerHitHelper.cpp
+++ b/Utilities/DataHelper/src/TrackerHitHelper.cpp
@@ -2,7 +2,6 @@
 #include "Identifier/CEPCConf.h"
 
 #include "TMatrixF.h"
-#include "TMatrixFSym.h"
 #include "CLHEP/Matrix/SymMatrix.h"
 #include "CLHEP/Matrix/Matrix.h"
 #include "CLHEP/Vector/ThreeVector.h"
@@ -16,60 +15,13 @@ std::array<float,6> CEPC::GetCovMatrix(edm4hep::TrackerHit& hit, bool useSpacePo
       return hit.getCovMatrix();
     }
     else if(std::bitset<32>(type)[CEPCConf::TrkHitTypeBit::PLANAR]){
-      std::array<float,6> cov{0.,0.,0.,0.,0.,0.};
       float thetaU = hit.getCovMatrix(0);
       float phiU   = hit.getCovMatrix(1);
       float dU     = hit.getCovMatrix(2);
       float thetaV = hit.getCovMatrix(3);
       float phiV   = hit.getCovMatrix(4);
       float dV     = hit.getCovMatrix(5);
-      
-      if(!useSpacePointBuilderMethod){
-	TMatrixF diffs(2,3);
-	TMatrixF diffsT(3,2);
-	diffs(0,0) = sin(thetaU)*cos(phiU);
-	diffs(0,1) = sin(thetaU)*sin(phiU);
-	diffs(0,2) = cos(thetaU);
-	diffs(1,0) = sin(thetaV)*cos(phiV);
-	diffs(1,1) = sin(thetaV)*sin(phiV);
-	diffs(1,2) = cos(thetaV);
-	
-	diffsT.Transpose(diffs);
-	
-	TMatrixF covMatrixUV(2,2);
-	covMatrixUV(0,0) = dU*dU;
-	covMatrixUV(0,1) = 0;
-	covMatrixUV(1,0) = 0;
-	covMatrixUV(1,1) = dV*dV;
-	
-	TMatrixF covMatrixXYZ(3,3);
-	covMatrixXYZ = diffsT*covMatrixUV*diffs;
-	cov[0] = covMatrixXYZ(0,0);
-	cov[1] = covMatrixXYZ(1,0);
-	cov[2] = covMatrixXYZ(1,1);
-	cov[3] = covMatrixXYZ(2,0);
-	cov[4] = covMatrixXYZ(2,1);
-	cov[5] = covMatrixXYZ(2,2);
-      }
-      else{ // Method used in SpacePointBuilder, results are almost same with above
-	CLHEP::Hep3Vector u_sensor(sin(thetaU)*cos(phiU), sin(thetaU)*sin(phiU), cos(thetaU));
-	CLHEP::Hep3Vector v_sensor(sin(thetaV)*cos(phiV), sin(thetaV)*sin(phiV), cos(thetaV));
-	CLHEP::Hep3Vector w_sensor = u_sensor.cross(v_sensor);
-	CLHEP::HepRotation rot_sensor(u_sensor, v_sensor, w_sensor);
-	CLHEP::HepMatrix rot_sensor_matrix;
-	rot_sensor_matrix = rot_sensor;
-	CLHEP::HepSymMatrix cov_plane(3,0);
-	cov_plane(1,1) = dU*dU;
-	cov_plane(2,2) = dV*dV;
-	CLHEP::HepSymMatrix cov_xyz= cov_plane.similarity(rot_sensor_matrix);
-	cov[0] = cov_xyz[0][0];
-	cov[1] = cov_xyz[1][0];
-	cov[2] = cov_xyz[1][1];
-	cov[3] = cov_xyz[2][0];
-	cov[4] = cov_xyz[2][1];
-	cov[5] = cov_xyz[2][2];
-      }
-      return cov;
+      return ConvertToCovXYZ(dU, thetaU, phiU, dV, thetaV, phiV, useSpacePointBuilderMethod);
     }
     else{
       std::cout << "Warning: not SpacePoint and Planar, return original cov matrix preliminaryly." << std::endl;
@@ -112,4 +64,54 @@ float CEPC::GetResolutionZ(edm4hep::TrackerHit& hit){
     }
   }
   return 0.;
+}
+
+std::array<float, 6> CEPC::ConvertToCovXYZ(float dU, float thetaU, float phiU, float dV, float thetaV, float phiV, bool useSpacePointBuilderMethod){
+  std::array<float,6> cov{0.,0.,0.,0.,0.,0.};
+  if(!useSpacePointBuilderMethod){
+    TMatrixF diffs(2,3);
+    TMatrixF diffsT(3,2);
+    diffs(0,0) = sin(thetaU)*cos(phiU);
+    diffs(0,1) = sin(thetaU)*sin(phiU);
+    diffs(0,2) = cos(thetaU);
+    diffs(1,0) = sin(thetaV)*cos(phiV);
+    diffs(1,1) = sin(thetaV)*sin(phiV);
+    diffs(1,2) = cos(thetaV);
+
+    diffsT.Transpose(diffs);
+
+    TMatrixF covMatrixUV(2,2);
+    covMatrixUV(0,0) = dU*dU;
+    covMatrixUV(0,1) = 0;
+    covMatrixUV(1,0) = 0;
+    covMatrixUV(1,1) = dV*dV;
+
+    TMatrixF covMatrixXYZ(3,3);
+    covMatrixXYZ = diffsT*covMatrixUV*diffs;
+    cov[0] = covMatrixXYZ(0,0);
+    cov[1] = covMatrixXYZ(1,0);
+    cov[2] = covMatrixXYZ(1,1);
+    cov[3] = covMatrixXYZ(2,0);
+    cov[4] = covMatrixXYZ(2,1);
+    cov[5] = covMatrixXYZ(2,2);
+  }
+  else{ // Method used in SpacePointBuilder, results are almost same with above
+    CLHEP::Hep3Vector u_sensor(sin(thetaU)*cos(phiU), sin(thetaU)*sin(phiU), cos(thetaU));
+    CLHEP::Hep3Vector v_sensor(sin(thetaV)*cos(phiV), sin(thetaV)*sin(phiV), cos(thetaV));
+    CLHEP::Hep3Vector w_sensor = u_sensor.cross(v_sensor);
+    CLHEP::HepRotation rot_sensor(u_sensor, v_sensor, w_sensor);
+    CLHEP::HepMatrix rot_sensor_matrix;
+    rot_sensor_matrix = rot_sensor;
+    CLHEP::HepSymMatrix cov_plane(3,0);
+    cov_plane(1,1) = dU*dU;
+    cov_plane(2,2) = dV*dV;
+    CLHEP::HepSymMatrix cov_xyz= cov_plane.similarity(rot_sensor_matrix);
+    cov[0] = cov_xyz[0][0];
+    cov[1] = cov_xyz[1][0];
+    cov[2] = cov_xyz[1][1];
+    cov[3] = cov_xyz[2][0];
+    cov[4] = cov_xyz[2][1];
+    cov[5] = cov_xyz[2][2];
+  }
+  return cov;
 }


### PR DESCRIPTION
* prepare for switch cov matrix
* Plan:
  * function CEPC::GetResolutionRPhi() and CEPC::GetResolutionZ() to replace hit.getCovMatrix() to get resolution for planar sensors in silicon tracking algorithm
  * control to save XYZ cov matrix or RphiZ cov matrix