### PR TITLE
Change to single drift chamber and modify the percentage of gas elements

### DIFF
--- a/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
@@ -35,7 +35,6 @@
 
     <constant name="SDT_chamber_layer_width" value="10*mm"/>
     <constant name="SDT_chamber_cell_width" value="10*mm"/>
-    <constant name="SDT_chamber_layer_number" value="(DC_chamber_layer_rend-DC_chamber_layer_rbegin)/SDT_chamber_layer_width"/>
     <constant name="Epsilon" value="0*deg"/>
 
     <constant name="SDT_chamber_inner_wall_radius_min" value="SDT_chamber_radius_min-SDT_inner_wall_thickness"/>
@@ -85,7 +84,7 @@
 
   <readouts>
     <readout name="DriftChamberHitsCollection">
-      <segmentation type="GridDriftChamber" cell_size="SDT_chamber_cell_width" epsilon0="Epsilon" detector_length="DC_length" identifier_phi="cellID" DC_rbegin="DC_chamber_layer_rbegin" DC_rend="DC_chamber_layer_rend" DC_rmin="SDT_chamber_radius_min" DC_rmax="SDT_chamber_radius_max" DC_layer_number="SDT_chamber_layer_number" safe_distance="DC_safe_distance" layerID="layer" layer_width="SDT_chamber_layer_width"/>
+      <segmentation type="GridDriftChamber" cell_size="SDT_chamber_cell_width" epsilon0="Epsilon" detector_length="DC_length" identifier_phi="cellID" DC_rbegin="DC_chamber_layer_rbegin" DC_rend="DC_chamber_layer_rend" DC_rmin="SDT_chamber_radius_min" DC_rmax="SDT_chamber_radius_max" safe_distance="DC_safe_distance" layerID="layer" layer_width="SDT_chamber_layer_width"/>
 
       <!-- <id>system:8,chamber:1,layer:8,cellID:16</id> -->
       <id>system:5,layer:7:9,chamber:8,cellID:32:16</id>

--- a/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
@@ -57,6 +57,7 @@
 
   <detectors>
     <detector id="DetID_DC" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="VisibleBlue" sensitive="true" region="DriftChamberRegion" limits="DC_limits">
+      <chamber id="0"/>
       <envelope vis="SeeThrough">
         <shape type="BooleanShape" operation="Union" material="Air">
           <shape type="Tube" rmin="SDT_radius_min" rmax="SDT_radius_max" dz="SDT_half_length" />

--- a/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<lccdd>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
   <info name="DriftChamber"
     title="Test with Drift Chamber"
@@ -11,41 +13,39 @@
   </info>
 
   <define>
-    <constant name="SDT_radius_min" value="InnerTracker_inner_radius"/>
-    <constant name="SDT_radius_max" value="OuterTracker_outer_radius"/>
+    <constant name="world_size" value="2226*mm"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+
+    <!-- SDT -->
+    <constant name="DetID_DC"  value="7"/>
+    <constant name="SDT_radius_min" value="Tracker_inner_radius"/>
+    <constant name="SDT_radius_max" value="Tracker_outer_radius"/>
 
     <constant name="SDT_half_length" value="MainTracker_half_length"/>
-    <constant name="SDT_length" value="SDT_half_length*2"/>
     <constant name="DC_length" value="DC_half_length*2"/>
+    <constant name="SDT_length" value="SDT_half_length*2"/>
 
-    <constant name="SDT_inner_chamber_radius_min" value="DC_inner_chamber_layer_rbegin-DC_safe_distance"/>
-    <constant name="SDT_inner_chamber_radius_max" value="InnerTracker_outer_radius-SDT_outer_wall_thickness"/>
-    <constant name="SDT_inner_chamber_half_length" value="DC_half_length"/>
+    <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
+    <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
 
-    <constant name="SDT_outer_chamber_radius_min" value="DC_outer_chamber_radius_min-DC_safe_distance"/>
-    <constant name="SDT_outer_chamber_radius_max" value="DC_outer_chamber_radius_max"/>
-    <constant name="SDT_outer_chamber_half_length" value="DC_half_length"/>
+    <constant name="SDT_chamber_radius_min" value="DC_chamber_radius_min"/>
+    <constant name="SDT_chamber_radius_max" value="DC_chamber_radius_max"/>
+    <constant name="SDT_chamber_half_length" value="DC_half_length"/>
 
-    <constant name="SDT_inner_chamber_layer_number" value="67"/>
-    <constant name="SDT_outer_chamber_layer_number" value="63"/>
     <constant name="SDT_chamber_layer_width" value="10*mm"/>
+    <constant name="SDT_chamber_cell_width" value="10*mm"/>
+    <constant name="SDT_chamber_layer_number" value="(DC_chamber_layer_rend-DC_chamber_layer_rbegin)/SDT_chamber_layer_width"/>
     <constant name="Epsilon" value="0*deg"/>
 
-    <constant name="SDT_inner_chamber_inner_wall_radius_min" value="SDT_inner_chamber_radius_min-SDT_inner_wall_thickness"/>
-    <constant name="SDT_inner_chamber_inner_wall_radius_max" value="SDT_inner_chamber_radius_min"/>
-    <constant name="SDT_inner_chamber_outer_wall_radius_min" value="SDT_inner_chamber_radius_max"/>
-    <constant name="SDT_inner_chamber_outer_wall_radius_max" value="SDT_inner_chamber_radius_max+SDT_outer_wall_thickness"/>
-    <constant name="SDT_outer_chamber_inner_wall_radius_min" value="SDT_outer_chamber_radius_min-SDT_inner_wall_thickness"/>
-    <constant name="SDT_outer_chamber_inner_wall_radius_max" value="SDT_outer_chamber_radius_min"/>
-    <constant name="SDT_outer_chamber_outer_wall_radius_min" value="SDT_outer_chamber_radius_max"/>
-    <constant name="SDT_outer_chamber_outer_wall_radius_max" value="SDT_outer_chamber_radius_max+SDT_outer_wall_thickness"/>
+    <constant name="SDT_chamber_inner_wall_radius_min" value="SDT_chamber_radius_min-SDT_inner_wall_thickness"/>
+    <constant name="SDT_chamber_inner_wall_radius_max" value="SDT_chamber_radius_min"/>
+    <constant name="SDT_chamber_outer_wall_radius_min" value="SDT_chamber_radius_max"/>
+    <constant name="SDT_chamber_outer_wall_radius_max" value="SDT_chamber_radius_max+SDT_outer_wall_thickness"/>
 
     <constant name="DC_Endcap_rmin" value="SDT_radius_min"/>
     <constant name="DC_Endcap_rmax" value="SDT_radius_max"/>
-    <constant name="DC_Endcap_dz" value="DC_Endcap_z"/>
-
-    <constant name="DC_inner_chamber_enabled" value="1"/>
-    <constant name="DC_outer_chamber_enabled" value="1"/>
 
   </define>
 
@@ -61,29 +61,24 @@
   </regions>
 
   <detectors>
-    <detector id="DetID_DC" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="BlueVis" sensitive="true" insideTrackingVolume="true" limits="DC_limits">
+    <detector id="DetID_DC" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="VisibleBlue" sensitive="true" region="DriftChamberRegion" limits="DC_limits">
       <envelope vis="SeeThrough">
-<!--        <shape type="BooleanShape" operation="Union" material="Air">
-          <shape type="Tube" rmin="SDT_radius_min" rmax="OuterTracker_inner_radius" dz="SDT_half_length" />
-          <shape type="Tube" rmin="SDT_outer_chamber_inner_wall_radius_min" rmax="SDT_radius_max" dz="SDT_half_length" />
-        </shape> -->
-        <shape type="BooleanShape" operation="Subtraction" material="Air">
+        <shape type="BooleanShape" operation="Union" material="Air">
           <shape type="Tube" rmin="SDT_radius_min" rmax="SDT_radius_max" dz="SDT_half_length" />
-          <shape type="Tube" rmin="InnerTracker_outer_radius" rmax="SDT_outer_chamber_inner_wall_radius_min" dz="DC_half_length"/>
         </shape>
       </envelope>
 
-      <module id="0" repeat="1" name="SignalWire" type="Tube" rmin="0*mm" rmax="0.01*mm">
-           <tubs name="W" type="Tube" rmin="0*mm" rmax="0.007*mm" material="Tungsten"/>
-           <tubs name="Au" type="Tube" rmin="0.007*mm" rmax="0.01*mm" material="Gold"/>
+      <module id="0" name="SignalWire" type="Tube" rmin="0*mm" rmax="0.01*mm" vis="VisibleRed">
+          <tubs name="W" type="Tube" rmin="0*mm" rmax="0.007*mm" material="Tungsten"/>
+          <tubs name="Au" type="Tube" rmin="0.007*mm" rmax="0.01*mm" material="Gold"/>
       </module>
