### PR TITLE
Tracker: update dimensions for silicon tracker of CRD_o1_v01 and CRD_o1_v02

### DIFF
--- a/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/DC_Simple_v01_01.xml
@@ -13,10 +13,6 @@
   </info>
 
   <define>
-    <constant name="world_size" value="2226*mm"/>
-    <constant name="world_x" value="world_size"/>
-    <constant name="world_y" value="world_size"/>
-    <constant name="world_z" value="world_size"/>
 
     <!-- SDT -->
     <constant name="SDT_radius_min" value="DC_inner_radius"/>
@@ -56,7 +52,7 @@
   </regions>
 
   <detectors>
-    <detector id="DetID_DC" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="VisibleBlue" sensitive="true" region="DriftChamberRegion" limits="DC_limits">
+    <detector id="DetID_DC" name="DriftChamber" type="DriftChamber" readout="DriftChamberHitsCollection" vis="DCVis" sensitive="true" region="DriftChamberRegion" limits="DC_limits">
       <chamber id="0"/>
       <envelope vis="SeeThrough">
         <shape type="BooleanShape" operation="Union" material="Air">
@@ -64,12 +60,12 @@
         </shape>
       </envelope>
 
-      <module id="0" name="SignalWire" type="Tube" rmin="0*mm" rmax="0.01*mm" vis="VisibleRed">
+      <module id="0" name="SignalWire" type="Tube" rmin="0*mm" rmax="0.01*mm" vis="RedVis">
           <tubs name="W" type="Tube" rmin="0*mm" rmax="0.007*mm" material="Tungsten"/>
           <tubs name="Au" type="Tube" rmin="0.007*mm" rmax="0.01*mm" material="Gold"/>
       </module>
 
-      <module id="1" name="FieldWire" type="Tube" rmin="0*mm" rmax="0.02*mm" vis="VisibleGreen">
+      <module id="1" name="FieldWire" type="Tube" rmin="0*mm" rmax="0.02*mm" vis="GreenVis">
           <tubs name="Al" type="Tube" rmin="0*mm" rmax="0.017*mm" material="Aluminum"/>
           <tubs name="Ag" type="Tube" rmin="0.017*mm" rmax="0.02*mm" material="Silver"/>
       </module>

--- a/Detector/DetCRD/compact/CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml
@@ -4,6 +4,8 @@
     <constant name="ecalbarrel_inner_radius" value="Ecal_barrel_inner_radius"/>
     <constant name="ecalbarrel_thickness"    value="Ecal_barrel_thickness"/>    <!--Must be n*10*mm! -->
     <constant name="ecalbarrel_zlength"      value="Ecal_barrel_half_length*2"/>   <!--Must be n*10*mm! -->
+    <constant name="bar_x" value="1*cm"/>
+    <constant name="bar_y" value="1*cm"/>
   </define>
 
   <regions>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
@@ -17,6 +17,8 @@
   <define>
     <constant name="CrossingAngle" value="0.033*rad"/>  
 
+    <constant name="Global_endcap_costheta" value="0.99"/>
+
     <constant name="GlobalTrackerReadoutID_DCH" type="string" value="system:8,chamber:1,layer:7,phi:16"/>
     <constant name="GlobalTrackerReadoutID" type="string" value="system:5,side:-2,layer:9,module:8,sensor:8,barrelside:-2"/>
 
@@ -32,7 +34,7 @@
     <constant name="DetID_TPC"          value="  4"/>
     <constant name="DetID_SET"          value="  5"/>
     <constant name="DetID_ETD"          value="  6"/>
-    <constant name="DetID_DC"           value="  7"/>
+    <constant name="DetID_DC"           value="  4"/> <!--in order to cheat Clupatra, same as TPC--> 
     
     <constant name="DetID_ECAL"         value=" 20"/>
     <constant name="DetID_ECAL_PLUG"    value=" 21"/>
@@ -82,12 +84,13 @@
     <constant name="Vertex_half_length"  value="200*mm"/>
 
     <constant name="DC_Endcap_dz" value="0.1*mm"/>
-    <constant name="DC_half_length"  value="2225*mm" />
+    <constant name="DC_half_length"  value="2980*mm" />
     <constant name="DC_safe_distance" value="0.02*mm"/>
     <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
     <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
     <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_dz" />
 
+    <!--obselete for single drift chamber-->
     <constant name="InnerTracker_half_length"  value="DC_half_length" />
     <constant name="InnerTracker_inner_radius" value="234*mm"/>
     <constant name="InnerTracker_outer_radius" value="909*mm"/>
@@ -102,11 +105,30 @@
     <constant name="DC_inner_radius" value="DC_chamber_layer_rbegin-SDT_inner_wall_thickness-DC_safe_distance"/>
     <constant name="DC_outer_radius" value="DC_chamber_layer_rend+SDT_outer_wall_thickness+DC_safe_distance"/>
 
-    <constant name="SIT1_inner_radius"   value="152.90*mm"/>
-    <constant name="SIT1_half_length"    value="368.00*mm"/>
-    <constant name="SIT2_inner_radius"   value="InnerTracker_outer_radius + env_safety"/>
-    <constant name="SIT2_half_length"    value="DC_half_length"/>
+    <constant name="SIT1_inner_radius"   value="230*mm"/>
+    <constant name="SIT2_inner_radius"   value="410*mm"/>
+    <constant name="SIT3_inner_radius"   value="590*mm"/>
+    <constant name="SIT4_inner_radius"   value="770*mm"/>
+    <constant name="SIT1_half_length"    value="461*mm"/>
+    <constant name="SIT2_half_length"    value="691*mm"/>
+    <constant name="SIT3_half_length"    value="1013*mm"/>
+    <constant name="SIT4_half_length"    value="1335*mm"/>
 
+    <constant name="SET_inner_radius"    value="1815*mm"/>
+
+    <constant name="SiTracker_barrel_endcap_gap" value="5*mm"/>
+    <constant name="SiTracker_DC_endcap_gap"     value="10*mm"/>
+    <constant name="SiTracker_endcap_z1" value="SIT1_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z2" value="SIT2_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z3" value="SIT3_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z4" value="SIT4_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z5" value="MainTracker_half_length+SiTracker_DC_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius1" value="SIT1_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius2" value="SIT2_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius3" value="SIT3_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius4" value="SIT4_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius5" value="SET_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <!--obseleted -->
     <constant name="FTD_BeamPipe_cable_clearance"     value="10*mm"/> 
     <constant name="FTD_BeamPipe_gap"     value="15*mm"/>
     <constant name="FTD_InnerTracker_gap" value="5*mm"/>
@@ -123,69 +145,69 @@
     <constant name="TUBE_IPOuterTube_end_radius"  value="BeamPipe_Central_inner_radius+BeamPipe_Al_thickness"/>
     <constant name="TUBE_IPOuterBulge_end_z"      value="BeamPipe_Crotch_zmax"/><!--"BeamPipe_ConeAl_zmax"/-->
     <constant name="TUBE_IPOuterBulge_end_radius" value="BeamPipe_Crotch_zmax*tan(CrossingAngle/2)+BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness"/>
-                             <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
+    <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
 
