### PR TITLE
GEO&REC: Silicon tracker update

### DIFF
--- a/Detector/DetCRD/compact/CRD_common_v01/FTD_SkewRing_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/FTD_SkewRing_v01_01.xml
@@ -1,0 +1,54 @@
+<lccdd>
+  <define>
+    <constant name="SiliconThickness" value="0.2*mm"/>
+    <constant name="SupportThickness" value="1.0*mm"/>
+    <constant name="ModuleZGap"       value="1.0*mm"/>
+    <constant name="ModuleRPhiGap"    value="-10*mm"/>
+  </define>
+
+  <detectors>
+    <detector id="DetID_FTD" name="FTD" type="SiTrackerSkewRing_v01" vis="FTDVis" readout="FTDCollection" insideTrackingVolume="true" reflect="true">
+      <envelope>
+	<shape type="Assembly"/>
+      </envelope>
+
+      <type_flags type="DetType_TRACKER +  DetType_ENDCAP  + DetType_PIXEL "/>
+
+      <reconstruction strip_width="0.05*mm" strip_length="92*mm" strip_pitch="0" strip_angle="0"/>
+
+      <layer id="0" z="SiTracker_endcap_z1" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z1*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius1"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+	<component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+	<component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="1" z="SiTracker_endcap_z2" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z2*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius2"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="2" z="SiTracker_endcap_z3" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z3*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius3"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="3" z="SiTracker_endcap_z4" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z4*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius4"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="4" z="SiTracker_endcap_z5" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z5*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius5"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="FTDCollection">
+      <id>system:5,side:-2,layer:9,module:8,sensor:8</id>
+    </readout>
+  </readouts>
+
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_common_v01/FTD_SkewRing_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/FTD_SkewRing_v01_02.xml
@@ -1,0 +1,49 @@
+<lccdd>
+  <define>
+    <constant name="SiliconThickness" value="0.2*mm"/>
+    <constant name="SupportThickness" value="1.0*mm"/>
+    <constant name="ModuleZGap"       value="1.0*mm"/>
+    <constant name="ModuleRPhiGap"    value="-10*mm"/>
+  </define>
+
+  <detectors>
+    <detector id="DetID_FTD" name="FTD" type="SiTrackerSkewRing_v01" vis="FTDVis" readout="FTDCollection" insideTrackingVolume="true" reflect="true">
+      <envelope>
+	<shape type="Assembly"/>
+      </envelope>
+
+      <type_flags type="DetType_TRACKER +  DetType_ENDCAP  + DetType_PIXEL "/>
+
+      <reconstruction strip_width="0.05*mm" strip_length="92*mm" strip_pitch="0" strip_angle="0"/>
+
+      <layer id="0" z="SiTracker_endcap_z1" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z1*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius1"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+	<component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+	<component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="1" z="SiTracker_endcap_z2" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z2*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius2"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="2" z="SiTracker_endcap_z3" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z3*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius3"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="3" z="SiTracker_endcap_z4" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z4*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius4"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="FTDCollection">
+      <id>system:5,side:-2,layer:9,module:8,sensor:8</id>
+    </readout>
+  </readouts>
+
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_common_v01/SET_SimplePixel_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/SET_SimplePixel_v01_01.xml
@@ -1,0 +1,43 @@
+<lccdd>
+  <define>
+    <!--0.17mm silicon + 1.0mm carbon -> 0.65% of X0--> 
+    <constant name="SET_sensitive_thickness" value="0.17*mm"/>
+    <constant name="SET_support_thickness"   value="1.0*mm"/> 
+    <constant name="SET_sensor_length"       value="92*mm"/>
+    <constant name="SET_ladder_number"       value="2*pi*SET_inner_radius/SIT_sensor_length"/>
+    <constant name="SET_outer_radius" value="(SET_inner_radius+SET_sensitive_thickness+SET_support_thickness)/cos(pi/SET_ladder_number) + env_safety"/>
+    <constant name="SET_half_length"  value="OuterTracker_half_length"/>
+    <!--constant name="SET_distance_from_tpc" value="SET_inner_radius-OuterTracker_outer_radius+0.5*SET_sensitive_thickness"/-->
+  </define>
+  
+  <detectors>
+    <!--detector id="DetID_SET" name="SET" type="SET_Simple_Planar" vis="SETVis" readout="SETCollection" insideTrackingVolume="true"-->
+    <detector id="DetID_SET" name="SET" type="SIT_Simple_Pixel" vis="SETVis" readout="SETCollection" insideTrackingVolume="true">
+      <envelope>
+	<shape type="Tube" rmin="SET_inner_radius" rmax="SET_outer_radius" dz="SET_half_length"  material = "Air" />
+      </envelope>
+      
+      <type_flags type="DetType_TRACKER +  DetType_BARREL + DetType_PIXEL "/>
+      
+      <reconstruction strip_width="0." strip_length="0." strip_pitch="0." strip_angle="0*deg"  />
+
+      <global sensitive_thickness="SET_sensitive_thickness" support_thickness="SET_support_thickness" sensor_length="SIT_sensor_length" sensitive_mat="G4_Si"
+              support_mat="G4_C" sensitive_threshold_KeV="64*keV"  />
+      <display ladder="SeeThrough" support="SETSupportVis" sens_env="SeeThrough" sens="SETSensitiveVis" />
+      
+      <!--layer layer_id="0" sensitive_distance_from_tpc="SET_distance_from_tpc" coverage_of_TPC_Ecal_Hcal_barrel="1.0"
+             n_ladders="SET_ladder_number" ladder_clearance="0.1*mm" faces_IP="1"  /-->
+      <layer layer_id="0" sensitive_radius="SET_inner_radius+0.5*SET_sensitive_thickness" n_sensors_per_ladder="SET_half_length*2/SIT_sensor_length"
+	     n_ladders="SET_ladder_number" ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="0" is_SIT2="0"  />
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="SETCollection">
+      <id>system:5,side:-2,layer:9,module:8,sensor:8,barrelside:-2</id>
+    </readout>
+  </readouts>
+
+
+</lccdd>
+

