### PR TITLE
REC: GearSvc hot fix for GridDriftChamber segmentation

### DIFF
--- a/Service/GearSvc/CMakeLists.txt
+++ b/Service/GearSvc/CMakeLists.txt
@@ -8,6 +8,7 @@ gaudi_add_module(GearSvcPlugins
                       ${GEAR_LIBRARIES}
                       ${DD4hep_COMPONENT_LIBRARIES}
                       DetInterface
+		      DetSegmentation
 )
 
 install(TARGETS GearSvc GearSvcPlugins


### PR DESCRIPTION
Drift chamber real layers are removed in  PR#152, therefore layer number is invalid in volume. This update uses GridDriftChamber segmentation to obtain layer number, rbegin, rend and layer_width, to let job work again.