-    <constant name="Ecal_barrel_inner_radius" value="1800*mm"/>
+    <constant name="Ecal_barrel_inner_radius" value="1900*mm"/>
     <constant name="Ecal_barrel_thickness"    value="280*mm"/>
     <constant name="Ecal_barrel_outer_radius" value="(Ecal_barrel_inner_radius+Ecal_barrel_thickness)/cos(pi/8)"/>
-    <constant name="Ecal_barrel_half_length"  value="2300*mm"/>
+    <constant name="Ecal_barrel_half_length"  value="3350*mm"/>
     <constant name="Ecal_barrel_symmetry"    value="8"/>
-    
-    <constant name="Ecal_endcap_inner_radius" value="340*mm"/>
-    <constant name="Ecal_endcap_outer_radius" value="Ecal_barrel_outer_radius"/>
-    <constant name="Ecal_endcap_zmin"        value="2260*mm"/>
-    <constant name="Ecal_endcap_zmax"        value="2540*mm"/>
+
+    <constant name="Ecal_endcap_inner_radius" value="350*mm"/>
+    <constant name="Ecal_endcap_outer_radius" value="Ecal_barrel_inner_radius+Ecal_barrel_thickness"/>
+    <constant name="Ecal_endcap_zmin"        value="3050*mm"/>
+    <constant name="Ecal_endcap_zmax"        value="3350*mm"/>
     <constant name="Ecal_endcap_symmetry"    value="8"/>
     <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
     <constant name="EcalEndcap_outer_radius" value="Ecal_barrel_outer_radius"/>
     
-    <constant name="Solenoid_inner_radius" value="2260*mm"/>
-    <constant name="Solenoid_outer_radius" value="2560*mm"/>
-    <constant name="Solenoid_half_length" value="3000*mm"/>
-    <constant name="SolenoidCoil_half_length" value="2900*mm"/>
-    <constant name="SolenoidCoil_radius" value="2300*mm"/>
+    <constant name="Solenoid_inner_radius" value="2330*mm"/>
+    <constant name="Solenoid_outer_radius" value="2480*mm"/>
+    <constant name="Solenoid_half_length" value="3830*mm"/>
+    <constant name="SolenoidCoil_half_length" value="3800*mm"/>
+    <constant name="SolenoidCoil_radius" value="2351*mm"/>
     <constant name="SolenoidCoil_center_radius" value="(Solenoid_inner_radius+Solenoid_outer_radius)/2"/>
 
-    <constant name="Hcal_barrel_inner_radius" value="2600*mm"/>
-    <constant name="Hcal_barrel_outer_radius" value="3670.6805372782*mm"/>
-    <constant name="Hcal_barrel_half_length"  value="3000*mm"/>
+    <constant name="Hcal_barrel_inner_radius" value="2530*mm"/>
+    <constant name="Hcal_barrel_outer_radius" value="3610*mm"/>
+    <constant name="Hcal_barrel_half_length"  value="4480*mm"/>
     <constant name="Hcal_barrel_symmetry"    value="8"/>
     
-    <constant name="Hcal_endcap_inner_radius" value="340*mm"/>
+    <constant name="Hcal_endcap_inner_radius" value="400*mm"/>
     <constant name="Hcal_endcap_outer_radius" value="Hcal_barrel_outer_radius"/>
-    <constant name="Hcal_endcap_zmin" value="3010*mm"/>
-    <constant name="Hcal_endcap_zmax" value="4094.2*mm"/>
+    <constant name="Hcal_endcap_zmin" value="3400*mm"/>
+    <constant name="Hcal_endcap_zmax" value="4480*mm"/>
     <constant name="Hcal_endcap_symmetry" value="8"/>
     <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
     <constant name="HcalEndcap_max_z" value="Hcal_endcap_zmax"/>
     <constant name="Hcal_endcap_outer_symmetry" value="Hcal_endcap_symmetry"/>
     <constant name="Hcal_outer_radius" value="Hcal_barrel_outer_radius"/>
 
-    <constant name="Hcal_ring_inner_radius" value="Hcal_endcap_inner_radius"/>
+    <!--constant name="Hcal_ring_inner_radius" value="Hcal_endcap_inner_radius"/>
     <constant name="Hcal_ring_outer_radius" value="Solenoid_inner_radius"/>
     <constant name="Hcal_ring_zmin" value="2600*mm"/>
     <constant name="Hcal_ring_zmax" value="Hcal_endcap_zmin-10*mm"/>
-    <constant name="Hcal_ring_symmetry" value="8"/>
+    <constant name="Hcal_ring_symmetry" value="8"/-->
         
-    <constant name="Yoke_barrel_inner_radius" value="3710*mm"/>
-    <constant name="Yoke_barrel_outer_radius" value="6951*mm"/>
+    <constant name="Yoke_barrel_inner_radius" value="3660*mm"/>
+    <constant name="Yoke_barrel_outer_radius" value="4260*mm"/>
     <constant name="Yoke_barrel_half_length" value="Hcal_endcap_zmax"/>
     <constant name="Yoke_barrel_symmetry" value="8"/>
     
     <constant name="Yoke_endcap_inner_radius" value="400*mm"/>
     <constant name="Yoke_endcap_outer_radius" value="Yoke_barrel_outer_radius"/>
-    <constant name="Yoke_endcap_zmin" value="Yoke_barrel_half_length+25*mm"/>
-    <constant name="Yoke_endcap_zmax" value="6750*mm"/>
+    <constant name="Yoke_endcap_zmin" value="4660*mm"/>
+    <constant name="Yoke_endcap_zmax" value="5460*mm"/>
     <constant name="Yoke_endcap_outer_symmetry" value="8"/>
     <constant name="Yoke_endcap_inner_symmetry" value="0"/>
     <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
     <constant name="Yoke_Z_start_endcaps" value="Yoke_endcap_zmin"/>
     
-    <constant name="LumiCal_zmax" value="805*mm" />
+    <!--constant name="LumiCal_zmax" value="805*mm" />
     <constant name="LumiCal_zmin" value="700*mm"/>
     <constant name="LumiCal_thickness" value="(LumiCal_zmax-LumiCal_zmin)/2.0"/>
     <constant name="LumiCal_inner_radius" value="35.0*mm"/>
-    <constant name="LumiCal_outer_radius" value="100.0*mm- env_safety"/>
+    <constant name="LumiCal_outer_radius" value="100.0*mm- env_safety"/-->
         
     <constant name="tracker_region_zmax" value="OuterTracker_half_length"/>
     <constant name="tracker_region_rmax" value="OuterTracker_outer_radius"/>
@@ -214,17 +236,24 @@
     <vis name="VXDVis"           alpha="0.1" r="0.1"   g=".5"      b=".5"    showDaughters="true"  visible="true"/>
     <vis name="VXDLayerVis"      alpha="1.0" r="0.1"   g=".5"      b=".5"    showDaughters="true"  visible="true"/>
     <vis name="VXDSupportVis"    alpha="1.0" r="0.0"   g="1.0"     b="0.0"   showDaughters="true"  visible="true"/>