-      <module id="1" repeat="3" name="FieldWire" type="Tube" rmin="0*mm" rmax="0.02*mm">
-         <tubs name="Al" type="Tube" rmin="0*mm" rmax="0.017*mm" material="Aluminum"/>
-         <tubs name="Ag" type="Tube" rmin="0.017*mm" rmax="0.02*mm" material="Silver"/>
+
+      <module id="1" name="FieldWire" type="Tube" rmin="0*mm" rmax="0.02*mm" vis="VisibleGreen">
+          <tubs name="Al" type="Tube" rmin="0*mm" rmax="0.017*mm" material="Aluminum"/>
+          <tubs name="Ag" type="Tube" rmin="0.017*mm" rmax="0.02*mm" material="Silver"/>
       </module>
 
       <type_flags type="DetType_TRACKER + DetType_BARREL + DetType_GASEOUS + DetType_WIRE"/>
-
       <!-- Use cm as unit if you want to use Pandora for reconstruction -->
      <sensitive type="SimpleDriftChamber"/>
      </detector>
@@ -91,10 +86,9 @@
 
   <readouts>
     <readout name="DriftChamberHitsCollection">
-      <segmentation type="GridDriftChamber" cell_size="10*mm" epsilon0="Epsilon" detector_length="DC_length" identifier_phi="cellID" DC_inner_rbegin="DC_inner_chamber_layer_rbegin" DC_inner_rend="DC_inner_chamber_layer_rend" DC_outer_rbegin="DC_outer_chamber_layer_rbegin" DC_outer_rend="DC_outer_chamber_layer_rend" DC_inner_rmin="SDT_inner_chamber_radius_min" DC_inner_rmax="SDT_inner_chamber_radius_max" DC_outer_rmin="SDT_outer_chamber_radius_min" DC_outer_rmax="SDT_outer_chamber_radius_max" DC_inner_layer_number="SDT_inner_chamber_layer_number" DC_outer_layer_number="SDT_outer_chamber_layer_number" safe_distance="DC_safe_distance" layerID="layer" layer_width="SDT_chamber_layer_width"/>
+      <segmentation type="GridDriftChamber" cell_size="SDT_chamber_cell_width" epsilon0="Epsilon" detector_length="DC_length" identifier_phi="cellID" DC_rbegin="DC_chamber_layer_rbegin" DC_rend="DC_chamber_layer_rend" DC_rmin="SDT_chamber_radius_min" DC_rmax="SDT_chamber_radius_max" DC_layer_number="SDT_chamber_layer_number" safe_distance="DC_safe_distance" layerID="layer" layer_width="SDT_chamber_layer_width"/>
 
-      <!--<id>system:8,chamber:1,layer:8,cellID:16</id> -->
-      <!--<id>system:5,side:-2,layer:9,chamber:8,sensor:8,cellID:16</id> -->
+      <!-- <id>system:8,chamber:1,layer:8,cellID:16</id> -->
       <id>system:5,layer:7:9,chamber:8,cellID:32:16</id>
     </readout>
   </readouts>

--- a/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
@@ -19,18 +19,15 @@
     <constant name="world_z" value="world_size"/>
 
     <!-- SDT -->
-    <constant name="SDT_radius_min" value="799.78*mm"/>
-    <constant name="SDT_radius_max" value="1803*mm"/>
+    <constant name="SDT_radius_min" value="DC_inner_radius"/>
+    <constant name="SDT_radius_max" value="DC_outer_radius"/>
 
     <constant name="SDT_half_length" value="MainTracker_half_length"/>
     <constant name="DC_length" value="DC_half_length*2"/>
     <constant name="SDT_length" value="SDT_half_length*2"/>
 
-    <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
-    <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
-
-    <constant name="SDT_chamber_radius_min" value="DC_chamber_radius_min"/>
-    <constant name="SDT_chamber_radius_max" value="DC_chamber_radius_max"/>
+    <constant name="SDT_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
+    <constant name="SDT_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
     <constant name="SDT_chamber_half_length" value="DC_half_length"/>
 
     <constant name="SDT_chamber_layer_width" value="10*mm"/>

--- a/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
@@ -19,9 +19,8 @@
     <constant name="world_z" value="world_size"/>
 
     <!-- SDT -->
-    <constant name="DetID_DC"  value="7"/>
-    <constant name="SDT_radius_min" value="Tracker_inner_radius"/>
-    <constant name="SDT_radius_max" value="Tracker_outer_radius"/>
+    <constant name="SDT_radius_min" value="799.78*mm"/>
+    <constant name="SDT_radius_max" value="1803*mm"/>
 
     <constant name="SDT_half_length" value="MainTracker_half_length"/>
     <constant name="DC_length" value="DC_half_length*2"/>

--- a/Detector/DetCRD/compact/CRD_common_v01/materials.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/materials.xml
@@ -565,9 +565,9 @@
     <!-- Driftchamber: material for the drift chamber -->
    <material name="GasHe_90Isob_10">
      <D value="0.0003983999999999999" unit="g/cm3" />
-     <fraction n="0.3826351004462046" ref="He"/>
-     <fraction n="0.011371937371285891"   ref="H" />
-     <fraction n="0.6059929621825095" ref="C" />
+     <fraction n="0.3826373431212555" ref="He"/>
+     <fraction n="0.1070614182488552"   ref="H" />
+     <fraction n="0.5103012386298891" ref="C" />
    </material>
 
   </materials>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
@@ -87,6 +87,7 @@
     <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
     <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
     <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_dz" />
+
     <constant name="InnerTracker_half_length"  value="DC_half_length" />
     <constant name="InnerTracker_inner_radius" value="234*mm"/>
     <constant name="InnerTracker_outer_radius" value="909*mm"/>
@@ -97,10 +98,9 @@
     <!-- Parameters of single drift chamber  -->
     <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
     <constant name="DC_chamber_layer_rend" value="1800*mm"/>
-    <constant name="DC_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
-    <constant name="DC_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
-    <constant name="DC_inner_radius" value="799.78*mm"/>
-    <constant name="DC_outer_radius" value="1803*mm"/>
+
+    <constant name="DC_inner_radius" value="DC_chamber_layer_rbegin-SDT_inner_wall_thickness-DC_safe_distance"/>
+    <constant name="DC_outer_radius" value="DC_chamber_layer_rend+SDT_outer_wall_thickness+DC_safe_distance"/>
 
     <constant name="SIT1_inner_radius"   value="152.90*mm"/>
     <constant name="SIT1_half_length"    value="368.00*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
@@ -4,11 +4,11 @@
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
   <info name="CRDDimensions"
-	title="master file with includes and world dimension"
-	author="C.D.Fu, "
-	url="no"
-	status="development"
-	version="1.0">
+       title="master file with includes and world dimension"
+       author="C.D.Fu, "
+       url="no"
+       status="development"
+       version="1.0">
     <comment>
       undeterminded parameters
     </comment>
@@ -81,27 +81,28 @@
     <constant name="Vertex_outer_radius" value="101*mm"/>
     <constant name="Vertex_half_length"  value="200*mm"/>
 
-    <constant name="DC_Endcap_z" value="0.1*mm"/>
+    <constant name="DC_Endcap_dz" value="0.1*mm"/>
     <constant name="DC_half_length"  value="2225*mm" />
-    <constant name="DC_safe_distance" value="0.2*mm"/>
+    <constant name="DC_safe_distance" value="0.02*mm"/>
     <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
     <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
-    <constant name="DC_inner_chamber_layer_rbegin" value="235*mm"/>
-    <constant name="DC_inner_chamber_layer_rend" value="905*mm"/>
-    <constant name="DC_outer_chamber_layer_rbegin" value="1085*mm"/>
-    <constant name="DC_outer_chamber_layer_rend" value="1715*mm"/>
-    <constant name="DC_inner_chamber_radius_min" value="DC_inner_chamber_layer_rbegin"/>
-    <constant name="DC_inner_chamber_radius_max" value="909*mm"/>
-    <constant name="DC_outer_chamber_radius_min" value="DC_outer_chamber_layer_rbegin"/>
-    <constant name="DC_outer_chamber_radius_max" value="1716*mm"/>
-    <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_z" />
+    <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_dz" />
     <constant name="InnerTracker_half_length"  value="DC_half_length" />
     <constant name="InnerTracker_inner_radius" value="234*mm"/>
-    <constant name="InnerTracker_outer_radius" value="DC_inner_chamber_radius_max"/>
+    <constant name="InnerTracker_outer_radius" value="909*mm"/>
     <constant name="OuterTracker_half_length"  value="DC_half_length"/>
-    <constant name="OuterTracker_inner_radius" value="DC_outer_chamber_radius_min-DC_safe_distance-SDT_inner_wall_thickness"/>
-    <constant name="OuterTracker_outer_radius" value="1720*mm"/>
-    
+    <constant name="OuterTracker_inner_radius" value="1082.18*mm"/>
+    <constant name="OuterTracker_outer_radius" value="1723*mm"/>
+
+    <!-- Parameters of single drift chamber  -->
+    <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
+    <constant name="DC_chamber_layer_rend" value="1720*mm"/>
+    <constant name="DC_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
+    <constant name="DC_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
+    <constant name="Tracker_half_length"  value="DC_half_length" />
+    <constant name="Tracker_inner_radius" value="799.78*mm"/>
+    <constant name="Tracker_outer_radius" value="1723*mm"/>
+
     <constant name="SIT1_inner_radius"   value="152.90*mm"/>
     <constant name="SIT1_half_length"    value="368.00*mm"/>
     <constant name="SIT2_inner_radius"   value="InnerTracker_outer_radius + env_safety"/>