--- a/Detector/DetCRD/compact/CRD_common_v01/SET_SimplePlanar_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/SET_SimplePlanar_v01_01.xml
@@ -1,34 +1,31 @@
 <lccdd>
   <define>
-    <constant name="SET_inner_radius" value="OuterTracker_outer_radius + env_safety"/>
-    <constant name="SET_outer_radius" value="Ecal_barrel_inner_radius - env_safety "/>
-    <constant name="SET_half_length"  value="DC_half_length"/>
+    <!--0.17mm silicon + 1.0mm carbon -> 0.65% of X0-->
+    <constant name="SET_sensitive_thickness" value="0.17*mm"/>
+    <constant name="SET_support_thickness"   value="1.0*mm"/>
+    <constant name="SET_ladder_number"       value="24"/>
+    <constant name="SET_outer_radius" value="(SET_inner_radius+SET_sensitive_thickness*2+SET_support_thickness*2)/cos(pi/SET_ladder_number) + env_safety"/>
+    <constant name="SET_half_length"  value="OuterTracker_half_length"/>
+    <constant name="SET_distance_from_tpc" value="SET_inner_radius-OuterTracker_outer_radius+0.5*SET_sensitive_thickness"/>
   </define>
 
   <detectors>
     <detector id="DetID_SET" name="SET" type="SET_Simple_Planar" vis="SETVis" readout="SETCollection" insideTrackingVolume="true">
-      <envelope vis="SETVis">
-        <shape type="Tube" rmin="SET_inner_radius" rmax="SET_outer_radius" dz="SET_half_length"  material = "Air" />
+      <envelope>
+	<shape type="Tube" rmin="SET_inner_radius" rmax="SET_outer_radius" dz="SET_half_length"  material = "Air" />
       </envelope>
 
       <type_flags type="DetType_TRACKER +  DetType_BARREL + DetType_STRIP "/>
 