-    <vis name="FTDVis"           alpha="1.0" r="0.0"   g="0.1"     b="0.0"   showDaughters="true"  visible="false"/>
-    <vis name="FTDSensitiveVis"  alpha="1.0" r="1.0"   g="1.0"     b="0.45"  showDaughters="true" visible="true"/>
-    <vis name="FTDSupportVis"    alpha="1.0" r="1.0"   g="0.5"     b="0.5"   showDaughters="true" visible="true"/>
-    <vis name="SITVis"           alpha="1.0" r="0.54"  g="0.43"    b="0.04"  showDaughters="true"  visible="true"/>
-    <vis name="SETVis"           alpha="1.0" r="0.8"   g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
+    <vis name="FTDVis"           alpha="1.0" r="0.5"   g="0.87"    b="0.11"  showDaughters="true"  visible="true"/>
+    <vis name="FTDSupportVis"    alpha="1.0" r="0.3"   g="0.3"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="FTDSensitiveVis"  alpha="1.0" r="0.3"   g="0.5"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="DCVis"            alpha="1.0" r="0.96"  g="0.64"    b="0.90"  showDaughters="true"  visible="true"/>
+    <vis name="DCLayerVis"       alpha="1.0" r="0.96"  g="0.64"    b="0.90"  showDaughters="false" visible="true"/>
+    <vis name="SITVis"           alpha="0.0" r="0.54"  g="0.59"    b="0.93"  showDaughters="true"  visible="false"/>
+    <vis name="SITSupportVis"    alpha="1.0" r="0.0"   g="0.0"     b="1.0"   showDaughters="false" visible="true"/>
+    <vis name="SITSensitiveVis"  alpha="1.0" r="0.67"  g="0.99"    b="0.78"  showDaughters="false" visible="true"/>
+    <vis name="SETVis"           alpha="0.0" r="0.8"   g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
+    <vis name="SETSupportVis"    alpha="1.0" r="1.0"   g="0.0"     b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="SETSensitiveVis"  alpha="1.0" r="0.0"   g="0.0"     b="1.0"   showDaughters="true"  visible="true"/>
     <vis name="ECALVis"          alpha="1.0" r="0.2"   g="0.6"     b="0"     showDaughters="true"  visible="true"/>
-    <vis name="HCALVis"          alpha="1.0" r="0.078" g="0.01176" b="0.588" showDaughters="true"  visible="true"/>
+    <vis name="HCALVis"          alpha="1.0" r="0.95"  g="0.78"    b="0.69"  showDaughters="true"  visible="true"/>
     <vis name="SOLVis"           alpha="1.0" r="0.4"   g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
-    <vis name="YOKEVis"          alpha="1.0" r="0.6"   g="0.0"     b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="YOKEVis"          alpha="1.0" r="0.64"  g="0.75"    b="0.99"  showDaughters="false" visible="true"/>
     <vis name="LCALVis"          alpha="1.0" r="0.25"  g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
-    <vis name="SupportVis"       alpha="1.0" r="0.2"   g="0.2"     b="0.2"   showDaughters="true" visible="true"/>
+    <vis name="SupportVis"       alpha="1.0" r="0.2"   g="0.2"     b="0.2"   showDaughters="true"  visible="true"/>
+    <vis name="ShellVis"         alpha="1.0" r="0.83"  g="0.55"    b="0.89"  showDaughters="false" visible="true"/>
 
     <vis name="WhiteVis"         alpha="0.0" r=".96" g=".96"  b=".96"   showDaughters="true"  visible="true"/>
     <vis name="LightGrayVis"     alpha="0.0" r=".75" g=".75"  b=".75"   showDaughters="true"  visible="true"/>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01-onlyTracker.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01-onlyTracker.xml
@@ -2,12 +2,12 @@
 <lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
        xmlns:xs="http://www.w3.org/2001/XMLSchema"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
-  <info name="CRD_o1_v02"
-        title="CepC reference detctor with coil inside Hcal, pixel SIT and strip SET"
+  <info name="CRD_o1_v01"
+        title="CepC reference detctor with coil inside Hcal, pixel SIT/SET"
         author="C.D.Fu, "
         url="http://cepc.ihep.ac.cn"
         status="developing"
-        version="v02">
+        version="v01">
     <comment>CepC reference detector simulation models used for detector study </comment>
   </info>
   
@@ -25,23 +25,15 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
   </define>
 
-  <include ref="./CRD_Dimensions_v01_02.xml"/>
+  <include ref="./CRD_Dimensions_v01_01.xml"/>
 
   <include ref="../CRD_common_v01/Beampipe_v01_01.xml"/>
   <include ref="../CRD_common_v01/VXD_v01_01.xml"/>
   <include ref="../CRD_common_v01/FTD_SkewRing_v01_01.xml"/>
   <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
   <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
-  <include ref="../CRD_common_v01/SET_SimplePlanar_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
-  <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->
-  <!--include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Hcal_Rpc_Barrel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Hcal_Rpc_Endcaps_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Yoke_Barrel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Yoke_Endcaps_v01_01.xml"/-->
-  <!--include ref="../CRD_common_v01/Lcal_v01_01.xml"/-->
-
+  <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
+  
   <fields>
     <field name="InnerSolenoid" type="solenoid"
            inner_field="Field_nominal_value"

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01.xml
@@ -3,7 +3,7 @@
        xmlns:xs="http://www.w3.org/2001/XMLSchema"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
   <info name="CRD_o1_v01"
-        title="CepC reference detctor with coil inside Hcal, strip SIT"
+        title="CepC reference detctor with coil inside Hcal, pixel SIT/SET"
         author="C.D.Fu, "
         url="http://cepc.ihep.ac.cn"
         status="developing"
@@ -29,20 +29,19 @@
 
   <include ref="../CRD_common_v01/Beampipe_v01_01.xml"/>
   <include ref="../CRD_common_v01/VXD_v01_01.xml"/>
-  <include ref="../CRD_common_v01/FTD_SimpleStaggered_v01_01.xml"/>
-  <!--<include ref="../CRD_common_v01/SIT_SimplePlanar_v01_01.xml"/> -->
+  <include ref="../CRD_common_v01/FTD_SkewRing_v01_01.xml"/>
+  <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
   <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
-<!--  <include ref="../CRD_common_v01/SET_SimplePlanar_v01_01.xml"/> -->
-<!--  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/> -->
+  <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
   <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->
-  <include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>
+  <!--include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>
   <include ref="../CRD_common_v01/Hcal_Rpc_Barrel_v01_01.xml"/>
   <include ref="../CRD_common_v01/Hcal_Rpc_Endcaps_v01_01.xml"/>
-  <!--include ref="../CRD_common_v01/Hcal_Rpc_EndcapRing_v01_01.xml"/-->
   <include ref="../CRD_common_v01/Yoke_Barrel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Yoke_Endcaps_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Yoke_Endcaps_v01_01.xml"/-->
   <!--include ref="../CRD_common_v01/Lcal_v01_01.xml"/-->
-
+  
   <fields>
     <field name="InnerSolenoid" type="solenoid"
            inner_field="Field_nominal_value"

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
@@ -17,6 +17,8 @@
   <define>
     <constant name="CrossingAngle" value="0.033*rad"/>  
 