@@ -123,7 +124,7 @@
     <constant name="TUBE_IPOuterTube_end_radius"  value="BeamPipe_Central_inner_radius+BeamPipe_Al_thickness"/>
     <constant name="TUBE_IPOuterBulge_end_z"      value="BeamPipe_Crotch_zmax"/><!--"BeamPipe_ConeAl_zmax"/-->
     <constant name="TUBE_IPOuterBulge_end_radius" value="BeamPipe_Crotch_zmax*tan(CrossingAngle/2)+BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness"/>
-							 <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
+                             <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
 
     <constant name="Ecal_barrel_inner_radius" value="1800*mm"/>
     <constant name="Ecal_barrel_thickness"    value="280*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
@@ -5,7 +5,7 @@
 
   <info name="CRDDimensions"
        title="master file with includes and world dimension"
-       author="C.D.Fu, "
+       author="C.D.Fu, Mengyao Liu"
        url="no"
        status="development"
        version="1.0">
@@ -96,12 +96,11 @@
 
     <!-- Parameters of single drift chamber  -->
     <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
-    <constant name="DC_chamber_layer_rend" value="1720*mm"/>
+    <constant name="DC_chamber_layer_rend" value="1800*mm"/>
     <constant name="DC_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
     <constant name="DC_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
-    <constant name="Tracker_half_length"  value="DC_half_length" />
-    <constant name="Tracker_inner_radius" value="799.78*mm"/>
-    <constant name="Tracker_outer_radius" value="1723*mm"/>
+    <constant name="DC_inner_radius" value="799.78*mm"/>
+    <constant name="DC_outer_radius" value="1803*mm"/>
 
     <constant name="SIT1_inner_radius"   value="152.90*mm"/>
     <constant name="SIT1_half_length"    value="368.00*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01.xml
@@ -32,8 +32,8 @@
   <include ref="../CRD_common_v01/FTD_SimpleStaggered_v01_01.xml"/>
   <!--<include ref="../CRD_common_v01/SIT_SimplePlanar_v01_01.xml"/> -->
   <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
-  <include ref="../CRD_common_v01/SET_SimplePlanar_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
+<!--  <include ref="../CRD_common_v01/SET_SimplePlanar_v01_01.xml"/> -->
+<!--  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/> -->
   <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->
   <include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>
   <include ref="../CRD_common_v01/Hcal_Rpc_Barrel_v01_01.xml"/>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01.xml
@@ -30,7 +30,7 @@
   <include ref="../CRD_common_v01/Beampipe_v01_01.xml"/>
   <include ref="../CRD_common_v01/VXD_v01_01.xml"/>
   <include ref="../CRD_common_v01/FTD_SimpleStaggered_v01_01.xml"/>
-  <include ref="../CRD_common_v01/SIT_SimplePlanar_v01_01.xml"/>
+  <!--<include ref="../CRD_common_v01/SIT_SimplePlanar_v01_01.xml"/> -->
   <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
   <include ref="../CRD_common_v01/SET_SimplePlanar_v01_01.xml"/>
   <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
@@ -4,11 +4,11 @@
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
   <info name="CRDDimensions"
-	title="master file with includes and world dimension"
-	author="C.D.Fu, "
-	url="no"
-	status="development"
-	version="1.0">
+       title="master file with includes and world dimension"
+       author="C.D.Fu, "
+       url="no"
+       status="development"
+       version="1.0">
     <comment>
       undeterminded parameters
     </comment>
@@ -81,26 +81,28 @@
     <constant name="Vertex_outer_radius" value="101*mm"/>
     <constant name="Vertex_half_length"  value="200*mm"/>
 
-    <constant name="DC_Endcap_z" value="0.1*mm"/>
+    <constant name="DC_Endcap_dz" value="0.1*mm"/>
     <constant name="DC_half_length"  value="2225*mm" />
-    <constant name="DC_safe_distance" value="0.2*mm"/>
+    <constant name="DC_safe_distance" value="0.02*mm"/>
     <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
     <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
-    <constant name="DC_inner_chamber_layer_rbegin" value="235*mm"/>
-    <constant name="DC_inner_chamber_layer_rend" value="905*mm"/>
-    <constant name="DC_outer_chamber_layer_rbegin" value="1085*mm"/>
-    <constant name="DC_outer_chamber_layer_rend" value="1715*mm"/>
-    <constant name="DC_inner_chamber_radius_min" value="DC_inner_chamber_layer_rbegin"/>
-    <constant name="DC_inner_chamber_radius_max" value="909*mm"/>
-    <constant name="DC_outer_chamber_radius_min" value="DC_outer_chamber_layer_rbegin"/>
-    <constant name="DC_outer_chamber_radius_max" value="1716*mm"/>
-    <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_z" />
+    <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_dz" />
     <constant name="InnerTracker_half_length"  value="DC_half_length" />
     <constant name="InnerTracker_inner_radius" value="234*mm"/>
-    <constant name="InnerTracker_outer_radius" value="DC_inner_chamber_radius_max"/>
+    <constant name="InnerTracker_outer_radius" value="909*mm"/>
     <constant name="OuterTracker_half_length"  value="DC_half_length"/>
-    <constant name="OuterTracker_inner_radius" value="DC_outer_chamber_radius_min-DC_safe_distance-SDT_inner_wall_thickness"/>
-    <constant name="OuterTracker_outer_radius" value="1720*mm"/>
+    <constant name="OuterTracker_inner_radius" value="1082.18*mm"/>
+    <constant name="OuterTracker_outer_radius" value="1723*mm"/>
+
+    <!-- Parameters of single drift chamber  -->
+    <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
+    <constant name="DC_chamber_layer_rend" value="1720*mm"/>
+    <constant name="DC_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
+    <constant name="DC_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
+    <constant name="Tracker_half_length"  value="DC_half_length" />
+    <constant name="Tracker_inner_radius" value="799.78*mm"/>
+    <constant name="Tracker_outer_radius" value="1723*mm"/>
+
 
     <constant name="SIT1_inner_radius"   value="140*mm"/>
     <constant name="SIT1_half_length"    value="368.00*mm"/>
@@ -123,7 +125,7 @@
     <constant name="TUBE_IPOuterTube_end_radius"  value="BeamPipe_Central_inner_radius+BeamPipe_Al_thickness"/>
     <constant name="TUBE_IPOuterBulge_end_z"      value="BeamPipe_Crotch_zmax"/><!--"BeamPipe_ConeAl_zmax"/-->
     <constant name="TUBE_IPOuterBulge_end_radius" value="BeamPipe_Crotch_zmax*tan(CrossingAngle/2)+BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness"/>
-							 <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
+                             <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
 
     <constant name="Ecal_barrel_inner_radius" value="1800*mm"/>
     <constant name="Ecal_barrel_thickness"    value="280*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
@@ -87,6 +87,7 @@
     <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
     <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
     <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_dz" />
+
     <constant name="InnerTracker_half_length"  value="DC_half_length" />
     <constant name="InnerTracker_inner_radius" value="234*mm"/>
     <constant name="InnerTracker_outer_radius" value="909*mm"/>
@@ -97,10 +98,9 @@
     <!-- Parameters of single drift chamber  -->
     <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
     <constant name="DC_chamber_layer_rend" value="1800*mm"/>
-    <constant name="DC_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
-    <constant name="DC_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
-    <constant name="Tracker_inner_radius" value="799.78*mm"/>
-    <constant name="Tracker_outer_radius" value="1803*mm"/>
+
+    <constant name="DC_inner_radius" value="DC_chamber_layer_rbegin-SDT_inner_wall_thickness-DC_safe_distance"/>
+    <constant name="DC_outer_radius" value="DC_chamber_layer_rend+SDT_outer_wall_thickness+DC_safe_distance"/>
 
 
     <constant name="SIT1_inner_radius"   value="140*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
@@ -5,7 +5,7 @@
 
   <info name="CRDDimensions"
        title="master file with includes and world dimension"
-       author="C.D.Fu, "
+       author="C.D.Fu, Mengyao Liu"
        url="no"
        status="development"
        version="1.0">
@@ -96,12 +96,11 @@
 
     <!-- Parameters of single drift chamber  -->
     <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
-    <constant name="DC_chamber_layer_rend" value="1720*mm"/>
+    <constant name="DC_chamber_layer_rend" value="1800*mm"/>
     <constant name="DC_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
     <constant name="DC_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
-    <constant name="Tracker_half_length"  value="DC_half_length" />
     <constant name="Tracker_inner_radius" value="799.78*mm"/>
-    <constant name="Tracker_outer_radius" value="1723*mm"/>
+    <constant name="Tracker_outer_radius" value="1803*mm"/>
 
 
     <constant name="SIT1_inner_radius"   value="140*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02.xml
@@ -30,9 +30,9 @@
   <include ref="../CRD_common_v01/Beampipe_v01_01.xml"/>
   <include ref="../CRD_common_v01/VXD_v01_01.xml"/>
   <include ref="../CRD_common_v01/FTD_SimpleStaggered_v01_02.xml"/>