-      <!-- database : set_simple_planar_sensors_01 -->
-
-      <!-- SQL command: "select * from extended_reconstruction_parameters;"  -->
       <reconstruction strip_width="0.0125*mm" strip_length="92*mm" strip_pitch="0.05*mm" strip_angle="7*deg"  />
 
-      <!-- SQL command: "select * from global;"  -->
-      <global sensitive_thickness="0.2*mm" support_thickness="1*mm" sensor_length="92*mm" sensitive_mat="G4_Si"
+      <global sensitive_thickness="SET_sensitive_thickness" support_thickness="SET_support_thickness" sensor_length="92*mm" sensitive_mat="G4_Si"
               support_mat="G4_C" sensitive_threshold_KeV="64*keV"  />
 
-      <!-- SQL command: "select * from set_layers;"  -->
-
-      <layer layer_id="0" sensitive_distance_from_tpc="3*mm" coverage_of_TPC_Ecal_Hcal_barrel="0.98"
-             n_ladders="24" ladder_clearance="0.1*mm" faces_IP="1"  />
-
-      <layer layer_id="1" sensitive_distance_from_tpc="5.5*mm" coverage_of_TPC_Ecal_Hcal_barrel="0.98"
-             n_ladders="24" ladder_clearance="0.1*mm" faces_IP="0"  />
+      <layer layer_id="0" sensitive_distance_from_tpc="SET_distance_from_tpc" coverage_of_TPC_Ecal_Hcal_barrel="1.0"
+             n_ladders="SET_ladder_number" ladder_clearance="0.1*mm" faces_IP="1"  />
+      <layer layer_id="1" sensitive_distance_from_tpc="SET_distance_from_tpc+SET_support_thickness*2+SET_sensitive_thickness" coverage_of_TPC_Ecal_Hcal_barrel="1.0"
+             n_ladders="SET_ladder_number" ladder_clearance="0.1*mm" faces_IP="0"  />
 
     </detector>
 

--- a/Detector/DetCRD/compact/CRD_common_v01/SIT_SimplePixel_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/SIT_SimplePixel_v01_01.xml
@@ -1,42 +1,46 @@
 <lccdd>
   <define>
-    <constant name="SIT_sensitive_thickness" value="0.2*mm"/>
-    <constant name="SIT_inner_radius"   value="SIT1_inner_radius"/>
+    <!--0.17mm silicon + 1.0mm carbon -> 0.65% of X0-->
+    <constant name="SIT_sensitive_thickness" value="0.17*mm"/>
+    <constant name="SIT_support_thickness"   value="1*mm"/>
+    <constant name="SIT_sensor_length"       value="92*mm"/>
+    <!--constant name="SIT_inner_radius"   value="SIT1_inner_radius"/>
     <constant name="SIT_inner_radius_1"   value="SIT_inner_radius + env_safety"/>
     <constant name="SIT_outer_radius_1" value="SIT_inner_radius_1/cos(pi/8)"/>
     <constant name="SIT_inner_radius_2" value="SIT2_inner_radius"/>
     <constant name="SIT_outer_radius"   value="OuterTracker_inner_radius"/>
     <constant name="SIT_half_length"    value="SIT2_half_length"/>
     <constant name="SIT_half_length_1"  value="SIT1_half_length"/>
-    <constant name="SIT_layer_gap" value="2.5*mm"/>
+    <constant name="SIT_layer_gap" value="2.5*mm"/-->
   </define>
 
   <detectors>
-    <detector id="DetID_SIT" name="SIT" type="SIT_Simple_Planar" vis="SITVis" readout="SITCollection" insideTrackingVolume="true">
-      <envelope vis="SeeThrough">
-        <shape type="BooleanShape" operation="Union" material="Air" >
+    <detector id="DetID_SIT" name="SIT" type="SIT_Simple_Pixel" vis="SITVis" readout="SITCollection" insideTrackingVolume="true">
+      <envelope>
+	<shape type="Assembly"/>
+        <!--shape type="BooleanShape" operation="Union" material="Air" >
           <shape type="Tube" rmin="SIT_inner_radius"   rmax="SIT_outer_radius_1" dz="SIT_half_length_1" />
           <shape type="Tube" rmin="SIT_inner_radius_2" rmax="SIT_outer_radius"   dz="SIT_half_length" />
