### PR TITLE
As the latest DDG4 removes DDG4Legacy, the code is updated. It will fix the issue #159

### DIFF
--- a/Simulation/DetSimSD/src/DDG4SensitiveDetector.cpp
+++ b/Simulation/DetSimSD/src/DDG4SensitiveDetector.cpp
@@ -1,6 +1,5 @@
 #include "DetSimSD/DDG4SensitiveDetector.h"
 
-#include "DDG4/Geant4SensitiveDetector.h"
 #include "DDG4/Geant4Converter.h"
 #include "DDG4/Geant4Hits.h"
 #include "DD4hep/Segmentations.h"


### PR DESCRIPTION
In the latest DD4hep, the DDG4 Legacy is removed in https://github.com/AIDASoft/DD4hep/commit/a732b835fa571ba5db47e29da7d05c2eea7339b2#diff-bf9e9572dd8da09de21a1b7143d7c73189dad8ae2eb581ad2caaa216e4cc573f , which cause the build of Key4hep project failed (see issue #159). The solution is removing the related code in CEPCSW. 