+    <constant name="Global_endcap_costheta" value="0.99"/>
+
     <constant name="GlobalTrackerReadoutID_DCH" type="string" value="system:8,chamber:1,layer:7,phi:16"/>
     <constant name="GlobalTrackerReadoutID" type="string" value="system:5,side:-2,layer:9,module:8,sensor:8,barrelside:-2"/>
 
@@ -32,7 +34,7 @@
     <constant name="DetID_TPC"          value="  4"/>
     <constant name="DetID_SET"          value="  5"/>
     <constant name="DetID_ETD"          value="  6"/>
-    <constant name="DetID_DC"           value="  7"/>
+    <constant name="DetID_DC"           value="  4"/> <!--in order to cheat Clupatra, same as TPC--> 
     
     <constant name="DetID_ECAL"         value=" 20"/>
     <constant name="DetID_ECAL_PLUG"    value=" 21"/>
@@ -82,12 +84,13 @@
     <constant name="Vertex_half_length"  value="200*mm"/>
 
     <constant name="DC_Endcap_dz" value="0.1*mm"/>
-    <constant name="DC_half_length"  value="2225*mm" />
+    <constant name="DC_half_length"  value="2980*mm" />
     <constant name="DC_safe_distance" value="0.02*mm"/>
     <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
     <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
     <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_dz" />
 
+    <!--obselete for single drift chamber-->
     <constant name="InnerTracker_half_length"  value="DC_half_length" />
     <constant name="InnerTracker_inner_radius" value="234*mm"/>
     <constant name="InnerTracker_outer_radius" value="909*mm"/>
@@ -102,12 +105,30 @@
     <constant name="DC_inner_radius" value="DC_chamber_layer_rbegin-SDT_inner_wall_thickness-DC_safe_distance"/>
     <constant name="DC_outer_radius" value="DC_chamber_layer_rend+SDT_outer_wall_thickness+DC_safe_distance"/>
 
+    <constant name="SIT1_inner_radius"   value="230*mm"/>
+    <constant name="SIT2_inner_radius"   value="410*mm"/>
+    <constant name="SIT3_inner_radius"   value="590*mm"/>
+    <constant name="SIT4_inner_radius"   value="770*mm"/>
+    <constant name="SIT1_half_length"    value="461*mm"/>
+    <constant name="SIT2_half_length"    value="691*mm"/>
+    <constant name="SIT3_half_length"    value="1013*mm"/>
+    <constant name="SIT4_half_length"    value="1335*mm"/>
 
-    <constant name="SIT1_inner_radius"   value="140*mm"/>
-    <constant name="SIT1_half_length"    value="368.00*mm"/>
-    <constant name="SIT2_inner_radius"   value="225*mm"/>
-    <constant name="SIT2_half_length"    value="InnerTracker_half_length"/>
+    <constant name="SET_inner_radius"    value="1815*mm"/>
 
+    <constant name="SiTracker_barrel_endcap_gap" value="5*mm"/>
+    <constant name="SiTracker_DC_endcap_gap"     value="10*mm"/>
+    <constant name="SiTracker_endcap_z1" value="SIT1_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z2" value="SIT2_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z3" value="SIT3_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z4" value="SIT4_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z5" value="MainTracker_half_length+SiTracker_DC_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius1" value="SIT1_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius2" value="SIT2_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius3" value="SIT3_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius4" value="SIT4_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius5" value="SET_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <!--obseleted -->
     <constant name="FTD_BeamPipe_cable_clearance"     value="10*mm"/> 
     <constant name="FTD_BeamPipe_gap"     value="15*mm"/>
     <constant name="FTD_InnerTracker_gap" value="5*mm"/>
@@ -124,69 +145,69 @@
     <constant name="TUBE_IPOuterTube_end_radius"  value="BeamPipe_Central_inner_radius+BeamPipe_Al_thickness"/>
     <constant name="TUBE_IPOuterBulge_end_z"      value="BeamPipe_Crotch_zmax"/><!--"BeamPipe_ConeAl_zmax"/-->
     <constant name="TUBE_IPOuterBulge_end_radius" value="BeamPipe_Crotch_zmax*tan(CrossingAngle/2)+BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness"/>
-                             <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
+    <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
 
-    <constant name="Ecal_barrel_inner_radius" value="1800*mm"/>
+    <constant name="Ecal_barrel_inner_radius" value="1900*mm"/>
     <constant name="Ecal_barrel_thickness"    value="280*mm"/>
     <constant name="Ecal_barrel_outer_radius" value="(Ecal_barrel_inner_radius+Ecal_barrel_thickness)/cos(pi/8)"/>
-    <constant name="Ecal_barrel_half_length"  value="2300*mm"/>
+    <constant name="Ecal_barrel_half_length"  value="3350*mm"/>
     <constant name="Ecal_barrel_symmetry"    value="8"/>
-    
-    <constant name="Ecal_endcap_inner_radius" value="340*mm"/>
-    <constant name="Ecal_endcap_outer_radius" value="Ecal_barrel_outer_radius"/>
-    <constant name="Ecal_endcap_zmin"        value="2260*mm"/>
-    <constant name="Ecal_endcap_zmax"        value="2540*mm"/>
+
+    <constant name="Ecal_endcap_inner_radius" value="350*mm"/>
+    <constant name="Ecal_endcap_outer_radius" value="Ecal_barrel_inner_radius+Ecal_barrel_thickness"/>
+    <constant name="Ecal_endcap_zmin"        value="3050*mm"/>
+    <constant name="Ecal_endcap_zmax"        value="3350*mm"/>
     <constant name="Ecal_endcap_symmetry"    value="8"/>
     <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
     <constant name="EcalEndcap_outer_radius" value="Ecal_barrel_outer_radius"/>
     
-    <constant name="Solenoid_inner_radius" value="2260*mm"/>
-    <constant name="Solenoid_outer_radius" value="2560*mm"/>
-    <constant name="Solenoid_half_length" value="3000*mm"/>
-    <constant name="SolenoidCoil_half_length" value="2900*mm"/>
-    <constant name="SolenoidCoil_radius" value="2300*mm"/>
+    <constant name="Solenoid_inner_radius" value="2330*mm"/>
+    <constant name="Solenoid_outer_radius" value="2480*mm"/>
+    <constant name="Solenoid_half_length" value="3830*mm"/>
+    <constant name="SolenoidCoil_half_length" value="3800*mm"/>
+    <constant name="SolenoidCoil_radius" value="2351*mm"/>
     <constant name="SolenoidCoil_center_radius" value="(Solenoid_inner_radius+Solenoid_outer_radius)/2"/>
 
-    <constant name="Hcal_barrel_inner_radius" value="2600*mm"/>
-    <constant name="Hcal_barrel_outer_radius" value="3670.6805372782*mm"/>
-    <constant name="Hcal_barrel_half_length"  value="3000*mm"/>
+    <constant name="Hcal_barrel_inner_radius" value="2530*mm"/>
+    <constant name="Hcal_barrel_outer_radius" value="3610*mm"/>
+    <constant name="Hcal_barrel_half_length"  value="4480*mm"/>
     <constant name="Hcal_barrel_symmetry"    value="8"/>
     