-        </shape>
+        </shape-->
       </envelope>
 
-      <type_flags type="DetType_TRACKER + DetType_BARREL + DetType_STRIP "/>
+      <type_flags type="DetType_TRACKER + DetType_BARREL + DetType_PIXEL "/>
 
-      <!-- database : sit_simple_planar_sensors_03 -->
-      
-      <!-- SQL command: "select * from extended_reconstruction_parameters;"  -->
       <reconstruction strip_width="0." strip_length="92*mm" strip_pitch="0." strip_angle="0*deg"  />
 
-      <!-- SQL command: "select * from global;"  -->
-      <global sensitive_thickness="SIT_sensitive_thickness" support_thickness="1*mm" sensor_length="92*mm"
+      <global sensitive_thickness="SIT_sensitive_thickness" support_thickness="SIT_support_thickness" sensor_length="SIT_sensor_length"
               sensitive_mat="G4_Si" support_mat="G4_C" sensitive_threshold_KeV="64*keV"  />
+      <display ladder="SeeThrough" support="SITSupportVis" sens_env="SeeThrough" sens="SITSensitiveVis" />
 
-      <!-- SQL command: "select * from sit_layers;"  -->
-      <layer layer_id="0" sensitive_radius="SIT_inner_radius_1+0.5*SIT_sensitive_thickness" n_sensors_per_ladder="8" n_ladders="10"
-             ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="1" is_SIT2="0"  />
+      <layer layer_id="0" sensitive_radius="SIT1_inner_radius+0.5*SIT_sensitive_thickness" n_sensors_per_ladder="SIT1_half_length*2/SIT_sensor_length"
+	     n_ladders="2*pi*SIT1_inner_radius/SIT_sensor_length" ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="1" is_SIT2="0"  />
+      <layer layer_id="1" sensitive_radius="SIT2_inner_radius+0.5*SIT_sensitive_thickness" n_sensors_per_ladder="SIT2_half_length*2/SIT_sensor_length"
+             n_ladders="2*pi*SIT2_inner_radius/SIT_sensor_length" ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="0" is_SIT2="1"  />
+      <layer layer_id="2" sensitive_radius="SIT3_inner_radius+0.5*SIT_sensitive_thickness" n_sensors_per_ladder="SIT3_half_length*2/SIT_sensor_length"
+             n_ladders="2*pi*SIT3_inner_radius/SIT_sensor_length" ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="0" is_SIT2="0"  />
+      <layer layer_id="3" sensitive_radius="SIT4_inner_radius+0.5*SIT_sensitive_thickness" n_sensors_per_ladder="SIT4_half_length*2/SIT_sensor_length"
+             n_ladders="2*pi*SIT4_inner_radius/SIT_sensor_length" ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="0" is_SIT2="0"  />
 
-      <layer layer_id="1" sensitive_radius="SIT_inner_radius_2+0.5*SIT_sensitive_thickness" n_sensors_per_ladder="48" n_ladders="16"
-             ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="0" is_SIT2="1"  />
     </detector>
   </detectors>
 

--- a/Detector/DetCRD/compact/CRD_common_v01/SIT_SimplePixel_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/SIT_SimplePixel_v01_02.xml
@@ -38,8 +38,6 @@
              n_ladders="2*pi*SIT2_inner_radius/SIT_sensor_length" ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="0" is_SIT2="1"  />
       <layer layer_id="2" sensitive_radius="SIT3_inner_radius+0.5*SIT_sensitive_thickness" n_sensors_per_ladder="SIT3_half_length*2/SIT_sensor_length"
              n_ladders="2*pi*SIT3_inner_radius/SIT_sensor_length" ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="0" is_SIT2="0"  />
