### PR TITLE
REC: cheat DC as TPC for Gear and fix VXD error while no cryostat

### DIFF
--- a/Service/GearSvc/src/GearSvc.cpp
+++ b/Service/GearSvc/src/GearSvc.cpp
@@ -93,6 +93,9 @@ StatusCode GearSvc::initialize()
       else if(it->first=="TPC"){
 	sc = convertTPC(sub);
       }
+      else if(it->first=="DriftChamber"){
+        sc = convertDC(sub);
+      }
       else if(it->first=="SET"){
 	sc = convertSET(sub);
       }
@@ -101,6 +104,7 @@ StatusCode GearSvc::initialize()
       }
       if(sc==StatusCode::FAILURE) return sc;
     }
+
     gear::CalorimeterParametersImpl* barrelParam = new gear::CalorimeterParametersImpl(1847.415655, 2350., 8, 0.);
     gear::CalorimeterParametersImpl* endcapParam = new gear::CalorimeterParametersImpl(400., 2088.8, 2450., 2, 0.);
     for(int i=0;i<29;i++){
@@ -200,7 +204,7 @@ StatusCode GearSvc::convertVXD(dd4hep::DetElement& vxd){
   double phi0=0;
   helpLayer thisLadder;
   double beryllium_ladder_block_length=0,end_electronics_half_z=0,side_band_electronics_width=0;
-  double rAlu, drAlu, rSty, drSty, dzSty, rInner, aluEndcapZ, aluHalfZ, alu_RadLen, Cryostat_dEdx;
+  double rAlu=0, drAlu, rSty, drSty, dzSty, rInner, aluEndcapZ, aluHalfZ, alu_RadLen, Cryostat_dEdx;
   double VXDSupportDensity, VXDSupportZeff, VXDSupportAeff, VXDSupportRadLen, VXDSupportIntLen=0;
   double styDensity, styZeff, styAeff, styRadLen, styIntLen; 
   dd4hep::Volume vxd_vol = vxd.volume();
@@ -558,14 +562,17 @@ StatusCode GearSvc::convertVXD(dd4hep::DetElement& vxd){
            << helpSensitives[i].thickness*2 << ", " << helpSensitives[i].length << ", " << helpSensitives[i].width*2 << ", " << helpSensitives[i].radLength << endmsg;
   }
   m_gearMgr->setVXDParameters(vxdParameters) ;
-  gear::GearParametersImpl* gearParameters = new gear::GearParametersImpl;
-  //CryostatAlRadius, CryostatAlThickness, CryostatAlInnerR, CryostatAlZEndCap, CryostatAlHalfZ
-  gearParameters->setDoubleVal("CryostatAlRadius",    rAlu);
-  gearParameters->setDoubleVal("CryostatAlThickness", drAlu);
-  gearParameters->setDoubleVal("CryostatAlInnerR",    rInner);
-  gearParameters->setDoubleVal("CryostatAlZEndCap",   aluEndcapZ = dzSty+drSty+drAlu/2);
-  gearParameters->setDoubleVal("CryostatAlHalfZ",     dzSty+drSty);
-  m_gearMgr->setGearParameters("VXDInfra", gearParameters);
+  if(rAlu!=0){
+    // rAlu=0, denote no cryostat 
+    gear::GearParametersImpl* gearParameters = new gear::GearParametersImpl;
+    //CryostatAlRadius, CryostatAlThickness, CryostatAlInnerR, CryostatAlZEndCap, CryostatAlHalfZ
+    gearParameters->setDoubleVal("CryostatAlRadius",    rAlu);
+    gearParameters->setDoubleVal("CryostatAlThickness", drAlu);
+    gearParameters->setDoubleVal("CryostatAlInnerR",    rInner);
+    gearParameters->setDoubleVal("CryostatAlZEndCap",   aluEndcapZ = dzSty+drSty+drAlu/2);
+    gearParameters->setDoubleVal("CryostatAlHalfZ",     dzSty+drSty);
+    m_gearMgr->setGearParameters("VXDInfra", gearParameters);
+  }
   //effective A different with what in Mokka, fix them as Mokka's
   gear::SimpleMaterialImpl* VXDFoamShellMaterial_old = new gear::SimpleMaterialImpl("VXDFoamShellMaterial_old", 1.043890843e+01, 5.612886646e+00, 2.500000000e+01, 1.751650267e+04, 0);
   m_gearMgr->registerSimpleMaterial(VXDFoamShellMaterial_old);
@@ -721,6 +728,116 @@ StatusCode GearSvc::convertTPC(dd4hep::DetElement& tpc){
   return StatusCode::SUCCESS;
 }
 
+StatusCode GearSvc::convertDC(dd4hep::DetElement& dc){
+  dd4hep::rec::FixedPadSizeTPCData* dcData = nullptr;
+  try{
+    dcData = dc.extension<dd4hep::rec::FixedPadSizeTPCData>();
+  }
+  catch(std::runtime_error& e){
+    warning() << e.what() << " " << dcData << ", to search volume" << endmsg;
+    // before extension ready, force to convert from volumes
+    dcData = new dd4hep::rec::FixedPadSizeTPCData;
+    dcData->rMinReadout = 99999;
+    dcData->rMaxReadout = 0;
+    std::vector<double> innerRadiusWalls,outerRadiusWalls;
+    bool is_convert = true;
+    dd4hep::Volume dc_vol = dc.volume();
+    for(int i=0;i<dc_vol->GetNdaughters();i++){
+      TGeoNode* daughter = dc_vol->GetNode(i);
+      std::string nodeName = daughter->GetName();
+      std::cout << nodeName << std::endl;
+      if(nodeName.find("chamber_vol")!=-1){
+	const TGeoShape* chamber_shape = daughter->GetVolume()->GetShape();
+	if(chamber_shape->TestShapeBit(TGeoTube::kGeoTube)){
+	  const TGeoTube* tube = (const TGeoTube*) chamber_shape;
+	  double innerRadius = tube->GetRmin();
+	  double outerRadius = tube->GetRmax();
+	  double halfLength  = tube->GetDz();
+	  dcData->driftLength = halfLength;
+	}
+	else{
+	  error() << nodeName << " not TGeoTube::kGeoTube" << endmsg;
+	  is_convert = false;
+	}
+
+	dcData->maxRow = daughter->GetNdaughters();
+	for(int i=0;i<daughter->GetNdaughters();i++){
+	  TGeoNode* layer = daughter->GetDaughter(i);
+	  const TGeoShape* shape = layer->GetVolume()->GetShape();
+	  if(shape->TestShapeBit(TGeoTube::kGeoTube)){
+	    const TGeoTube* tube = (const TGeoTube*) shape;
+	    double innerRadius = tube->GetRmin();
+	    double outerRadius = tube->GetRmax();
+	    double halfLength  = tube->GetDz();
+	    if(innerRadius<dcData->rMinReadout) dcData->rMinReadout = innerRadius;
+	    if(outerRadius>dcData->rMaxReadout) dcData->rMaxReadout = outerRadius;
+	  }
+	  else{
+	    error() << layer->GetName() << " not TGeoTube::kGeoTube" << endmsg;
+	    is_convert = false;
+	  }
+	}
+	dcData->padHeight = (dcData->rMaxReadout-dcData->rMinReadout)/dcData->maxRow;
+	dcData->padWidth  = dcData->padHeight;
+      }
+      else if(nodeName.find("wall_vol")!=-1){
+	const TGeoShape* wall_shape = daughter->GetVolume()->GetShape();
+        if(wall_shape->TestShapeBit(TGeoTube::kGeoTube)){
+          const TGeoTube* tube = (const TGeoTube*) wall_shape;
+          double innerRadius = tube->GetRmin();
+          double outerRadius = tube->GetRmax();
+          double halfLength  = tube->GetDz();
+          innerRadiusWalls.push_back(innerRadius);
+	  outerRadiusWalls.push_back(outerRadius);
+        }
+	else{
+	  error() << nodeName << " not TGeoTube::kGeoTube" << endmsg;
+	  is_convert = false;
+	}
+      }
+    }
+    if(innerRadiusWalls.size()<2||outerRadiusWalls.size()<2){
+      error() << "wall number < 2" << endmsg;
+      is_convert = false;
+    }
+    if(!is_convert){
+      error() << "Cannot convert DC volume to extension data!" << endmsg;
+      delete dcData;
+      return StatusCode::FAILURE;
+    }
+    if(innerRadiusWalls[0]<innerRadiusWalls[innerRadiusWalls.size()-1]){
+      dcData->rMin = innerRadiusWalls[0];
+      dcData->rMax = outerRadiusWalls[outerRadiusWalls.size()-1];
+      dcData->innerWallThickness = outerRadiusWalls[0]-innerRadiusWalls[0];
+      dcData->outerWallThickness = outerRadiusWalls[outerRadiusWalls.size()-1]-innerRadiusWalls[innerRadiusWalls.size()-1];
+    }
+    else{
+      dcData->rMin = innerRadiusWalls[innerRadiusWalls.size()-1];
+      dcData->rMax = outerRadiusWalls[0];
+      dcData->innerWallThickness = outerRadiusWalls[outerRadiusWalls.size()-1]-innerRadiusWalls[innerRadiusWalls.size()-1];
+      dcData->outerWallThickness = outerRadiusWalls[0]-innerRadiusWalls[0];
+    }
+    info() << (*dcData) << endmsg;
+  }
+
+  // regard as TPCParameters, TODO: drift chamber parameters
+  gear::TPCParametersImpl *tpcParameters = new gear::TPCParametersImpl();
+  gear::PadRowLayout2D *padLayout = new gear::FixedPadSizeDiskLayout(dcData->rMinReadout*CLHEP::cm, dcData->rMaxReadout*CLHEP::cm,
+                                                                     dcData->padHeight*CLHEP::cm, dcData->padWidth*CLHEP::cm, dcData->maxRow, 0.0);
+  tpcParameters->setPadLayout(padLayout);
+  tpcParameters->setMaxDriftLength(dcData->driftLength*CLHEP::cm);
+  tpcParameters->setDriftVelocity(    0.0);
+  tpcParameters->setReadoutFrequency( 0.0);
+  tpcParameters->setDoubleVal( "tpcOuterRadius" , dcData->rMax*CLHEP::cm ) ;
+  tpcParameters->setDoubleVal( "tpcInnerRadius",  dcData->rMin*CLHEP::cm ) ;
+  tpcParameters->setDoubleVal( "tpcInnerWallThickness",  dcData->innerWallThickness*CLHEP::cm ) ;
+  tpcParameters->setDoubleVal( "tpcOuterWallThickness",  dcData->outerWallThickness*CLHEP::cm ) ;
+
+  m_gearMgr->setTPCParameters(tpcParameters);
+
+  return StatusCode::SUCCESS;
+}
+
 StatusCode GearSvc::convertSET(dd4hep::DetElement& set){
   dd4hep::rec::ZPlanarData* setData = nullptr;
   try{
@@ -773,7 +890,7 @@ TGeoNode* GearSvc::FindNode(TGeoNode* mother, char* name){
     for(int i=0;i<mother->GetNdaughters();i++){
       TGeoNode* daughter = mother->GetDaughter(i);
       std::string s = daughter->GetName();
-      //info() << "current: " << s << " search for" << name << endmsg;                                                                                                                      
+      //info() << "current: " << s << " search for" << name << endmsg;
       if(s.find(name)!=-1){
         next = daughter;
         break;

--- a/Service/GearSvc/src/GearSvc.h
+++ b/Service/GearSvc/src/GearSvc.h
@@ -23,6 +23,7 @@ class GearSvc : public extends<Service, IGearSvc>
 	StatusCode convertVXD(dd4hep::DetElement& vxd);
 	StatusCode convertSIT(dd4hep::DetElement& sit);
 	StatusCode convertTPC(dd4hep::DetElement& tpc);
+	StatusCode convertDC (dd4hep::DetElement& dc);
 	StatusCode convertSET(dd4hep::DetElement& set);
 	StatusCode convertFTD(dd4hep::DetElement& ftd);
 	TGeoNode* FindNode(TGeoNode* mother, char* name);


### PR DESCRIPTION
* Cryostat is optional, and if no crystat and still fill "VXDInfra" GearParameter will cause crash. No fill while no crystat will fix it.
* cheat DC parameters as TPC, maybe create driftchamber extension data will be better in future
  * if extension data exists, use it
  * if not exist, convert from volume directly as preliminary 