-    <constant name="Hcal_endcap_inner_radius" value="340*mm"/>
+    <constant name="Hcal_endcap_inner_radius" value="400*mm"/>
     <constant name="Hcal_endcap_outer_radius" value="Hcal_barrel_outer_radius"/>
-    <constant name="Hcal_endcap_zmin" value="3010*mm"/>
-    <constant name="Hcal_endcap_zmax" value="4094.2*mm"/>
+    <constant name="Hcal_endcap_zmin" value="3400*mm"/>
+    <constant name="Hcal_endcap_zmax" value="4480*mm"/>
     <constant name="Hcal_endcap_symmetry" value="8"/>
     <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
     <constant name="HcalEndcap_max_z" value="Hcal_endcap_zmax"/>
     <constant name="Hcal_endcap_outer_symmetry" value="Hcal_endcap_symmetry"/>
     <constant name="Hcal_outer_radius" value="Hcal_barrel_outer_radius"/>
 
-    <constant name="Hcal_ring_inner_radius" value="Hcal_endcap_inner_radius"/>
+    <!--constant name="Hcal_ring_inner_radius" value="Hcal_endcap_inner_radius"/>
     <constant name="Hcal_ring_outer_radius" value="Solenoid_inner_radius"/>
     <constant name="Hcal_ring_zmin" value="2600*mm"/>
     <constant name="Hcal_ring_zmax" value="Hcal_endcap_zmin-10*mm"/>
-    <constant name="Hcal_ring_symmetry" value="8"/>
+    <constant name="Hcal_ring_symmetry" value="8"/-->
         
-    <constant name="Yoke_barrel_inner_radius" value="3710*mm"/>
-    <constant name="Yoke_barrel_outer_radius" value="6951*mm"/>
+    <constant name="Yoke_barrel_inner_radius" value="3660*mm"/>
+    <constant name="Yoke_barrel_outer_radius" value="4260*mm"/>
     <constant name="Yoke_barrel_half_length" value="Hcal_endcap_zmax"/>
     <constant name="Yoke_barrel_symmetry" value="8"/>
     
     <constant name="Yoke_endcap_inner_radius" value="400*mm"/>
     <constant name="Yoke_endcap_outer_radius" value="Yoke_barrel_outer_radius"/>
-    <constant name="Yoke_endcap_zmin" value="Yoke_barrel_half_length+25*mm"/>
-    <constant name="Yoke_endcap_zmax" value="6750*mm"/>
+    <constant name="Yoke_endcap_zmin" value="4660*mm"/>
+    <constant name="Yoke_endcap_zmax" value="5460*mm"/>
     <constant name="Yoke_endcap_outer_symmetry" value="8"/>
     <constant name="Yoke_endcap_inner_symmetry" value="0"/>
     <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
     <constant name="Yoke_Z_start_endcaps" value="Yoke_endcap_zmin"/>
     
-    <constant name="LumiCal_zmax" value="805*mm" />
+    <!--constant name="LumiCal_zmax" value="805*mm" />
     <constant name="LumiCal_zmin" value="700*mm"/>
     <constant name="LumiCal_thickness" value="(LumiCal_zmax-LumiCal_zmin)/2.0"/>
     <constant name="LumiCal_inner_radius" value="35.0*mm"/>
-    <constant name="LumiCal_outer_radius" value="100.0*mm- env_safety"/>
+    <constant name="LumiCal_outer_radius" value="100.0*mm- env_safety"/-->
         
     <constant name="tracker_region_zmax" value="OuterTracker_half_length"/>
     <constant name="tracker_region_rmax" value="OuterTracker_outer_radius"/>
@@ -215,17 +236,24 @@
     <vis name="VXDVis"           alpha="0.1" r="0.1"   g=".5"      b=".5"    showDaughters="true"  visible="true"/>
     <vis name="VXDLayerVis"      alpha="1.0" r="0.1"   g=".5"      b=".5"    showDaughters="true"  visible="true"/>
     <vis name="VXDSupportVis"    alpha="1.0" r="0.0"   g="1.0"     b="0.0"   showDaughters="true"  visible="true"/>
-    <vis name="FTDVis"           alpha="1.0" r="0.0"   g="0.1"     b="0.0"   showDaughters="true"  visible="false"/>
-    <vis name="FTDSensitiveVis"  alpha="1.0" r="1.0"   g="1.0"     b="0.45"  showDaughters="true" visible="true"/>
-    <vis name="FTDSupportVis"    alpha="1.0" r="1.0"   g="0.5"     b="0.5"   showDaughters="true" visible="true"/>
-    <vis name="SITVis"           alpha="1.0" r="0.54"  g="0.43"    b="0.04"  showDaughters="true"  visible="true"/>
-    <vis name="SETVis"           alpha="1.0" r="0.8"   g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
+    <vis name="FTDVis"           alpha="1.0" r="0.5"   g="0.87"    b="0.11"  showDaughters="true"  visible="true"/>
+    <vis name="FTDSupportVis"    alpha="1.0" r="0.3"   g="0.3"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="FTDSensitiveVis"  alpha="1.0" r="0.3"   g="0.5"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="DCVis"            alpha="1.0" r="0.96"  g="0.64"    b="0.90"  showDaughters="true"  visible="true"/>
+    <vis name="DCLayerVis"       alpha="1.0" r="0.96"  g="0.64"    b="0.90"  showDaughters="false" visible="true"/>
+    <vis name="SITVis"           alpha="0.0" r="0.54"  g="0.59"    b="0.93"  showDaughters="true"  visible="false"/>
+    <vis name="SITSupportVis"    alpha="1.0" r="0.0"   g="0.0"     b="1.0"   showDaughters="false" visible="true"/>
+    <vis name="SITSensitiveVis"  alpha="1.0" r="0.67"  g="0.99"    b="0.78"  showDaughters="false" visible="true"/>
+    <vis name="SETVis"           alpha="0.0" r="0.8"   g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
+    <vis name="SETSupportVis"    alpha="1.0" r="1.0"   g="0.0"     b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="SETSensitiveVis"  alpha="1.0" r="0.0"   g="0.0"     b="1.0"   showDaughters="true"  visible="true"/>
     <vis name="ECALVis"          alpha="1.0" r="0.2"   g="0.6"     b="0"     showDaughters="true"  visible="true"/>
-    <vis name="HCALVis"          alpha="1.0" r="0.078" g="0.01176" b="0.588" showDaughters="true"  visible="true"/>
+    <vis name="HCALVis"          alpha="1.0" r="0.95"  g="0.78"    b="0.69"  showDaughters="true"  visible="true"/>
     <vis name="SOLVis"           alpha="1.0" r="0.4"   g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
-    <vis name="YOKEVis"          alpha="1.0" r="0.6"   g="0.0"     b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="YOKEVis"          alpha="1.0" r="0.64"  g="0.75"    b="0.99"  showDaughters="false" visible="true"/>
     <vis name="LCALVis"          alpha="1.0" r="0.25"  g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