-  <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
+<!--  <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/> -->
   <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
-  <include ref="../CRD_common_v01/SET_SimplePlanar_v01_02.xml"/>
+<!--  <include ref="../CRD_common_v01/SET_SimplePlanar_v01_02.xml"/> -->
   <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
   <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->
   <include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02.xml
@@ -33,7 +33,7 @@
 <!--  <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/> -->
   <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
 <!--  <include ref="../CRD_common_v01/SET_SimplePlanar_v01_02.xml"/> -->
-  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
+<!--  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/> -->
   <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->
   <include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>
   <include ref="../CRD_common_v01/Hcal_Rpc_Barrel_v01_01.xml"/>

--- a/Detector/DetDriftChamber/compact/det.xml
+++ b/Detector/DetDriftChamber/compact/det.xml
@@ -53,7 +53,6 @@
 
     <constant name="SDT_chamber_layer_width" value="10*mm"/>
     <constant name="SDT_chamber_cell_width" value="10*mm"/>
-    <constant name="SDT_chamber_layer_number" value="(DC_chamber_layer_rend-DC_chamber_layer_rbegin)/SDT_chamber_layer_width"/>
     <constant name="Epsilon" value="0*deg"/>
 
     <constant name="SDT_chamber_inner_wall_radius_min" value="SDT_chamber_radius_min-SDT_inner_wall_thickness"/>
@@ -112,7 +111,8 @@
 
   <readouts>
     <readout name="DriftChamberHitsCollection">
-      <segmentation type="GridDriftChamber" cell_size="SDT_chamber_cell_width" epsilon0="Epsilon" detector_length="DC_length" identifier_phi="cellID" DC_rbegin="DC_chamber_layer_rbegin" DC_rend="DC_chamber_layer_rend" DC_rmin="SDT_chamber_radius_min" DC_rmax="SDT_chamber_radius_max" DC_layer_number="SDT_chamber_layer_number" safe_distance="DC_safe_distance" layerID="layer" layer_width="SDT_chamber_layer_width"/>
+      <segmentation type="GridDriftChamber" cell_size="SDT_chamber_cell_width" epsilon0="Epsilon" detector_length="DC_length" identifier_phi="cellID" DC_rbegin="DC_chamber_layer_rbegin" DC_rend="DC_chamber_layer_rend" DC_rmin="SDT_chamber_radius_min" DC_rmax="SDT_chamber_radius_max" safe_distance="DC_safe_distance" layerID="layer" layer_width="SDT_chamber_layer_width"/>
+
 
       <!-- <id>system:8,chamber:1,layer:8,cellID:16</id> -->
       <id>system:5,layer:7:9,chamber:8,cellID:32:16</id>

--- a/Detector/DetDriftChamber/compact/det.xml
+++ b/Detector/DetDriftChamber/compact/det.xml
@@ -27,7 +27,7 @@
     <!-- SDT -->
     <constant name="DetID_DC"  value="7"/>
     <constant name="SDT_radius_min" value="799.78*mm"/>
-    <constant name="SDT_radius_max" value="1723*mm"/>
+    <constant name="SDT_radius_max" value="1803*mm"/>
 
     <constant name="DC_Endcap_dz" value="0.1*mm"/>
 
@@ -42,7 +42,7 @@
     <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
 
     <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
-    <constant name="DC_chamber_layer_rend" value="1720*mm"/>
+    <constant name="DC_chamber_layer_rend" value="1800*mm"/>
 
     <constant name="DC_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
     <constant name="DC_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>

--- a/Detector/DetDriftChamber/compact/det.xml
+++ b/Detector/DetDriftChamber/compact/det.xml
@@ -26,8 +26,8 @@
 
     <!-- SDT -->
     <constant name="DetID_DC"  value="7"/>
-    <constant name="SDT_radius_min" value="234*mm"/>
-    <constant name="SDT_radius_max" value="1720*mm"/>
+    <constant name="SDT_radius_min" value="799.78*mm"/>
+    <constant name="SDT_radius_max" value="1723*mm"/>
 
     <constant name="DC_Endcap_dz" value="0.1*mm"/>
 
@@ -36,50 +36,33 @@
     <constant name="SDT_length" value="SDT_half_length*2"/>
     <constant name="DC_length" value="SDT_length-DC_Endcap_dz*2"/>
 
-    <constant name="DC_safe_distance" value="0.2*mm"/>
+    <constant name="DC_safe_distance" value="0.02*mm"/>
 
     <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
     <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
 
-    <constant name="DC_inner_chamber_layer_rbegin" value="235*mm"/>
-    <constant name="DC_inner_chamber_layer_rend" value="905*mm"/>
+    <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
+    <constant name="DC_chamber_layer_rend" value="1720*mm"/>
 
-    <constant name="DC_outer_chamber_layer_rbegin" value="1085*mm"/>
-    <constant name="DC_outer_chamber_layer_rend" value="1715*mm"/>
+    <constant name="DC_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
+    <constant name="DC_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
 
-    <constant name="DC_inner_chamber_radius_min" value="DC_inner_chamber_layer_rbegin"/>
-    <constant name="DC_inner_chamber_radius_max" value="909*mm"/>
+    <constant name="SDT_chamber_radius_min" value="DC_chamber_radius_min"/>
+    <constant name="SDT_chamber_radius_max" value="DC_chamber_radius_max"/>
+    <constant name="SDT_chamber_half_length" value="DC_half_length"/>
 
-    <constant name="DC_outer_chamber_radius_min" value="DC_outer_chamber_layer_rbegin"/>
-    <constant name="DC_outer_chamber_radius_max" value="1716*mm"/>
-
-    <constant name="SDT_inner_chamber_radius_min" value="DC_inner_chamber_layer_rbegin-DC_safe_distance"/>
-    <constant name="SDT_inner_chamber_radius_max" value="DC_inner_chamber_radius_max-SDT_outer_wall_thickness"/>
-    <constant name="SDT_inner_chamber_half_length" value="DC_half_length"/>
-
-    <constant name="SDT_outer_chamber_radius_min" value="DC_outer_chamber_layer_rbegin-DC_safe_distance"/>
-    <constant name="SDT_outer_chamber_radius_max" value="DC_outer_chamber_radius_max"/>
-    <constant name="SDT_outer_chamber_half_length" value="DC_half_length"/>
-
-    <constant name="SDT_inner_chamber_layer_number" value="67"/>
-    <constant name="SDT_outer_chamber_layer_number" value="63"/>
     <constant name="SDT_chamber_layer_width" value="10*mm"/>
+    <constant name="SDT_chamber_cell_width" value="10*mm"/>
+    <constant name="SDT_chamber_layer_number" value="(DC_chamber_layer_rend-DC_chamber_layer_rbegin)/SDT_chamber_layer_width"/>
     <constant name="Epsilon" value="0*deg"/>
 
-    <constant name="SDT_inner_chamber_inner_wall_radius_min" value="SDT_inner_chamber_radius_min-SDT_inner_wall_thickness"/>
-    <constant name="SDT_inner_chamber_inner_wall_radius_max" value="SDT_inner_chamber_radius_min"/>
-    <constant name="SDT_inner_chamber_outer_wall_radius_min" value="SDT_inner_chamber_radius_max"/>
-    <constant name="SDT_inner_chamber_outer_wall_radius_max" value="SDT_inner_chamber_radius_max+SDT_outer_wall_thickness"/>
-    <constant name="SDT_outer_chamber_inner_wall_radius_min" value="SDT_outer_chamber_radius_min-SDT_inner_wall_thickness"/>
-    <constant name="SDT_outer_chamber_inner_wall_radius_max" value="SDT_outer_chamber_radius_min"/>
-    <constant name="SDT_outer_chamber_outer_wall_radius_min" value="SDT_outer_chamber_radius_max"/>
-    <constant name="SDT_outer_chamber_outer_wall_radius_max" value="SDT_outer_chamber_radius_max+SDT_outer_wall_thickness"/>
+    <constant name="SDT_chamber_inner_wall_radius_min" value="SDT_chamber_radius_min-SDT_inner_wall_thickness"/>
+    <constant name="SDT_chamber_inner_wall_radius_max" value="SDT_chamber_radius_min"/>
+    <constant name="SDT_chamber_outer_wall_radius_min" value="SDT_chamber_radius_max"/>
+    <constant name="SDT_chamber_outer_wall_radius_max" value="SDT_chamber_radius_max+SDT_outer_wall_thickness"/>
 
     <constant name="DC_Endcap_rmin" value="SDT_radius_min"/>
     <constant name="DC_Endcap_rmax" value="SDT_radius_max"/>
-
-    <constant name="DC_inner_chamber_enabled" value="1"/>
-    <constant name="DC_outer_chamber_enabled" value="1"/>
 
   </define>
 
@@ -104,15 +87,10 @@
   </regions>
 
   <detectors>
-    <detector id="7" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="VisibleBlue" sensitive="true" region="DriftChamberRegion" limits="DC_limits">
+    <detector id="DetID_DC" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="VisibleBlue" sensitive="true" region="DriftChamberRegion" limits="DC_limits">
       <envelope vis="SeeThrough">