-      <layer layer_id="3" sensitive_radius="SIT4_inner_radius+0.5*SIT_sensitive_thickness" n_sensors_per_ladder="SIT4_half_length*2/SIT_sensor_length"
-             n_ladders="2*pi*SIT4_inner_radius/SIT_sensor_length" ladder_clearance="0.1*mm" faces_IP="1" is_SIT1="0" is_SIT2="0"  />
 
     </detector>
   </detectors>

--- a/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
@@ -3,6 +3,7 @@
 #include "EventSeeder/IEventSeeder.h"
 #include "TrackSystemSvc/ITrackSystemSvc.h"
 #include "DataHelper/Navigation.h"
+#include "DataHelper/TrackerHitHelper.h"
 #include "edm4hep/MCParticle.h"
 #include "edm4hep/TrackerHit.h"
 //#include "edm4hep/TrackerHitPlane.h"
@@ -420,7 +421,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
   }
   catch ( GaudiException &e ) {
     debug() << "Collection " << _inFTDPixelColHdl.fullKey() << " is unavailable in event " << _nEvt << endmsg;
-    success = 0;
+    //success = 0;
   }
   
   if(hitFTDPixelCol){
@@ -520,7 +521,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
   }
   catch ( GaudiException &e ) {
     debug() << "Collection " << _inFTDSpacePointColHdl.fullKey() << " is unavailable in event " << _nEvt << endmsg;
-    success = 0;
+    //success = 0;
   }
 
   const edm4hep::TrackerHitCollection* rawHitCol = nullptr;
@@ -626,6 +627,8 @@ int SiliconTrackingAlg::InitialiseFTD() {
     }
     
   }
+  if(hitFTDPixelCol==nullptr&&hitFTDSpacePointCol==nullptr) success = 0;
+
   debug() << "FTD initialized" << endmsg;
   return success;
 }
@@ -771,7 +774,6 @@ int SiliconTrackingAlg::InitialiseVTX() {
         //    v)   Must be standard TrackerHit
         
 	//const edm4hep::ConstTrackerHit trkhit = hitSITCol->at(ielem);
-        
         int layer = getLayerID(trkhit);
         
         // VXD and SIT are treated as one system so SIT layers start from _nLayersVTX
@@ -2671,7 +2673,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
         // check if the hit has been rejected as being on the same layer and further from the helix lh==0
         if (lh[i] == 1) {
 	  edm4hep::ConstTrackerHit trkHit = hitVec[i]->getTrackerHit();
-	  debug() << "TrackerHit " << i << " address = " << trkHit << endmsg;
+	  debug() << "TrackerHit " << i << " id = " << trkHit.id() << endmsg;
           nFit++;
           if(trkHit.isAvailable()) { 
             trkHits.push_back(trkHit);   
@@ -2791,7 +2793,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       marlinTrk->getHitsInFit(hits_in_fit);
       
       for ( unsigned ihit = 0; ihit < hits_in_fit.size(); ++ihit) {
-	debug() << "Hit address=" << hits_in_fit[ihit].first << endmsg;
+	debug() << "Hit id =" << hits_in_fit[ihit].first.id() << endmsg;
 	edm4hep::ConstTrackerHit trk = hits_in_fit[ihit].first;
         all_hits.push_back(trk);//hits_in_fit[ihit].first);
       }


### PR DESCRIPTION
* fix bug
  * SiliconTrackingAlg does not work for only pixel or strip FTD hits exist
* update
  * SIT_Simple_Pixel geometry module: change vis option input, and change volume prefix from fixed "SIT" to detector name (input by XML), to make possible to use it to create pixel SET
  * optional sensitive thickness and support thickness, default as 0.65% of X0
  * SIT_SimplePixel_v01_01.xml change to 4 layers
* new implementation preparing for new 4th conceptual detector 
  *  SIT_SimplePixel_v01_02.xml for 3 layers
  *  SET_SimplePixel_v01_01.xml for pixel SET
  *  FTD_SkewRing_v01_01.xml for 5 layers
  *  FTD_SkewRing_v01_02.xml for 4 layers
      