-    <vis name="SupportVis"       alpha="1.0" r="0.2"   g="0.2"     b="0.2"   showDaughters="true" visible="true"/>
+    <vis name="SupportVis"       alpha="1.0" r="0.2"   g="0.2"     b="0.2"   showDaughters="true"  visible="true"/>
+    <vis name="ShellVis"         alpha="1.0" r="0.83"  g="0.55"    b="0.89"  showDaughters="false" visible="true"/>
 
     <vis name="WhiteVis"         alpha="0.0" r=".96" g=".96"  b=".96"   showDaughters="true"  visible="true"/>
     <vis name="LightGrayVis"     alpha="0.0" r=".75" g=".75"  b=".75"   showDaughters="true"  visible="true"/>

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02-onlyTracker.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02-onlyTracker.xml
@@ -33,14 +33,6 @@
   <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
   <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
   <include ref="../CRD_common_v01/SET_SimplePlanar_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
-  <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->
-  <!--include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Hcal_Rpc_Barrel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Hcal_Rpc_Endcaps_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Yoke_Barrel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/Yoke_Endcaps_v01_01.xml"/-->
-  <!--include ref="../CRD_common_v01/Lcal_v01_01.xml"/-->
 
   <fields>
     <field name="InnerSolenoid" type="solenoid"

--- a/Detector/DetCRD/compact/README.md
+++ b/Detector/DetCRD/compact/README.md
@@ -4,8 +4,8 @@ The following CRD detector models are available in CEPCSW
 
 | Model         |  Description                 | MainTracker |  Ecal   | Hcal | Status         |
 | ------------- | -----------------------------|------------ |---------|------|----------------|
-| CRD_o1_v01    | coil inside simulation model | DC          | crystal | RPC  | developing     |
-| CRD_o1_v02    | pixel SIT                    | DC          | crystal | RPC  | developing     |
+| CRD_o1_v01    | coil inside simulation model | SIT+DC+SET  | crystal | RPC  | developing     |
+| CRD_o1_v02    | pixel SET                    | SIT+DC+SET  | crystal | RPC  | developing     |
 | ------------- | -----------------------------|-------------|---------|------|----------------|
  
 ## Details
@@ -20,13 +20,13 @@ The following CRD detector models are available in CEPCSW
          - Detector/DetCEPCv4/src/tracker/VXD04_geo.cpp
          - Detector/DetCEPCv4/src/tracker/SIT_Simple_Planar_geo.cpp
  - MainTracker
-         - with Dirft Chamber + silicon layer between inner and outer chambers (DC + SIT34 + SET)
-         - DC_outer_radius = 1716*mm
+         - with Dirft Chamber + pixel silicon layer between inner and outer chambers (SIT1234 + DC + SET)
+         - DC_outer_radius = 1800*mm for maximum sensitive gas 
          - Detector/DetDriftChamber/src/driftchamber/DriftChamber.cpp
-         - Detector/DetCEPCv4/src/tracker/SET_Simple_Planar_geo.cpp  
+         - Detector/DetCEPCv4/src/tracker/SIT_Simple_Pixel_geo.cpp  
  - EndcapTracker
-         - with silicon pestals (FTDPixel + FTDStrip)
-         - Detector/DetCEPCv4/src/tracker/FTD_Simple_Staggered_geo.cpp
+         - with silicon pestals (FTDPixel)
+         - Detector/DetCRD/src/Tracker/SiTrackerSkewRing_v01_geo.cpp
  - Ecal
          - with crystal 
          - Detector/DetCRD/src/Calorimeter/CRDEcal.cpp
@@ -43,10 +43,6 @@ The following CRD detector models are available in CEPCSW
 
 ### CRD_o1_v02 (to update)
  - based on CRD_o1_v01
- - SIT:   strip -> pixel
- - SIT12->SIT1: r = 152.90  -> 140.00 mm (pixel SIT1)
- - SIT34->SIT2: between DCs -> 225.00 mm (pixel SIT2)
- - SET12: outside DC -> between DCs
- - SET34: outside DC (added)
+ - strip SET: double layers
  - compact files:
          - [./CRD_o1_v02/CRD_o1_v02.xml](./CRD_o1_v02/CRD_o1_v02.xml)

--- a/Detector/DetCRD/scripts/CRD_o1_v01-SimRec.py
+++ b/Detector/DetCRD/scripts/CRD_o1_v01-SimRec.py
@@ -14,7 +14,9 @@ rndmengine.Seeds = seed
 rndmgensvc = RndmGenSvc("RndmGenSvc")
 rndmgensvc.Engine = rndmengine.name()
 
-geometry_option = "CRD_o1_v01/CRD_o1_v01.xml"
+# option for standalone tracker study 
+geometry_option = "CRD_o1_v01/CRD_o1_v01-onlyTracker.xml"
+#geometry_option = "CRD_o1_v01/CRD_o1_v01.xml"
 
 if not os.getenv("DETCRDROOT"):
     print("Can't find the geometry. Please setup envvar DETCRDROOT." )
@@ -42,8 +44,8 @@ gun = GtGunTool("GtGunTool")
 gun.Particles = ["mu-"]
 gun.EnergyMins = [100.] # GeV
 gun.EnergyMaxs = [100.] # GeV
-gun.ThetaMins  = [0]    # deg
-gun.ThetaMaxs  = [180]  # deg
+gun.ThetaMins  = [85]    # deg
+gun.ThetaMaxs  = [85]  # deg
 gun.PhiMins    = [0]    # deg
 gun.PhiMaxs    = [360]  # deg
 # stdheprdr = StdHepRdr("StdHepRdr")
@@ -91,14 +93,14 @@ gearsvc = GearSvc("GearSvc")
 from Configurables import TrackSystemSvc
 tracksystemsvc = TrackSystemSvc("TrackSystemSvc")
 
+# digitization
 vxdhitname  = "VXDTrackerHits"
 sithitname  = "SITTrackerHits"
-sitspname   = "SITSpacePoints"
-tpchitname  = "TPCTrackerHits"
+dchitname   = "DCTrackerHits"
 sethitname  = "SETTrackerHits"
 setspname   = "SETSpacePoints"
-ftdspname   = "FTDSpacePoints"
 ftdhitname  = "FTDTrackerHits"
+ftdspname   = "FTDSpacePoints"
 from Configurables import PlanarDigiAlg
 digiVXD = PlanarDigiAlg("VXDDigi")
 digiVXD.SimTrackHitCollection = "VXDCollection"
@@ -109,49 +111,42 @@ digiVXD.UsePlanarTag = True
 #digiVXD.OutputLevel = DEBUG
 
 digiSIT = PlanarDigiAlg("SITDigi")
-digiSIT.IsStrip = True
+digiSIT.IsStrip = False
 digiSIT.SimTrackHitCollection = "SITCollection"
 digiSIT.TrackerHitCollection = sithitname
 digiSIT.TrackerHitAssociationCollection = "SITTrackerHitAssociation"
-digiSIT.ResolutionU = [0.007]
-digiSIT.ResolutionV = [0.000]
+digiSIT.ResolutionU = [0.0072]
+digiSIT.ResolutionV = [0.086]
 digiSIT.UsePlanarTag = True
 #digiSIT.OutputLevel = DEBUG
 
 digiSET = PlanarDigiAlg("SETDigi")
-digiSET.IsStrip = True
+digiSET.IsStrip = False
 digiSET.SimTrackHitCollection = "SETCollection"
 digiSET.TrackerHitCollection = sethitname
 digiSET.TrackerHitAssociationCollection = "SETTrackerHitAssociation"