-<!--        <shape type="BooleanShape" operation="Union" material="Air">
-          <shape type="Tube" rmin="SDT_radius_min" rmax="SDT_inner_chamber_outer_wall_radius_max" dz="SDT_half_length" />
-          <shape type="Tube" rmin="SDT_outer_chamber_inner_wall_radius_min" rmax="SDT_radius_max" dz="SDT_half_length" />
-        </shape> -->
-        <shape type="BooleanShape" operation="Subtraction" material="Air">
+        <shape type="BooleanShape" operation="Union" material="Air">
           <shape type="Tube" rmin="SDT_radius_min" rmax="SDT_radius_max" dz="SDT_half_length" />
-          <shape type="Tube" rmin="DC_inner_chamber_radius_max" rmax="SDT_outer_chamber_inner_wall_radius_min" dz="DC_half_length"/>
         </shape>
       </envelope>
 
@@ -134,10 +112,10 @@
 
   <readouts>
     <readout name="DriftChamberHitsCollection">
-      <segmentation type="GridDriftChamber" cell_size="10*mm" epsilon0="Epsilon" detector_length="DC_length" identifier_phi="cellID" DC_inner_rbegin="DC_inner_chamber_layer_rbegin" DC_inner_rend="DC_inner_chamber_layer_rend" DC_outer_rbegin="DC_outer_chamber_layer_rbegin" DC_outer_rend="DC_outer_chamber_layer_rend" DC_inner_rmin="SDT_inner_chamber_radius_min" DC_inner_rmax="SDT_inner_chamber_radius_max" DC_outer_rmin="SDT_outer_chamber_radius_min" DC_outer_rmax="SDT_outer_chamber_radius_max" DC_inner_layer_number="SDT_inner_chamber_layer_number" DC_outer_layer_number="SDT_outer_chamber_layer_number" safe_distance="DC_safe_distance" layerID="layer" layer_width="SDT_chamber_layer_width"/>
+      <segmentation type="GridDriftChamber" cell_size="SDT_chamber_cell_width" epsilon0="Epsilon" detector_length="DC_length" identifier_phi="cellID" DC_rbegin="DC_chamber_layer_rbegin" DC_rend="DC_chamber_layer_rend" DC_rmin="SDT_chamber_radius_min" DC_rmax="SDT_chamber_radius_max" DC_layer_number="SDT_chamber_layer_number" safe_distance="DC_safe_distance" layerID="layer" layer_width="SDT_chamber_layer_width"/>
 
       <!-- <id>system:8,chamber:1,layer:8,cellID:16</id> -->
-      <id>system:5,side:-2,layer:9,chamber:8,sensor:8,cellID:16</id>
+      <id>system:5,layer:7:9,chamber:8,cellID:32:16</id>
     </readout>
   </readouts>
 

--- a/Detector/DetDriftChamber/compact/det.xml
+++ b/Detector/DetDriftChamber/compact/det.xml
@@ -26,15 +26,6 @@
 
     <!-- SDT -->
     <constant name="DetID_DC"  value="7"/>
-    <constant name="SDT_radius_min" value="799.78*mm"/>
-    <constant name="SDT_radius_max" value="1803*mm"/>
-
-    <constant name="DC_Endcap_dz" value="0.1*mm"/>
-
-    <constant name="SDT_half_length" value="2225*mm+DC_Endcap_dz"/>
-    <constant name="DC_half_length" value="2225*mm"/>
-    <constant name="SDT_length" value="SDT_half_length*2"/>
-    <constant name="DC_length" value="SDT_length-DC_Endcap_dz*2"/>
 
     <constant name="DC_safe_distance" value="0.02*mm"/>
 
@@ -44,11 +35,18 @@
     <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
     <constant name="DC_chamber_layer_rend" value="1800*mm"/>
 
-    <constant name="DC_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
-    <constant name="DC_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
+    <constant name="SDT_radius_min" value="DC_chamber_layer_rbegin-SDT_inner_wall_thickness-DC_safe_distance"/>
+    <constant name="SDT_radius_max" value="DC_chamber_layer_rend+SDT_outer_wall_thickness+DC_safe_distance"/>
 
-    <constant name="SDT_chamber_radius_min" value="DC_chamber_radius_min"/>
-    <constant name="SDT_chamber_radius_max" value="DC_chamber_radius_max"/>
+    <constant name="DC_Endcap_dz" value="0.1*mm"/>
+
+    <constant name="SDT_half_length" value="2225*mm+DC_Endcap_dz"/>
+    <constant name="DC_half_length" value="2225*mm"/>
+    <constant name="SDT_length" value="SDT_half_length*2"/>
+    <constant name="DC_length" value="SDT_length-DC_Endcap_dz*2"/>
+
+    <constant name="SDT_chamber_radius_min" value="DC_chamber_layer_rbegin-DC_safe_distance"/>
+    <constant name="SDT_chamber_radius_max" value="DC_chamber_layer_rend+DC_safe_distance"/>
     <constant name="SDT_chamber_half_length" value="DC_half_length"/>
 
     <constant name="SDT_chamber_layer_width" value="10*mm"/>
@@ -87,6 +85,7 @@
 
   <detectors>
     <detector id="DetID_DC" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="VisibleBlue" sensitive="true" region="DriftChamberRegion" limits="DC_limits">
+      <chamber id="0"/>
       <envelope vis="SeeThrough">
         <shape type="BooleanShape" operation="Union" material="Air">
           <shape type="Tube" rmin="SDT_radius_min" rmax="SDT_radius_max" dz="SDT_half_length" />

--- a/Detector/DetDriftChamber/compact/materials.xml
+++ b/Detector/DetDriftChamber/compact/materials.xml
@@ -151,9 +151,9 @@
   <!-- Driftchamber: material for the drift chamber -->
   <material name="GasHe_90Isob_10">
     <D value="0.0003983999999999999" unit="g/cm3" />
-    <fraction n="0.3826351004462046" ref="He"/>
-    <fraction n="0.011371937371285891"   ref="H" />
-    <fraction n="0.6059929621825095" ref="C" />
+    <fraction n="0.3826373431212555" ref="He"/>
+    <fraction n="0.1070614182488552"   ref="H" />
+    <fraction n="0.5103012386298891" ref="C" />
   </material>
 
 </materials>

--- a/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
+++ b/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
@@ -43,31 +43,19 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
     // - global
     double chamber_half_length     = theDetector.constant<double>("DC_half_length");
 
-    // - inner chamber
-    double inner_chamber_radius_min = theDetector.constant<double>("SDT_inner_chamber_radius_min");
-    double inner_chamber_radius_max = theDetector.constant<double>("SDT_inner_chamber_radius_max");
-    double inner_chamber_half_length     = theDetector.constant<double>("SDT_inner_chamber_half_length");
-
-    // - outer chamber
-    double outer_chamber_radius_min = theDetector.constant<double>("SDT_outer_chamber_radius_min");
-    double outer_chamber_radius_max = theDetector.constant<double>("SDT_outer_chamber_radius_max");
-    double outer_chamber_half_length     = theDetector.constant<double>("SDT_outer_chamber_half_length");
+    // - chamber
+    double chamber_radius_min = theDetector.constant<double>("SDT_chamber_radius_min");
+    double chamber_radius_max = theDetector.constant<double>("SDT_chamber_radius_max");
+    double SDT_half_length     = theDetector.constant<double>("SDT_chamber_half_length");
 
     // - layer
-    int inner_chamber_layer_number = theDetector.constant<int>("SDT_inner_chamber_layer_number");
-    int outer_chamber_layer_number = theDetector.constant<int>("SDT_outer_chamber_layer_number");
+    int chamber_layer_number = theDetector.constant<int>("SDT_chamber_layer_number");
     double chamber_layer_width  = theDetector.constant<double>("SDT_chamber_layer_width");
-    double inner_chamber_layer_rbegin = theDetector.constant<double>("DC_inner_chamber_layer_rbegin");
-    double inner_chamber_layer_rend = theDetector.constant<double>("DC_inner_chamber_layer_rend");
-    double outer_chamber_layer_rbegin = theDetector.constant<double>("DC_outer_chamber_layer_rbegin");
-    double outer_chamber_layer_rend = theDetector.constant<double>("DC_outer_chamber_layer_rend");
+    double chamber_cell_width  = theDetector.constant<double>("SDT_chamber_cell_width");
+    double chamber_layer_rbegin = theDetector.constant<double>("DC_chamber_layer_rbegin");
+    double chamber_layer_rend = theDetector.constant<double>("DC_chamber_layer_rend");
 
     double epsilon = theDetector.constant<double>("Epsilon");
-
-    // - Control the number of drift chambersr
-    int inner_chamber_enabled = theDetector.constant<int>("DC_inner_chamber_enabled");
-    int outer_chamber_enabled = theDetector.constant<int>("DC_outer_chamber_enabled");
-
 
     // =======================================================================
     // Detector Construction
@@ -88,40 +76,26 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
     // - global
     Assembly det_vol( det_name+"_assembly" ) ;
 
