### PR TITLE
Fixes for compilation with clang12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build.*
+spack*
 ./Generator/output/
 ./Generator/options/

--- a/Analysis/TrackInspect/CMakeLists.txt
+++ b/Analysis/TrackInspect/CMakeLists.txt
@@ -5,6 +5,7 @@ gaudi_add_module(TrackInspect
                  LINK DataHelperLib 
                       Gaudi::GaudiKernel 
                       EDM4HEP::edm4hep 
+                      k4FWCore::k4FWCore
                       ${ROOT_LIBRARIES}
                       ${CLHEP_LIBRARIES}
 )

--- a/Detector/GeomSvc/src/GeomSvc.cpp
+++ b/Detector/GeomSvc/src/GeomSvc.cpp
@@ -125,7 +125,7 @@ const std::map<std::string,double>& GeomSvc::getDetParameters(std::string name){
   if(m_detParameters.find(name)!=m_detParameters.end()) return m_detParameters[name];
   else{
     char message[200];
-    sprintf(message,"GeomSvc has not the parameter set named %s", name); 
+    sprintf(message,"GeomSvc has not the parameter set named %s", name.c_str()); 
     throw std::runtime_error(message);
   }
 }
@@ -136,7 +136,7 @@ double GeomSvc::getDetParameter(std::string set_name, std::string par_name){
     if(it->second.find(par_name)!=it->second.end()) return it->second[par_name];  
   }
   char message[200];
-  sprintf(message,"GeomSvc has not the parameter named %s in set %s", par_name, set_name);
+  sprintf(message,"GeomSvc has not the parameter named %s in set %s", par_name.c_str(), set_name.c_str());
   throw std::runtime_error(message);
 }
 

--- a/Detector/GeomSvc/src/GeomSvc.h
+++ b/Detector/GeomSvc/src/GeomSvc.h
@@ -19,7 +19,6 @@
 #include <gearimpl/ZPlanarParametersImpl.h>
 #include <gearimpl/GearParametersImpl.h>
 
-class dd4hep::DetElement;
 class TGeoNode;
 
 class GeomSvc: public extends<Service, IGeomSvc> {

--- a/Reconstruction/RecGenfitAlg/CMakeLists.txt
+++ b/Reconstruction/RecGenfitAlg/CMakeLists.txt
@@ -19,6 +19,7 @@ gaudi_add_module(RecGenfitAlg
              EDM4HEP::edm4hep
              EDM4HEP::edm4hepDict
              GenFit::genfit2
+             k4FWCore::k4FWCore
 )
 
 target_include_directories(RecGenfitAlg PUBLIC

--- a/Reconstruction/Tracking/CMakeLists.txt
+++ b/Reconstruction/Tracking/CMakeLists.txt
@@ -15,6 +15,7 @@ gaudi_add_module(Tracking
                       ${LCIO_LIBRARIES}
                       DetSegmentation
                       EDM4HEP::edm4hep EDM4HEP::edm4hepDict
+                      k4FWCore::k4FWCore
 )
 
 target_include_directories(Tracking PUBLIC

--- a/Service/GearSvc/src/GearSvc.h
+++ b/Service/GearSvc/src/GearSvc.h
@@ -4,7 +4,6 @@
 #include "GearSvc/IGearSvc.h"
 #include <GaudiKernel/Service.h>
 #include "DD4hep/Detector.h"
-class dd4hep::DetElement;
 class TGeoNode;
 
 class GearSvc : public extends<Service, IGearSvc>

--- a/Simulation/DetSimAna/CMakeLists.txt
+++ b/Simulation/DetSimAna/CMakeLists.txt
@@ -8,6 +8,7 @@ gaudi_add_module(DetSimAna
                       ${DD4hep_COMPONENT_LIBRARIES} 
                       Gaudi::GaudiKernel
                       EDM4HEP::edm4hep EDM4HEP::edm4hepDict
+                      k4FWCore::k4FWCore
 )
 
 install(TARGETS DetSimAna

--- a/Simulation/DetSimCore/CMakeLists.txt
+++ b/Simulation/DetSimCore/CMakeLists.txt
@@ -20,6 +20,7 @@ gaudi_add_module(DetSimCore
                       Gaudi::GaudiKernel
                       ${Geant4_LIBRARIES}
                       ${DD4hep_COMPONENT_LIBRARIES} 
+                      k4FWCore::k4FWCore
                       EDM4HEP::edm4hep EDM4HEP::edm4hepDict
 )
 

--- a/Utilities/KalDet/CMakeLists.txt
+++ b/Utilities/KalDet/CMakeLists.txt
@@ -72,6 +72,8 @@ gaudi_add_library(KalDetLib
                        ${GEAR_LIBRARIES} 
                        EDM4HEP::edm4hep EDM4HEP::edm4hepDict
                        ${DD4hep_COMPONENT_LIBRARIES}
+                       GenFit::genfit2
+
 )
 
 install(TARGETS KalDetLib


### PR DESCRIPTION
Some small fixes specific to the compilation with clang12:

* Adds some missing linking targets to avoid genconf error
* Fixes an error with string conversion for sprintf (Probably framework logging could be used here, I'll take a look at that)
* Remove some forward declarations of DD4hep::DetElement since the header where it is declared is included before

Also:
* git-ignore spack files and directories ( useful for `spack dev-build` )