-digiSET.ResolutionU = [0.007]
-digiSET.ResolutionV = [0.000]
+digiSET.ResolutionU = [0.0072]
+digiSET.ResolutionV = [0.086]
 digiSET.UsePlanarTag = True
 #digiSET.OutputLevel = DEBUG
 
 digiFTD = PlanarDigiAlg("FTDDigi")
+digiFTD.IsStrip = False
 digiFTD.SimTrackHitCollection = "FTDCollection"
 digiFTD.TrackerHitCollection = ftdhitname
 digiFTD.TrackerHitAssociationCollection = "FTDTrackerHitAssociation"
-digiFTD.ResolutionU = [0.003, 0.003, 0.007, 0.007, 0.007, 0.007, 0.007, 0.007]
-digiFTD.ResolutionV = [0.003, 0.003, 0,     0,     0,     0,     0,     0    ]
+digiFTD.ResolutionU = [0.003, 0.003, 0.0072, 0.0072, 0.0072, 0.0072, 0.0072]
+digiFTD.ResolutionV = [0.003, 0.003, 0.0072, 0.0072, 0.0072, 0.0072, 0.0072]
 digiFTD.UsePlanarTag = True
 #digiFTD.OutputLevel = DEBUG
 
+from Configurables import DCHDigiAlg
+digiDC = DCHDigiAlg("DCHDigi")
+digiDC.DigiDCHitCollection = dchitname
+#digiDC.OutputLevel = DEBUG
+
+# two strip tracker hits -> one space point
 from Configurables import SpacePointBuilderAlg
-spSIT = SpacePointBuilderAlg("SITBuilder")
-spSIT.TrackerHitCollection = sithitname
-spSIT.TrackerHitAssociationCollection = "SITTrackerHitAssociation"
-spSIT.SpacePointCollection = sitspname
-spSIT.SpacePointAssociationCollection = "SITSpacePointAssociation"
-#spSIT.OutputLevel = DEBUG
-
-spSET = SpacePointBuilderAlg("SETBuilder")
-spSET.TrackerHitCollection = sethitname
-spSET.TrackerHitAssociationCollection = "SETTrackerHitAssociation"
-spSET.SpacePointCollection = setspname
-spSET.SpacePointAssociationCollection = "SETSpacePointAssociation"
-#spSET.OutputLevel = DEBUG
-
 spFTD = SpacePointBuilderAlg("FTDBuilder")
 spFTD.TrackerHitCollection = ftdhitname
 spFTD.TrackerHitAssociationCollection = "FTDTrackerHitAssociation"
@@ -159,14 +154,15 @@ spFTD.SpacePointCollection = ftdspname
 spFTD.SpacePointAssociationCollection = "FTDSpacePointAssociation"
 #spFTD.OutputLevel = DEBUG
 
+# tracking
 from Configurables import SiliconTrackingAlg
 tracking = SiliconTrackingAlg("SiliconTracking")
 tracking.HeaderCol = "EventHeader"
 tracking.VTXHitCollection = vxdhitname
-tracking.SITHitCollection = sitspname
+tracking.SITHitCollection = sithitname
 tracking.FTDPixelHitCollection = ftdhitname
 tracking.FTDSpacePointCollection = ftdspname
-tracking.SITRawHitCollection = sithitname
+tracking.SITRawHitCollection = "NotNeedForPixelSIT"
 tracking.FTDRawHitCollection = ftdhitname
 tracking.UseSIT = True
 tracking.SmoothOn = False