-    // - inner
-    dd4hep::Tube det_inner_chamber_solid(inner_chamber_radius_min, inner_chamber_radius_max, inner_chamber_half_length);
-    dd4hep::Volume det_inner_chamber_vol(det_name+"_inner_chamber_vol", det_inner_chamber_solid, chamber_mat);
+    // - chamber volume
+    dd4hep::Tube det_chamber_solid(chamber_radius_min, chamber_radius_max, chamber_half_length);
+    dd4hep::Volume det_chamber_vol(det_name+"_chamber_vol", det_chamber_solid, chamber_mat);
     if ( x_det.isSensitive() )   {
-       det_inner_chamber_vol.setRegion(theDetector,x_det.regionStr());
-       det_inner_chamber_vol.setLimitSet(theDetector,x_det.limitsStr());
-       det_inner_chamber_vol.setSensitiveDetector(sens);
+       det_chamber_vol.setRegion(theDetector,x_det.regionStr());
+       det_chamber_vol.setLimitSet(theDetector,x_det.limitsStr());
+       det_chamber_vol.setSensitiveDetector(sens);
        sd.setType("tracker");
     }
 
-     // - outer
-     dd4hep::Tube det_outer_chamber_solid(outer_chamber_radius_min, outer_chamber_radius_max, outer_chamber_half_length);
-     dd4hep::Volume det_outer_chamber_vol(det_name+"_outer_chamber_vol", det_outer_chamber_solid, chamber_mat);
-     if ( x_det.isSensitive() )   {
-        det_outer_chamber_vol.setRegion(theDetector,x_det.regionStr());
-        det_outer_chamber_vol.setLimitSet(theDetector,x_det.limitsStr());
-        det_outer_chamber_vol.setSensitiveDetector(sens);
-        sd.setType("tracker");
-     }
-
     // - wall
-    double inner_chamber_inner_wall_rmin = theDetector.constant<double>("SDT_inner_chamber_inner_wall_radius_min");
-    double inner_chamber_inner_wall_rmax = theDetector.constant<double>("SDT_inner_chamber_inner_wall_radius_max");
-    double inner_chamber_outer_wall_rmin = theDetector.constant<double>("SDT_inner_chamber_outer_wall_radius_min");
-    double inner_chamber_outer_wall_rmax = theDetector.constant<double>("SDT_inner_chamber_outer_wall_radius_max");
-    double outer_chamber_outer_wall_rmin = theDetector.constant<double>("SDT_outer_chamber_outer_wall_radius_min");
-    double outer_chamber_outer_wall_rmax = theDetector.constant<double>("SDT_outer_chamber_outer_wall_radius_max");
-    double outer_chamber_inner_wall_rmin = theDetector.constant<double>("SDT_outer_chamber_inner_wall_radius_min");
-    double outer_chamber_inner_wall_rmax = theDetector.constant<double>("SDT_outer_chamber_inner_wall_radius_max");
+    double chamber_inner_wall_rmin = theDetector.constant<double>("SDT_chamber_inner_wall_radius_min");
+    double chamber_inner_wall_rmax = theDetector.constant<double>("SDT_chamber_inner_wall_radius_max");
+    double chamber_outer_wall_rmin = theDetector.constant<double>("SDT_chamber_outer_wall_radius_min");
+    double chamber_outer_wall_rmax = theDetector.constant<double>("SDT_chamber_outer_wall_radius_max");
 
     dd4hep::Material wall_mat(theDetector.material("CarbonFiber"));
 
-    double wall_rmin[4] = {inner_chamber_inner_wall_rmin,inner_chamber_outer_wall_rmin,outer_chamber_inner_wall_rmin,outer_chamber_outer_wall_rmin};
-    double wall_rmax[4] = {inner_chamber_inner_wall_rmax,inner_chamber_outer_wall_rmax,outer_chamber_inner_wall_rmax,outer_chamber_outer_wall_rmax};
+    double wall_rmin[2] = {chamber_inner_wall_rmin, chamber_outer_wall_rmin};
+    double wall_rmax[2] = {chamber_inner_wall_rmax, chamber_outer_wall_rmax};
 
    // - wire
     dd4hep::Volume module_vol;
@@ -175,24 +149,15 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
     auto DCHseg = dynamic_cast<dd4hep::DDSegmentation::GridDriftChamber*>(_geoSeg->segmentation());
 
     // - layer
-    int chamber_id = -1;
+    int chamber_id = 0;
     int layerIndex = -1;
-    for(int layer_id = 0; layer_id < (inner_chamber_layer_number+outer_chamber_layer_number); layer_id++) {
+    for(int layer_id = 0; layer_id < chamber_layer_number; layer_id++) {
         double rmin,rmax,offset=0;
         dd4hep::Volume* current_vol_ptr = nullptr;
-        if(inner_chamber_enabled && (layer_id < inner_chamber_layer_number)) {
-           current_vol_ptr = &det_inner_chamber_vol;
-           rmin = inner_chamber_layer_rbegin+(layer_id*chamber_layer_width);
-           rmax = rmin+chamber_layer_width;
-           chamber_id = 0;
-           layerIndex = layer_id;
-        } else if(outer_chamber_enabled && (layer_id >= inner_chamber_layer_number)) {
-           current_vol_ptr = &det_outer_chamber_vol;
-           rmin = outer_chamber_layer_rbegin+((layer_id-inner_chamber_layer_number)*chamber_layer_width);
-           rmax = rmin+chamber_layer_width;
-           chamber_id = 1;
-           layerIndex = layer_id - inner_chamber_layer_number;
-        } else continue;
+        current_vol_ptr = &det_chamber_vol;
+        rmin = chamber_layer_rbegin+(layer_id*chamber_layer_width);
+        rmax = rmin+chamber_layer_width;
+        layerIndex = layer_id;
 
         //Construction of drift chamber layers
         double rmid = delta_a_func(rmin,rmax);
@@ -216,18 +181,20 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
         //    |                     |
         //    |   F0    F1   F2   F3|
         //    -----------------------
-     if(layer_id == 0 || layer_id ==66 || layer_id ==67 || layer_id ==129) {
+//     if(layer_id == 0 || layer_id ==66 || layer_id ==67 || layer_id ==91) {
         for(int icell=0; icell< numWire; icell++) {
             double wire_phi = (icell+0.5)*layer_Phi + offset;
             // - signal wire
             dd4hep::Transform3D transform_module(dd4hep::Rotation3D(),dd4hep::Position(rmid*std::cos(wire_phi),rmid*std::sin(wire_phi),0.));
             dd4hep::PlacedVolume module_phy = (*current_vol_ptr).placeVolume(module_vol,transform_module);
+            double wx = rmid*std::cos(wire_phi);
+            double wy = rmid*std::sin(wire_phi);
            // - Field wire
             dd4hep::PlacedVolume Module_phy;
             double radius[9] = {rmid-chamber_layer_width*0.5,rmid-chamber_layer_width*0.5,rmid-chamber_layer_width*0.5,rmid-chamber_layer_width*0.5,rmid,rmid+chamber_layer_width*0.5,rmid+chamber_layer_width*0.5,rmid+chamber_layer_width*0.5,rmid+chamber_layer_width*0.5};
             double phi[9] = {wire_phi+layer_Phi*0.25,wire_phi,wire_phi-layer_Phi*0.25,wire_phi-layer_Phi*0.5,wire_phi-layer_Phi*0.5,wire_phi-layer_Phi*0.5,wire_phi-layer_Phi*0.25,wire_phi,wire_phi+layer_Phi*0.25};
             int num = 5;
-            if(layer_id==(inner_chamber_layer_number-1)||layer_id==(inner_chamber_layer_number+outer_chamber_layer_number-1)) { num = 9; }
+            if(layer_id==(chamber_layer_number-1)) { num = 9; }
             for(int i=0; i<num ; i++) {
                 dd4hep::Position tr3D = Position(radius[i]*std::cos(phi[i]),radius[i]*std::sin(phi[i]),0.);
 
@@ -237,34 +204,24 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
         }
   }
 
-  }
+//  }
 
     // - place in det
-    // inner
-    dd4hep::Transform3D transform_inner_chamber(dd4hep::Rotation3D(),
+    // - chamber
+    dd4hep::Transform3D transform_chamber(dd4hep::Rotation3D(),
             dd4hep::Position(0,0,0));
-    if(inner_chamber_enabled) {
-         dd4hep::PlacedVolume det_inner_chamber_phy = det_vol.placeVolume(det_inner_chamber_vol,
-                 transform_inner_chamber);
+    dd4hep::PlacedVolume det_chamber_phy = det_vol.placeVolume(det_chamber_vol,
+                 transform_chamber);
 
-         det_inner_chamber_phy.addPhysVolID("chamber", 0);
-    }
-    // outer
-    dd4hep::Transform3D transform_outer_chamber(dd4hep::Rotation3D(),
-            dd4hep::Position(0,0,0));
-    if(outer_chamber_enabled) {
-       dd4hep::PlacedVolume det_outer_chamber_phy = det_vol.placeVolume(det_outer_chamber_vol,
-               transform_inner_chamber);
+    det_chamber_phy.addPhysVolID("chamber", 0);
 
-       det_outer_chamber_phy.addPhysVolID("chamber", 1);
-    }
     // - place in world
     dd4hep::Transform3D transform(dd4hep::Rotation3D(),
             dd4hep::Position(0,0,0));
     dd4hep::PlacedVolume phv = envelope.placeVolume(det_vol,transform);
     // - place wall
     dd4hep::PlacedVolume wall_phy;
-    for(int i=0; i<4; i++) {
+    for(int i=0; i<2; i++) {
        dd4hep::Tube wall_solid(wall_rmin[i],wall_rmax[i],chamber_half_length);
        dd4hep::Volume wall_vol(det_name+"_wall_vol",wall_solid,wall_mat);
        wall_vol.setVisAttributes(theDetector,"VisibleGreen");

--- a/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
+++ b/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
@@ -35,6 +35,9 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
 
     xml_det_t x_det = e;
 
+    xml_coll_t c(x_det,_U(chamber));
+    xml_comp_t x_chamber = c;
+
     std::string det_name = x_det.nameStr();
     std::string det_type = x_det.typeStr();
 
@@ -47,6 +50,7 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
     double chamber_radius_min = theDetector.constant<double>("SDT_chamber_radius_min");
     double chamber_radius_max = theDetector.constant<double>("SDT_chamber_radius_max");
     double SDT_half_length     = theDetector.constant<double>("SDT_chamber_half_length");
+    int chamberID = x_chamber.id();
 
     // - layer
     double chamber_layer_width  = theDetector.constant<double>("SDT_chamber_layer_width");
@@ -181,7 +185,7 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
         //    |                     |
         //    |   F0    F1   F2   F3|
         //    -----------------------
-//     if(layer_id == 0 || layer_id == 1 || layer_id == 2 || layer_id == 3) {
+//     if(layer_id == 0 || layer_id == 1 || layer_id == 2 || layer_id == 99) {
         for(int icell=0; icell< numWire; icell++) {
             double wire_phi = (icell+0.5)*layer_Phi + offset;
             // - signal wire
@@ -213,7 +217,7 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
     dd4hep::PlacedVolume det_chamber_phy = det_vol.placeVolume(det_chamber_vol,
                  transform_chamber);
 
-    det_chamber_phy.addPhysVolID("chamber", 0);
+    det_chamber_phy.addPhysVolID("chamber", chamberID);
 
     // - place in world
     dd4hep::Transform3D transform(dd4hep::Rotation3D(),

--- a/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
+++ b/Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
@@ -49,11 +49,11 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
     double SDT_half_length     = theDetector.constant<double>("SDT_chamber_half_length");
 
     // - layer
-    int chamber_layer_number = theDetector.constant<int>("SDT_chamber_layer_number");
     double chamber_layer_width  = theDetector.constant<double>("SDT_chamber_layer_width");
     double chamber_cell_width  = theDetector.constant<double>("SDT_chamber_cell_width");
     double chamber_layer_rbegin = theDetector.constant<double>("DC_chamber_layer_rbegin");
     double chamber_layer_rend = theDetector.constant<double>("DC_chamber_layer_rend");
+    int chamber_layer_number = floor((chamber_layer_rend-chamber_layer_rbegin)/chamber_layer_width);
 
     double epsilon = theDetector.constant<double>("Epsilon");
 
@@ -181,20 +181,20 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
         //    |                     |
         //    |   F0    F1   F2   F3|
         //    -----------------------
-//     if(layer_id == 0 || layer_id ==66 || layer_id ==67 || layer_id ==91) {
+//     if(layer_id == 0 || layer_id == 1 || layer_id == 2 || layer_id == 3) {
         for(int icell=0; icell< numWire; icell++) {
             double wire_phi = (icell+0.5)*layer_Phi + offset;
             // - signal wire
             dd4hep::Transform3D transform_module(dd4hep::Rotation3D(),dd4hep::Position(rmid*std::cos(wire_phi),rmid*std::sin(wire_phi),0.));
             dd4hep::PlacedVolume module_phy = (*current_vol_ptr).placeVolume(module_vol,transform_module);
-            double wx = rmid*std::cos(wire_phi);
-            double wy = rmid*std::sin(wire_phi);
            // - Field wire
             dd4hep::PlacedVolume Module_phy;
             double radius[9] = {rmid-chamber_layer_width*0.5,rmid-chamber_layer_width*0.5,rmid-chamber_layer_width*0.5,rmid-chamber_layer_width*0.5,rmid,rmid+chamber_layer_width*0.5,rmid+chamber_layer_width*0.5,rmid+chamber_layer_width*0.5,rmid+chamber_layer_width*0.5};
             double phi[9] = {wire_phi+layer_Phi*0.25,wire_phi,wire_phi-layer_Phi*0.25,wire_phi-layer_Phi*0.5,wire_phi-layer_Phi*0.5,wire_phi-layer_Phi*0.5,wire_phi-layer_Phi*0.25,wire_phi,wire_phi+layer_Phi*0.25};
             int num = 5;
-            if(layer_id==(chamber_layer_number-1)) { num = 9; }
+            if(layer_id==(chamber_layer_number-1)) {
+               num = 9;
+            }
             for(int i=0; i<num ; i++) {
                 dd4hep::Position tr3D = Position(radius[i]*std::cos(phi[i]),radius[i]*std::sin(phi[i]),0.);
 

--- a/Detector/DetSegmentation/include/DetSegmentation/GridDriftChamber.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/GridDriftChamber.h
@@ -72,7 +72,6 @@ public:
   inline double DC_rend() const { return m_DC_rend; }
   inline double DC_rmax() const { return m_DC_rmax; }
   inline double DC_rmin() const { return m_DC_rmin; }
-  inline int DC_layer_number() const { return m_DC_layer_number; }
   inline const std::string& fieldNamePhi() const { return m_phiID; }
   inline const std::string& Layerid() const { return layer_id; }
 
@@ -169,7 +168,6 @@ protected:
   double m_DC_rend;
   double m_DC_rmax;
   double m_DC_rmin;
-  int m_DC_layer_number;
 
   std::string m_phiID;
   std::string layer_id;

--- a/Detector/DetSegmentation/include/DetSegmentation/GridDriftChamber.h
+++ b/Detector/DetSegmentation/include/DetSegmentation/GridDriftChamber.h
@@ -66,20 +66,16 @@ public:
   inline double cell_Size() const { return m_cellSize; }
   inline double epsilon0() const { return m_epsilon0; }
   inline double detectorLength() const { return m_detectorLength; }
-  inline double DC_inner_rbegin() const { return m_DC_inner_rbegin; }
-  inline double DC_inner_rend() const { return m_DC_inner_rend; }
-  inline double DC_outer_rbegin() const { return m_DC_outer_rbegin; }
-  inline double DC_outer_rend() const { return m_DC_outer_rend; }
-  inline double DC_inner_rmin() const { return m_DC_inner_rmin; }
-  inline double DC_inner_rmax() const { return m_DC_inner_rmax; }
-  inline double DC_outer_rmin() const { return m_DC_outer_rmin; }
-  inline double DC_outer_rmax() const { return m_DC_outer_rmax; }
   inline double safe_distance() const { return m_safe_distance; }
   inline double layer_width() const { return m_layer_width; }
-  inline int DC_inner_layer_number() const { return m_DC_inner_layer_number; }
-  inline int DC_outer_layer_number() const { return m_DC_outer_layer_number; }
+  inline double DC_rbegin() const { return m_DC_rbegin; }
+  inline double DC_rend() const { return m_DC_rend; }
+  inline double DC_rmax() const { return m_DC_rmax; }
+  inline double DC_rmin() const { return m_DC_rmin; }
+  inline int DC_layer_number() const { return m_DC_layer_number; }
   inline const std::string& fieldNamePhi() const { return m_phiID; }
   inline const std::string& Layerid() const { return layer_id; }
+
   // Setters
 
   inline double phiFromXY(const Vector3D& aposition) const {
@@ -167,18 +163,13 @@ protected:
   double m_cellSize;
   double m_epsilon0;
   double m_detectorLength;
-  double m_DC_inner_rbegin;
-  double m_DC_inner_rend;
-  double m_DC_outer_rbegin;
-  double m_DC_outer_rend;
-  double m_DC_inner_rmin;
-  double m_DC_inner_rmax;
-  double m_DC_outer_rmin;
-  double m_DC_outer_rmax;
   double m_layer_width;
   double m_safe_distance;
-  int m_DC_inner_layer_number;
-  int m_DC_outer_layer_number;
+  double m_DC_rbegin;
+  double m_DC_rend;
+  double m_DC_rmax;
+  double m_DC_rmin;
+  int m_DC_layer_number;
 
   std::string m_phiID;
   std::string layer_id;

--- a/Detector/DetSegmentation/src/GridDriftChamber.cpp
+++ b/Detector/DetSegmentation/src/GridDriftChamber.cpp
@@ -14,10 +14,6 @@ GridDriftChamber::GridDriftChamber(const std::string& cellEncoding) : Segmentati
   registerParameter("detector_length", "Length of the wire", m_detectorLength, 1., SegmentationParameter::LengthUnit);
   registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "cellID");
   registerIdentifier("layerID", "layer id", layer_id, "layer");
-  registerParameter("DC_inner_rmin", "DC_inner_rmin", m_DC_inner_rmin, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_inner_rmax", "DC_inner_rmax", m_DC_inner_rmax, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_outer_rmin", "DC_outer_rmin", m_DC_outer_rmin, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_outer_rmax", "DC_outer_rmax", m_DC_outer_rmax, 0., SegmentationParameter::LengthUnit);
 }
 
 GridDriftChamber::GridDriftChamber(const BitFieldCoder* decoder) : Segmentation(decoder) {
@@ -30,18 +26,13 @@ GridDriftChamber::GridDriftChamber(const BitFieldCoder* decoder) : Segmentation(
   registerParameter("detector_length", "Length of the wire", m_detectorLength, 1., SegmentationParameter::LengthUnit);
   registerIdentifier("identifier_phi", "Cell ID identifier for phi", m_phiID, "cellID");
   registerIdentifier("layerID", "layer id", layer_id, "layer");
-  registerParameter("DC_inner_rbegin", "DC_inner_rbegin", m_DC_inner_rbegin, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_inner_rend", "DC_inner_rend", m_DC_inner_rend, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_outer_rbegin", "DC_outer_rbegin", m_DC_outer_rbegin, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_outer_rend", "DC_outer_rend", m_DC_outer_rend, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_inner_rmin", "DC_inner_rmin", m_DC_inner_rmin, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_inner_rmax", "DC_inner_rmax", m_DC_inner_rmax, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_outer_rmin", "DC_outer_rmin", m_DC_outer_rmin, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_outer_rmax", "DC_outer_rmax", m_DC_outer_rmax, 0., SegmentationParameter::LengthUnit);
   registerParameter("safe_distance", "safe_distance", m_safe_distance, 0., SegmentationParameter::LengthUnit);
   registerParameter("layer_width", "layer_width", m_layer_width, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_inner_layer_number", "DC_inner_layer_number", m_DC_inner_layer_number, 0,SegmentationParameter::LengthUnit);
-  registerParameter("DC_outer_layer_number", "DC_outer_layer_number", m_DC_outer_layer_number, 0, SegmentationParameter::LengthUnit);
+  registerParameter("DC_rbegin", "DC_rbegin", m_DC_rbegin, 0., SegmentationParameter::LengthUnit);
+  registerParameter("DC_rend", "DC_rend", m_DC_rend, 0., SegmentationParameter::LengthUnit);
+  registerParameter("DC_rmin", "DC_rmin", m_DC_rmin, 0., SegmentationParameter::LengthUnit);
+  registerParameter("DC_rmax", "DC_rmax", m_DC_rmax, 0., SegmentationParameter::LengthUnit);
+  registerParameter("DC_layer_number", "DC_layer_number", m_DC_layer_number, 0,SegmentationParameter::LengthUnit);
 }
 
 Vector3D GridDriftChamber::position(const CellID& /*cID*/) const {
@@ -63,20 +54,13 @@ CellID GridDriftChamber::cellID(const Vector3D& /*localPosition*/, const Vector3
   double DC_layerdelta = m_layer_width;
 
   int layerid;
-  if( radius<= m_DC_inner_rend && radius>= m_DC_inner_rbegin) {
-      layerid = floor((radius - m_DC_inner_rbegin)/DC_layerdelta);
-  } else if ( radius<= m_DC_outer_rend && radius>= m_DC_outer_rbegin ) {
-      layerid = floor((radius - m_DC_outer_rbegin)/DC_layerdelta);
-  } else if ( radius>= (m_DC_inner_rmin-m_safe_distance) && radius < m_DC_inner_rbegin) {
+  if( radius<= m_DC_rend && radius>= m_DC_rbegin) {
+      layerid = floor((radius - m_DC_rbegin)/DC_layerdelta);
+  } else if ( radius>= (m_DC_rmin-m_safe_distance) && radius < m_DC_rbegin) {
       layerid = 0;
-  } else if ( radius> m_DC_inner_rend && radius <= (m_DC_inner_rmax+m_safe_distance)) {
-      layerid = m_DC_inner_layer_number-1;
-  } else if ( radius>= (m_DC_outer_rmin-m_safe_distance) && radius < m_DC_outer_rbegin) {
-      layerid = 0;
-  } else if ( radius> m_DC_outer_rend && radius <= (m_DC_outer_rmax+m_safe_distance)) {
-      layerid = m_DC_outer_layer_number-1;
+  } else if ( radius> m_DC_rend && radius <= (m_DC_rmax+m_safe_distance)) {
+      layerid = m_DC_layer_number-1;
   }
-
 
   updateParams(chamberID,layerid);
 

--- a/Detector/DetSegmentation/src/GridDriftChamber.cpp
+++ b/Detector/DetSegmentation/src/GridDriftChamber.cpp
@@ -32,7 +32,6 @@ GridDriftChamber::GridDriftChamber(const BitFieldCoder* decoder) : Segmentation(
   registerParameter("DC_rend", "DC_rend", m_DC_rend, 0., SegmentationParameter::LengthUnit);
   registerParameter("DC_rmin", "DC_rmin", m_DC_rmin, 0., SegmentationParameter::LengthUnit);
   registerParameter("DC_rmax", "DC_rmax", m_DC_rmax, 0., SegmentationParameter::LengthUnit);
-  registerParameter("DC_layer_number", "DC_layer_number", m_DC_layer_number, 0,SegmentationParameter::LengthUnit);
 }
 
 Vector3D GridDriftChamber::position(const CellID& /*cID*/) const {
@@ -51,6 +50,7 @@ CellID GridDriftChamber::cellID(const Vector3D& /*localPosition*/, const Vector3
   double posy = globalPosition.Y;
   double radius = sqrt(posx*posx+posy*posy);
 
+  int m_DC_layer_number = floor((m_DC_rend-m_DC_rbegin)/m_layer_width);
   double DC_layerdelta = m_layer_width;
 
   int layerid;
@@ -101,8 +101,6 @@ void GridDriftChamber::cellposition(const CellID& cID, TVector3& Wstart,
   Wstart = returnWirePosition(phi_mid, -1);
   Wend = returnWirePosition(phi_end, 1);
 }
-
-
 
 double GridDriftChamber::distanceTrackWire(const CellID& cID, const TVector3& hit_start,
                                            const TVector3& hit_end) const {

--- a/Detector/DetSegmentation/src/plugins/SegmentationFactories.cpp
+++ b/Detector/DetSegmentation/src/plugins/SegmentationFactories.cpp
@@ -19,4 +19,3 @@ dd4hep::SegmentationObject* create_segmentation(const dd4hep::BitFieldCoder* dec
 
 #include "DetSegmentation/GridDriftChamber.h"
 DECLARE_SEGMENTATION(GridDriftChamber, create_segmentation<dd4hep::DDSegmentation::GridDriftChamber>)
-

--- a/Service/GearSvc/src/GearSvc.cpp
+++ b/Service/GearSvc/src/GearSvc.cpp
@@ -759,9 +759,8 @@ StatusCode GearSvc::convertDC(dd4hep::DetElement& dc){
 	  dcData->rMinReadout = grid->DC_rbegin();
 	  dcData->rMaxReadout = grid->DC_rend();
 	  dcData->driftLength = grid->detectorLength();
-	  dcData->maxRow      = grid->DC_layer_number();
 	  dcData->padHeight   = grid->layer_width();
-          dcData->padWidth    = dcData->padHeight;
+      dcData->padWidth    = dcData->padHeight;
 	}
 	else{
 	  TGeoNode* next = daughter;

--- a/Service/GearSvc/src/GearSvc.cpp
+++ b/Service/GearSvc/src/GearSvc.cpp
@@ -756,10 +756,10 @@ StatusCode GearSvc::convertDC(dd4hep::DetElement& dc){
       if(nodeName.find("chamber_vol")!=-1||nodeName.find("assembly")!=-1){
 	if(grid){
 	  // if more than one chamber, just use the outer, TODO
-	  dcData->rMinReadout = grid->DC_outer_rbegin();
-	  dcData->rMaxReadout = grid->DC_outer_rend();
+	  dcData->rMinReadout = grid->DC_rbegin();
+	  dcData->rMaxReadout = grid->DC_rend();
 	  dcData->driftLength = grid->detectorLength();
-	  dcData->maxRow      = grid->DC_outer_layer_number();
+	  dcData->maxRow      = grid->DC_layer_number();
 	  dcData->padHeight   = grid->layer_width();
           dcData->padWidth    = dcData->padHeight;
 	}


### PR DESCRIPTION
   Change the dual drift chamber to a single drift chamber, where
1. inner radius:800mm
2. outer radius:1720mm
The radii of the inner and outer walls respectively extend outward.
  Due to the modification of the inner and outer radius of the drift chamber, the parameters of the silicon detector should also be corrected accordingly. Since I am not clear, I added the parameters of the single drift chamber in the `Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml` and `Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml` , and the parameters of the dual drift chamber were not deleted before. 