@@ -189,31 +185,38 @@ forward.CriteriaMax = [30, 1.02, 10, 1.015, 20, 1.3, 1.0, 150, 1.08,  99999999, 
 from Configurables import TrackSubsetAlg
 subset = TrackSubsetAlg("TrackSubset")
 subset.TrackInputCollections = ["ForwardTracks", "SiTracks"]
-subset.RawTrackerHitCollections = [vxdhitname, sithitname, ftdhitname, sitspname, ftdspname]
+subset.RawTrackerHitCollections = [vxdhitname, sithitname, ftdhitname, ftdspname]
 subset.TrackSubsetCollection = "SubsetTracks"
 #subset.OutputLevel = DEBUG
 
-#TODO: DC reconstruction
+#TODO: DC reconstruction, as preliminary, use Clupatra like as TPC
+from Configurables import ClupatraAlg
+clupatra = ClupatraAlg("Clupatra")
+clupatra.TPCHitCollection = dchitname
+clupatra.DistanceCut = 100.
+clupatra.MaxDeltaChi2 = 100.
+clupatra.Chi2Cut = 150.
+#clupatra.OutputLevel = DEBUG
 
 from Configurables import FullLDCTrackingAlg
 full = FullLDCTrackingAlg("FullTracking")
 full.VTXTrackerHits = vxdhitname
-full.SITTrackerHits = sitspname
-full.TPCTrackerHits = "NULL" # add TPC or DC tracker hit here, if TPC or DC track is set by full.TPCTracks
-full.SETTrackerHits = setspname
+full.SITTrackerHits = sithitname
+full.TPCTrackerHits = dchitname # add TPC or DC tracker hit here, if TPC or DC track is set by full.TPCTracks
+full.SETTrackerHits = sethitname
 full.FTDPixelTrackerHits = ftdhitname
 full.FTDSpacePoints = ftdspname
-full.SITRawHits     = sithitname
-full.SETRawHits     = sethitname
+full.SITRawHits     = "NotNeedForPixelSIT"
+full.SETRawHits     = "NotNeedForPixelSET"
 full.FTDRawHits     = ftdhitname
-full.TPCTracks = "NULL" # add standalone TPC or DC track here
+full.TPCTracks = "ClupatraTracks" # add standalone TPC or DC track here
 full.SiTracks  = "SubsetTracks"
 full.OutputTracks  = "MarlinTrkTracks"
 full.SITHitToTrackDistance = 3.
 full.SETHitToTrackDistance = 5.
 #full.OutputLevel = DEBUG
 
-#TODO: more reconstruction, PFA etc. 
+#TODO: more reconstruction, PFA etc.
 
 # output
 from Configurables import PodioOutput
@@ -224,7 +227,8 @@ out.outputCommands = ["keep *"]
 # ApplicationMgr
 from Configurables import ApplicationMgr
 ApplicationMgr(
-    TopAlg = [genalg, detsimalg, digiVXD, digiSIT, digiSET, digiFTD, spSIT, spSET, spFTD, tracking, forward, subset, full, out],
+    #TopAlg = [genalg, detsimalg, digiVXD, digiSIT, digiSET, digiFTD, spFTD, digiDC, tracking, forward, subset, clupatra, full, out],
+    TopAlg = [genalg, detsimalg, digiVXD, digiSIT, digiSET, digiFTD, spFTD, digiDC, tracking, forward, subset, full, out],
     EvtSel = 'NONE',
     EvtMax = 10,
     ExtSvc = [rndmengine, rndmgensvc, dsvc, evtseeder, geosvc, gearsvc, tracksystemsvc],

--- a/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
@@ -458,7 +458,7 @@ StatusCode ClupatraAlg::execute() {
 			sclu.setOwner() ;
 
 			// FIXME Mingrui
-			//streamlog_out( DEBUG2 ) << "   call cluster_sorted with " <<  hits.size() << " hits " << std::endl ;
+			debug() << "   call cluster_sorted with " <<  hits.size() << " hits " << endmsg;
 
 			nncl.cluster_sorted( hits.begin(), hits.end() , std::back_inserter( sclu ), dist , _minCluSize ) ;
 
@@ -491,7 +491,7 @@ StatusCode ClupatraAlg::execute() {
 			} //------------------------------------------------------------------------------------------
 
 			// FIXME Mingrui
-			// debug()  << "     found " <<  sclu.size() << "  clusters " << std::endl ;
+			debug()  << "     found " <<  sclu.size() << "  clusters " << endmsg;
 
 			// try to split up clusters according to multiplicity
 			int layerWithMultiplicity = _padRowRange - 2  ; // fixme: make parameter
@@ -534,15 +534,15 @@ StatusCode ClupatraAlg::execute() {
 
 				int nHitsAdded = 0 ;
 
-				// debug() <<  " call fitter for seed cluster with " << (*icv)->size() << " hits " << endmsg;
-				// int counter = 0;
-				// for( Clusterer::cluster_type::iterator ci=(*icv)->begin(), end= (*icv)->end() ; ci!=end; ++ci ) {
-				// 	debug() << counter++ << " " <<  *((*ci)->first->edm4hepHit) << " \nlayer " << (*ci)->first->layer << endmsg;
-				// }
+				debug() <<  " call fitter for seed cluster with " << (*icv)->size() << " hits " << endmsg;
+				int counter = 0;
+				for( Clusterer::cluster_type::iterator ci=(*icv)->begin(), end= (*icv)->end() ; ci!=end; ++ci ) {
+				  debug() << counter++ << " " <<  (*ci)->first->edm4hepHit << " \nlayer " << (*ci)->first->layer << endmsg;
+				}
 
 
 				MarlinTrk::IMarlinTrack* mTrk = fitter( *icv ) ;
-
+				debug() << "before add hits and filter" << endmsg;
                 // std::vector<std::pair<edm4hep::ConstTrackerHit, double> > hitsInFit ;
                 // mTrk->getHitsInFit( hitsInFit ) ;
                 // for (auto hit : hitsInFit) std::cout << hit.first << std::endl;
@@ -556,15 +556,15 @@ StatusCode ClupatraAlg::execute() {
 
 
 				// drop seed clusters with no hits added - but not in the very forward region...
-				// debug() << "Goes here" << endmsg;
+				debug() << "Goes here" << endmsg;
 				if( nHitsAdded < 1  &&  outerRow >   2*_padRowRange  ){  //FIXME: make parameter ?
 
 					ConstTrack edm4hepTrk( converter( *icv ) ) ;
 					// debug() << "Goes goes here" << endmsg;
 
 					// FIXME Mingrui
-					//streamlog_out( DEBUG2) << "=============  poor seed cluster - no hits added - started from row " <<  outerRow << "\n"
-					//<< *edm4hepTrk << std::endl ;
+					debug() << "=============  poor seed cluster - no hits added - started from row " <<  outerRow << "\n"
+						<< edm4hepTrk << endmsg;
 
 
 					for( Clusterer::cluster_type::iterator ci=(*icv)->begin(), end= (*icv)->end() ; ci!=end; ++ci ) {

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
@@ -1240,27 +1240,26 @@ start:
 		unsigned nHit = 0 ;
 
 		if( reverse_order ){
-                        // std::cout << "It is true order" << std::endl;
-			for( CluTrack::reverse_iterator it=clu->rbegin() ; it != clu->rend() ; ++it){
-				edm4hep::ConstTrackerHit ph = (*it)->first->edm4hepHit;
-				trk->addHit(ph) ;
-				++nHit ;
-				// std::cout  <<  "   hit  added  " <<  (*it)->first->edm4hepHit   << std::endl ;
-			}
-
-			trk->initialise( MarlinTrk::IMarlinTrack::forward ) ;
+		  //std::cout << "It is true order" << std::endl;
+		  for( CluTrack::reverse_iterator it=clu->rbegin() ; it != clu->rend() ; ++it){
+		    edm4hep::ConstTrackerHit ph = (*it)->first->edm4hepHit;
+		    trk->addHit(ph) ;
+		    ++nHit ;
+		    //std::cout  <<  "   hit  added  " <<  (*it)->first->edm4hepHit   << std::endl ;
+		  }
+		  
+		  trk->initialise( MarlinTrk::IMarlinTrack::forward ) ;
 
 		} else {
+		  //std::cout << "It is reverse order" << std::endl;
+		  for( CluTrack::iterator it=clu->begin() ; it != clu->end() ; ++it){
+		    edm4hep::ConstTrackerHit ph = (*it)->first->edm4hepHit;
+		    trk->addHit(ph) ;
+		    ++nHit ;
+		    //std::cout <<  "   hit  added  "<<  (*it)->first->edm4hepHit   << std::endl ;
+		  }
 
-                        // std::cout << "It is reverse order" << std::endl;
-			for( CluTrack::iterator it=clu->begin() ; it != clu->end() ; ++it){
-				edm4hep::ConstTrackerHit ph = (*it)->first->edm4hepHit;
-				trk->addHit(ph) ;
-				++nHit ;
-				// std::cout <<  "   hit  added  "<<  (*it)->first->edm4hepHit   << std::endl ;
-			}
-
-			trk->initialise( MarlinTrk::IMarlinTrack::backward ) ;
+		  trk->initialise( MarlinTrk::IMarlinTrack::backward ) ;
 		}
 
 		int code = trk->fit(  maxChi2  ) ;


### PR DESCRIPTION
* geometry update
  * change length of DC to 2980mm 
  * 4 layers SIT and one supper layer SET (one pixel or one double-side strip) 
  * CRD_o1_v01: pixel for both SIT and SET
  * CRD_o1_v02: pixel for SIT and strip for SET
* dispaly
  * change some colors
* option
  * update job option to match SIT/SET modification
  * add tracker only geometry option file for tracking study
* note:
  * calorimeters commented out, since overlap exists while changing inner radius of Ecal from 1800mm to 1900mm, will fix in future PR
  * Clupatra for DC commented out, if want to open it, the branch [fucd/CEPCSW/surface-patch](https://github.com/fucd/CEPCSW/tree/surface-patch) is needed extraly. Because current DC hits is not always at the center of cells. This issue will be fixed through merge the `surface-patch` or update the hits in future or import new DC tracking. 
 ![CRD_o1_v01-tracker](https://user-images.githubusercontent.com/12792582/120274804-f55f6800-c2e2-11eb-9719-c14920207a29.png) 
input output check by distributions for silicon (VXD+SIT) only
![pull_subset](https://user-images.githubusercontent.com/12792582/121458409-e0b65a80-c9db-11eb-91b0-869aa39c2902.png)
for silicon+DC combining fit
![pull_full](https://user-images.githubusercontent.com/12792582/121458628-4aceff80-c9dc-11eb-9a51-482121528474.png)
