### PR TITLE
REC: fix bug for very large phi value and spend much CPU time

### DIFF
--- a/Reconstruction/Tracking/include/Tracking/TrackingHelper.h
+++ b/Reconstruction/Tracking/include/Tracking/TrackingHelper.h
@@ -28,22 +28,29 @@ inline edm4hep::TrackState getTrackStateAt(edm4hep::ConstTrack track, int locati
 }
 
 inline std::array<float,15> getCovMatrix(const edm4hep::ConstTrack &track) {
-    return track.getTrackStates(0).covMatrix;
+  if(track.trackStates_size()>0) return track.getTrackStates(0).covMatrix;
+  std::array<float,15> dummy{};
+  return dummy;
 }
 inline float getTanLambda(const edm4hep::ConstTrack &track) {
-    return track.getTrackStates(0).tanLambda;
+  if(track.trackStates_size()>0) return track.getTrackStates(0).tanLambda;
+  return 0;
 }
 inline float getOmega(const edm4hep::ConstTrack &track) {
-    return track.getTrackStates(0).omega;
+  if(track.trackStates_size()>0) return track.getTrackStates(0).omega;
+  return 0;
 }
 inline float getD0(const edm4hep::ConstTrack &track) {
-    return track.getTrackStates(0).D0;
+  if(track.trackStates_size()>0) return track.getTrackStates(0).D0;
+  return 0;
 }
 inline float getZ0(const edm4hep::ConstTrack &track) {
-    return track.getTrackStates(0).Z0;
+  if(track.trackStates_size()>0) return track.getTrackStates(0).Z0;
+  return 0;
 }
 inline float getPhi(const edm4hep::ConstTrack &track) {
-    return track.getTrackStates(0).phi;
+  if(track.trackStates_size()>0) return track.getTrackStates(0).phi;
+  return 0;
 }
 
 

--- a/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
@@ -233,7 +233,7 @@ StatusCode ClupatraAlg::initialize() {
 StatusCode ClupatraAlg::execute() {
 
 
-	debug() << "Clupatra Algorithm started" << endmsg;
+  info() << "Clupatra Algorithm started" << endmsg;
 
 	//  clock_t start =  clock() ;
 	Timer timer ;
@@ -537,7 +537,7 @@ StatusCode ClupatraAlg::execute() {
 				debug() <<  " call fitter for seed cluster with " << (*icv)->size() << " hits " << endmsg;
 				int counter = 0;
 				for( Clusterer::cluster_type::iterator ci=(*icv)->begin(), end= (*icv)->end() ; ci!=end; ++ci ) {
-				  debug() << counter++ << " " <<  (*ci)->first->edm4hepHit << " \nlayer " << (*ci)->first->layer << endmsg;
+				  debug() << counter++ << " " <<  (*ci)->first->edm4hepHit.id() << " layer " << (*ci)->first->layer << endmsg;
 				}
 
 
@@ -562,9 +562,8 @@ StatusCode ClupatraAlg::execute() {
 					ConstTrack edm4hepTrk( converter( *icv ) ) ;
 					// debug() << "Goes goes here" << endmsg;
 
-					// FIXME Mingrui
-					debug() << "=============  poor seed cluster - no hits added - started from row " <<  outerRow << "\n"
-						<< edm4hepTrk << endmsg;
+					debug() << "=============  poor seed cluster - no hits added - started from row " <<  outerRow << " track id="
+						<< edm4hepTrk.id() << endmsg;
 
 
 					for( Clusterer::cluster_type::iterator ci=(*icv)->begin(), end= (*icv)->end() ; ci!=end; ++ci ) {

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
@@ -288,7 +288,7 @@ namespace clupatra_new{
 		encoder[UTIL::ILDCellID0::subdet] = UTIL::ILDDetID::TPC ;
 
 		edm4hep::ConstTrackerHit firstHit; // =  0 ;
-                firstHit.unlink();
+                //firstHit.unlink();
 
 		IMarlinTrack* bwTrk = 0 ;
 
@@ -1354,11 +1354,18 @@ start:
 					//IMPL::TrackerHitImpl* thi = dynamic_cast<IMPL::TrackerHitImpl*> ( hitsInFit[i].first ) ;
 					//thi->setQualityBit( UTIL::ILDTrkHitQualityBit::USED_IN_FIT , 1 )  ;
 				}
-
-				edm4hep::TrackState tsIP;
-				edm4hep::TrackState tsFH;
-				edm4hep::TrackState tsLH;
-				edm4hep::TrackState tsCA;
+				edm4hep::TrackState tsBase;
+				tsBase.D0 = 0;
+				tsBase.phi = 0;
+				tsBase.omega = 0;
+				tsBase.Z0 = 0;
+				tsBase.tanLambda = 0;
+				tsBase.referencePoint = edm4hep::Vector3f(0,0,0);
+				tsBase.covMatrix = std::array<float, 15>{};
+				edm4hep::TrackState tsIP(tsBase);
+				edm4hep::TrackState tsFH(tsBase);
+				edm4hep::TrackState tsLH(tsBase);
+				edm4hep::TrackState tsCA(tsBase);
 
 				tsIP.location = lcio::TrackState::AtIP;
 				tsFH.location = lcio::TrackState::AtFirstHit;
@@ -1385,10 +1392,9 @@ start:
 				code = mtrk->getTrackState( fHit, tsFH, chi2, ndf ) ;
 
 				if( code != MarlinTrk::IMarlinTrack::success ){
-
-					   std::cout << "  >>>>>>>>>>> PLCIOTrackConverter :  could not get TrackState at first Hit !!?? "
-					   << " error code : " << MarlinTrk::errorCode( code )
-					   << std::endl ;
+				  //std::cout << "  >>>>>>>>>>> PLCIOTrackConverter :  could not get TrackState at first Hit !!?? "
+				  //	    << " error code : " << MarlinTrk::errorCode( code )
+				  //	    << std::endl ;
 				}
 
 				// ======= get TrackState at last hit  ========================
@@ -1398,17 +1404,17 @@ start:
 #if use_fit_at_last_hit
 				code = mtrk->getTrackState( lHit, tsLH, chi2, ndf ) ;
 #else     // get the track state at the last hit by propagating from the last(first) constrained fit position (a la MarlinTrkUtils)
-				edm4hep::ConstTrackerHit last_constrained_hit;
+				edm4hep::ConstTrackerHit last_constrained_hit(0);
 				code = mtrk->getTrackerHitAtPositiveNDF( last_constrained_hit );
-				mtrk->smooth() ;
+				//code = mtrk->smooth() ;
 				if( code != MarlinTrk::IMarlinTrack::success ){
-				  std::cout << "last_constrained_hit is unavaibale" << std::endl;
+				  //std::cout << "last_constrained_hit is avaibale? " << last_constrained_hit.isAvailable() << std::endl;
 				}
-				else{
+				//else{
 // std::cout << "the hit" << std::endl;
 // std::cout << lHit.getCellID0() << std::endl;
 // std::cout << last_constrained_hit << std::endl;
-				//code = mtrk->smooth() ;
+				  code = mtrk->smooth() ;
 // std::cout << "Smooth success" << std::endl;
 				// gear::Vector3D last_hit_pos( lHit->getPosition()[0], lHit->getPosition()[1], lHit->getPosition()[2] );
 // std::cout << "lHit = " << lHit << std::endl;
@@ -1420,14 +1426,13 @@ start:
 				  edm4hep::Vector3d last_hit_pos( lHit.getPosition() );
 // std::cout << "lHit = " << lHit << std::endl;
 				  code = mtrk->propagate( last_hit_pos, last_constrained_hit, tsLH, chi2, ndf);
-                                } 
+				  //}
 // std::cout << "Propagate success" << std::endl;
 #endif
 
 // std::cout << "We are here" << std::endl; 
 				if( code != MarlinTrk::IMarlinTrack::success ){
-
-					std::cout << "  >>>>>>>>>>> PLCIOTrackConverter :  could not get TrackState at last Hit !!?? " << std::endl ;
+				  //std::cout << "  >>>>>>>>>>> PLCIOTrackConverter :  could not get TrackState at last Hit !!?? " << std::endl ;
 				}
 
 				// ======= get TrackState at calo face  ========================
@@ -1459,8 +1464,7 @@ start:
 
 				}
 				if ( code !=MarlinTrk::IMarlinTrack::success ) {
-
-					// streamlog_out( DEBUG6 ) << "  >>>>>>>>>>> PLCIOTrackConverter :  could not get TrackState at calo face !!?? " << std::endl ;
+				  //std::cout << "  >>>>>>>>>>> PLCIOTrackConverter :  could not get TrackState at calo face !!?? " << std::endl ;
 				}
 
 				// ======= get TrackState at IP ========================
@@ -1475,10 +1479,9 @@ start:
 				code = ( UsePropagate ?   mtrk->propagate( ipv, fHit, tsIP, chi2, ndf ) :  mtrk->extrapolate( ipv, tsIP, chi2, ndf ) ) ;
 
 				if( code != MarlinTrk::IMarlinTrack::success ){
-
-					std::cout << "  >>>>>>>>>>> PLCIOTrackConverter :  could not extrapolate TrackState to IP !!?? " << std::endl ;
+				  //std::cout << "  >>>>>>>>>>> PLCIOTrackConverter :  could not extrapolate TrackState to IP !!?? " << std::endl ;
 				}
-
+				//std::cout << "D0 = " << tsLH.D0 << " phi = " << tsLH.phi << " omega = " << tsLH.omega << " Z0 = " << tsLH.Z0 << " tanLambda = " << tsLH.tanLambda << std::endl;
 				trk.addToTrackStates( tsIP ) ;
 				trk.addToTrackStates( tsFH ) ;
 				trk.addToTrackStates( tsLH ) ;

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.h
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.h
@@ -156,8 +156,8 @@ namespace clupatra_new{
 
 				// FIXME debug Mingrui
 				//streamlog_out( DEBUG ) << "  add hit << "  <<   *first << " to layer " <<  (*first)->first->layer  << std::endl ;
-
-				hLV[ (*first)->first->layer ].push_back( *first )  ;
+			  //std::cout << "fucd debug: " << "  add hit << "  <<   *first << " to layer " <<  (*first)->first->layer  << std::endl ;
+			        hLV[ (*first)->first->layer ].push_back( *first )  ;
 				++first ;
 			}
 		}
@@ -437,6 +437,7 @@ namespace clupatra_new{
 
 				// track state at last hit migyt be rubish....
 				//      const lcio::TrackState* ts = ( outward ? trk->getTrackState( lcio::TrackState::AtLastHit  ) : trk->getTrackState( lcio::TrackState::AtFirstHit  ) ) ;
+				if(!hasTrackStateAt(trk, lcio::TrackState::AtFirstHit)) return false; //equivalent to pointer ts ==0 in lcio, fucd
 				const edm4hep::TrackState ts = getTrackStateAt(trk, lcio::TrackState::AtFirstHit  )  ;
 
 
@@ -455,7 +456,7 @@ namespace clupatra_new{
 
 				int nHit = trk.trackerHits_size() ;
 
-				if( nHit == 0 /*|| ts ==0*/ ) // FIXME Mingrui Since it is no pointer
+				if( nHit == 0 /*|| ts ==0*/ ) // FIXME Mingrui Since it is no pointer, fixed previous by hasTrackStateAt, fucd
 					return false ;
 
 				// float initial_chi2 = trk->getChi2() ;

--- a/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.h
+++ b/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.h
@@ -307,7 +307,8 @@ protected:
   
   int SegmentRadialOverlap(TrackExtended* pTracki, TrackExtended* pTrackj);
   bool VetoMerge(TrackExtended* firstTrackExt, TrackExtended* secondTrackExt);
-  
+
+  void checkTrackState(int type=0);
   
   int _nRun ;
   int _nEvt ;

--- a/Service/TrackSystemSvc/include/TrackSystemSvc/IMarlinTrack.h
+++ b/Service/TrackSystemSvc/include/TrackSystemSvc/IMarlinTrack.h
@@ -55,7 +55,7 @@ namespace MarlinTrk{
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */
-    virtual int addHit(edm4hep::ConstTrackerHit hit) = 0 ;
+    virtual int addHit(edm4hep::ConstTrackerHit& hit) = 0 ;
     
     /** initialise the fit using the hits added up to this point -
      *  the fit direction has to be specified using IMarlinTrack::backward or IMarlinTrack::forward. 
@@ -82,12 +82,12 @@ namespace MarlinTrk{
     /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from adding the hit via reference. 
      *  the given hit will not be added if chi2increment > maxChi2Increment. 
      */
-    virtual int addAndFit( edm4hep::ConstTrackerHit hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) = 0 ;
+    virtual int addAndFit( edm4hep::ConstTrackerHit& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) = 0 ;
 
     
     /** obtain the chi2 increment which would result in adding the hit to the fit. This method will not alter the current fit, and the hit will not be stored in the list of hits or outliers
      */
-    virtual int testChi2Increment( edm4hep::ConstTrackerHit hit, double& chi2increment ) = 0 ;
+    virtual int testChi2Increment( edm4hep::ConstTrackerHit& hit, double& chi2increment ) = 0 ;
 
     
     /** smooth all track states 
@@ -97,7 +97,7 @@ namespace MarlinTrk{
     
     /** smooth track states from the last filtered hit back to the measurement site associated with the given hit 
      */
-    virtual int smooth( edm4hep::ConstTrackerHit hit ) = 0 ;
+    virtual int smooth( edm4hep::ConstTrackerHit& hit ) = 0 ;
     
     
     
@@ -110,7 +110,7 @@ namespace MarlinTrk{
     
     /** get track state at measurement associated with the given hit, returning TrackState, chi2 and ndf via reference 
      */
-    virtual int getTrackState( edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
+    virtual int getTrackState( edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
     
     /** get the list of hits included in the fit, together with the chi2 contributions of the hits. 
      *  Pointers to the hits together with their chi2 contribution will be filled into a vector of 
@@ -144,7 +144,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point,
      *  returning TrackState, chi2 and ndf via reference   
      */
-    virtual int propagate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
+    virtual int propagate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
     
     
     /** propagate fit to numbered sensitive layer, returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference 
@@ -154,7 +154,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference 
      */
-    virtual int propagateToLayer(int layerID, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0;
+    virtual int propagateToLayer(int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0;
     
     /** propagate the fit to sensitive detector element, returning TrackState, chi2 and ndf via reference
      */
@@ -163,7 +163,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
      */
-    virtual int propagateToDetElement( int detEementID, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
+    virtual int propagateToDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
     
     
     
@@ -176,7 +176,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point, 
      *  returning TrackState, chi2 and ndf via reference   
      */
-    virtual int extrapolate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
+    virtual int extrapolate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
     
     /** extrapolate the fit to numbered sensitive layer, returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference
      */
@@ -185,7 +185,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference 
      */
-    virtual int extrapolateToLayer( int layerID, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0  ;
+    virtual int extrapolateToLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0  ;
     
     /** extrapolate the fit to sensitive detector element, returning TrackState, chi2 and ndf via reference
      */
@@ -194,7 +194,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
      */
-    virtual int extrapolateToDetElement( int detEementID, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
+    virtual int extrapolateToDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
     
     
     // INTERSECTORS
@@ -207,7 +207,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer,
      *  returning intersection point in global coordinates and integer ID of the intersected sensitive detector element via reference 
      */
-    virtual int intersectionWithLayer( int layerID, edm4hep::ConstTrackerHit hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest ) = 0  ;
+    virtual int intersectionWithLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest ) = 0  ;
     
     
     /** extrapolate the fit to numbered sensitive detector element, returning intersection point in global coordinates via reference 
@@ -217,7 +217,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element,
      *  returning intersection point in global coordinates via reference 
      */
-    virtual int intersectionWithDetElement( int detEementID, edm4hep::ConstTrackerHit hit, edm4hep::Vector3d& point, int mode=modeClosest ) = 0  ;
+    virtual int intersectionWithDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::Vector3d& point, int mode=modeClosest ) = 0  ;
     
     
   protected:

--- a/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
+++ b/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
@@ -76,7 +76,7 @@ namespace MarlinTrk {
   
   
   MarlinKalTestTrack::MarlinKalTestTrack(MarlinKalTest* ktest) 
-  : _ktest(ktest) {
+    : _ktest(ktest), _trackHitAtPositiveNDF(edm4hep::ConstTrackerHit(0)) {
     
     _kaltrack = new TKalTrack() ;
     _kaltrack->SetOwner() ;
@@ -88,7 +88,7 @@ namespace MarlinTrk {
     _fitDirection = false ;
     _smoothed = false ;
     
-    _trackHitAtPositiveNDF = 0;
+    //_trackHitAtPositiveNDF = 0;
     _hitIndexAtPositiveNDF = 0;
     
 #ifdef MARLINTRK_DIAGNOSTICS_ON
@@ -109,27 +109,26 @@ namespace MarlinTrk {
   
   
   
-  int MarlinKalTestTrack::addHit( edm4hep::ConstTrackerHit trkhit) {
+  int MarlinKalTestTrack::addHit( edm4hep::ConstTrackerHit& trkhit) {
     
     return this->addHit( trkhit, _ktest->findMeasLayer( trkhit )) ;
     
   } 
   
-  int MarlinKalTestTrack::addHit( edm4hep::ConstTrackerHit trkhit, const ILDVMeasLayer* ml) {
+  int MarlinKalTestTrack::addHit( edm4hep::ConstTrackerHit& trkhit, const ILDVMeasLayer* ml) {
     //std::cout << "MarlinKalTestTrack::addHit: trkhit = "  << trkhit.id() << " addr: " << trkhit << " ml = " << ml << std::endl ;
     if( trkhit.isAvailable() && ml ) {
       //if(ml){
       return this->addHit( trkhit, ml->ConvertLCIOTrkHit(trkhit), ml) ;
     }
     else {
-      //std::cout << "MarlinKalTestTrack::addHit: trkhit = "  << trkhit.id() << " addr: " << trkhit << " ml = " << ml << std::endl ;
-      //streamlog_out( ERROR ) << " MarlinKalTestTrack::addHit - bad inputs " <<  trkhit << " ml : " << ml << std::endl ;
+      //std::cout << "MarlinKalTestTrack::addHit: - bad inputs trkhit = "  << trkhit.id() << " addr: " << trkhit << " ml = " << ml << std::endl ;
       return bad_intputs ;
     }
     return bad_intputs ;
   }
   
-  int MarlinKalTestTrack::addHit( edm4hep::ConstTrackerHit trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) {
+  int MarlinKalTestTrack::addHit( edm4hep::ConstTrackerHit& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) {
     //std::cout << "MarlinKalTestTrack::addHit: trkhit = "  << trkhit.id() << " ILDVTrackHit: " << kalhit << " ml = " << ml << std::endl ;
     if( kalhit && ml ) {
       //if(ml){
@@ -230,7 +229,7 @@ namespace MarlinTrk {
     }
     
     /*
-    streamlog_out(DEBUG2) << "MarlinKalTestTrack::initialise Create initial helix from hits: \n "
+    std::cout << "DEBUG<<<<MarlinKalTestTrack::initialise Create initial helix from hits: \n "
     << "P1 x = " << x1.x() << " y = " << x1.y() << " z = " << x1.z() << " r = " << x1.Perp() << "\n "
     << "P2 x = " << x2.x() << " y = " << x2.y() << " z = " << x2.z() << " r = " << x2.Perp() << "\n "
     << "P3 x = " << x3.x() << " y = " << x3.y() << " z = " << x3.z() << " r = " << x3.Perp() << "\n "
@@ -289,13 +288,12 @@ namespace MarlinTrk {
     
     _initialised = true ;
     /*
-    streamlog_out( DEBUG2 ) << " track parameters used for init : " << std::scientific << std::setprecision(6) 
+    streamlog_out( DEBUG2 ) << " track parameters used for init : " << std::scientific << std::setprecision(6)
 			    << "\t D0 "          <<  0.0
 			    << "\t Phi :"        <<  toBaseRange( helstart.GetPhi0() + M_PI/2. )
-			    << "\t Omega "       <<  1. /helstart.GetRho() 
+			    << "\t Omega "       <<  1. /helstart.GetRho()
 			    << "\t Z0 "          <<  0.0
 			    << "\t tan(Lambda) " <<  helstart.GetTanLambda()
-      
 			    << "\t pivot : [" << helstart.GetPivot().X() << ", " << helstart.GetPivot().Y() << ", "  << helstart.GetPivot().Z()
 			    << " - r: " << std::sqrt( helstart.GetPivot().X()*helstart.GetPivot().X()+helstart.GetPivot().Y()*helstart.GetPivot().Y() ) << "]"
 			    << std::endl ;
@@ -335,7 +333,7 @@ namespace MarlinTrk {
 
     if (_kalhits->GetEntries() == 0) {
       
-      //streamlog_out( ERROR) << "<<<<<< MarlinKalTestTrack::Initialise: Number of Hits is Zero. Cannot Initialise >>>>>>>" << std::endl;
+      std::cout << "ERROR<<<<<< MarlinKalTestTrack::Initialise: Number of Hits is Zero. Cannot Initialise >>>>>>>" << std::endl;
       return error ;
       
     }
@@ -348,27 +346,25 @@ namespace MarlinTrk {
       
     }
     /*
-    streamlog_out( DEBUG2 ) << "MarlinKalTestTrack::initialise using TrackState: track parameters used for init : "
-    << "\t D0 "          <<  ts.getD0()         
-    << "\t Phi :"        <<  ts.getPhi()        
-    << "\t Omega "       <<  ts.getOmega()      
-    << "\t Z0 "          <<  ts.getZ0()         
-    << "\t tan(Lambda) " <<  ts.getTanLambda()  
-    
-    << "\t pivot : [" << ts.getReferencePoint()[0] << ", " << ts.getReferencePoint()[1] << ", "  << ts.getReferencePoint()[2] 
-    << " - r: " << std::sqrt( ts.getReferencePoint()[0]*ts.getReferencePoint()[0]+ts.getReferencePoint()[1]*ts.getReferencePoint()[1] ) << "]" 
-    << std::endl ;
+    std::cout << "MarlinKalTestTrack::initialise using TrackState: track parameters used for init : "
+	      << " D0 "          <<  ts.D0
+	      << " Phi :"        <<  ts.phi
+	      << " Omega "       <<  ts.omega
+	      << " Z0 "          <<  ts.Z0
+	      << " tan(Lambda) " <<  ts.tanLambda
+	      << " pivot : [" << ts.referencePoint[0] << ", " << ts.referencePoint[1] << ", "  << ts.referencePoint[2]
+	      << " - r: " << std::sqrt( ts.referencePoint[0]*ts.referencePoint[0]+ts.referencePoint[1]*ts.referencePoint[1] ) << "]"
+	      << std::endl ;
     */
-    
     _fitDirection = fitDirection ;
-    
+
     // for GeV, Tesla, R in mm  
     double alpha = bfield_z * 2.99792458E-4 ;
     double kappa;
     if ( bfield_z == 0.0 )
       kappa = DBL_MAX;
     else kappa = ts.omega / alpha ;
-    
+
     THelicalTrack helix( -ts.D0,
                         toBaseRange( ts.phi - M_PI/2. ) ,
                         kappa,
@@ -380,7 +376,6 @@ namespace MarlinTrk {
                         bfield_z );
     
     TMatrixD cov(5,5) ;   
-
     std::array<float, 15> covLCIO = ts.covMatrix;
     
     cov( 0 , 0 ) =   covLCIO[ 0] ;                   //   d0, d0
@@ -416,14 +411,14 @@ namespace MarlinTrk {
 //    cov.Print();
     
     // move the helix to either the position of the last hit or the first depending on initalise_at_end
-    
+
     // default case initalise_at_end
     int index = _kalhits->GetEntries() - 1 ;
     // or initialise at start 
     if( _fitDirection == IMarlinTrack::forward ){
       index = 0 ;
     }
-    
+
     TVTrackHit* kalhit = dynamic_cast<TVTrackHit *>(_kalhits->At(index)); 
     
     double dphi;
@@ -439,7 +434,6 @@ namespace MarlinTrk {
       initial_pivot =  TVector3(0.0,0.0,0.0);
     }
 
-    
     // ---------------------------
     //  Create an initial start site for the track using the  hit
     // ---------------------------
@@ -468,17 +462,16 @@ namespace MarlinTrk {
         surf->CalcXingPointWith(helix, initial_pivot, phi);        
 
       } else {
-        //streamlog_out( ERROR) << "<<<<<<<<< MarlinKalTestTrack::initialise: dynamic_cast failed for TVSurface  >>>>>>>" << std::endl;
+        //std::cout << "ERROR<<<<<<<<< MarlinKalTestTrack::initialise: dynamic_cast failed for TVSurface  >>>>>>>" << std::endl;
         return error ;        
       }
             
     
     }
     else {
-      //streamlog_out( ERROR) << "<<<<<<<<< MarlinKalTestTrack::initialise: dynamic_cast failed for hit type >>>>>>>" << std::endl;
+      //std::cout << "ERROR<<<<<<<<< MarlinKalTestTrack::initialise: dynamic_cast failed for hit type >>>>>>>" << std::endl;
       return error ;
     }
-    
     TVTrackHit& dummyHit = *pDummyHit;
         
     //SJA:FIXME: this constants should go in a header file
@@ -489,14 +482,12 @@ namespace MarlinTrk {
     
     // use dummy hit to create initial site
     TKalTrackSite& initialSite = *new TKalTrackSite(dummyHit);
-    
     initialSite.SetHitOwner();// site owns hit
     initialSite.SetOwner();   // site owns states
-    
+
     // ---------------------------
     //  Set up initial track state 
     // ---------------------------
-
     helix.MoveTo( initial_pivot, dphi, 0, &cov );  
     
     static TKalMatrix initialState(kSdim,1) ;
@@ -523,17 +514,15 @@ namespace MarlinTrk {
     if (kSdim == 6) covK(5,5) = 1.e6; // t0
         
 //    covK.Print();
-    
+
     // Add initial states to the site 
     initialSite.Add(new TKalTrackState(initialState,covK,initialSite,TVKalSite::kPredicted));
     initialSite.Add(new TKalTrackState(initialState,covK,initialSite,TVKalSite::kFiltered));
-    
+
     // add the initial site to the track: that is, give the track initial parameters and covariance 
     // matrix at the starting measurement layer
     _kaltrack->Add(&initialSite);
-    
     _initialised = true ;
-
     
 #ifdef MARLINTRK_DIAGNOSTICS_ON
     
@@ -603,7 +592,7 @@ namespace MarlinTrk {
     // although calling smooth will natrually update delta chi2.
     
     
-    if (!_kaltrack->AddAndFilter(*temp_site)) {        
+    if (!_kaltrack->AddAndFilter(*temp_site)) {
       
       chi2increment = temp_site->GetDeltaChi2() ;
       // get the measurement layer of the current hit
@@ -670,16 +659,16 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::addAndFit( edm4hep::ConstTrackerHit trkhit, double& chi2increment, double maxChi2Increment) {
+  int MarlinKalTestTrack::addAndFit( edm4hep::ConstTrackerHit& trkhit, double& chi2increment, double maxChi2Increment) {
     
-    if( ! trkhit.isAvailable() ) { 
+    if( ! trkhit.isAvailable() ) {
       std::cout << "Error: MarlinKalTestTrack::addAndFit(edm4hep::TrackerHit trkhit, double& chi2increment, double maxChi2Increment): trkhit == 0" << std::endl;
       return bad_intputs ; 
     }
     
     const ILDVMeasLayer* ml = _ktest->findMeasLayer( trkhit ) ;
     
-    if( ml == 0 ){  
+    if( ml == 0 ){
       // fg: not sure if ml should ever be 0 - but it seems to happen, 
       //     if point is not on surface and more than one surface exists ...
       
@@ -735,6 +724,10 @@ namespace MarlinTrk {
       << " NDF = " << _kaltrack->GetNDF() 
       <<  std::endl; 
       */
+      //std::cout << "ERROR<<<addAndFit(" << _trackHitAtPositiveNDF.isAvailable() << " " << _kaltrack->GetNDF() << std::endl;
+    }
+    else{
+      //std::cout << "ERROR<<<addAndFit(" << _trackHitAtPositiveNDF.isAvailable() << " " << _kaltrack->GetNDF() << std::endl;
     }
 
     return success ;
@@ -743,16 +736,16 @@ namespace MarlinTrk {
   
   
   
-  int MarlinKalTestTrack::testChi2Increment( edm4hep::ConstTrackerHit trkhit, double& chi2increment ) {
+  int MarlinKalTestTrack::testChi2Increment( edm4hep::ConstTrackerHit& trkhit, double& chi2increment ) {
     
-    //if( ! trkhit ) { 
+    //if( ! trkhit ) {
     //  streamlog_out( ERROR) << "MarlinKalTestTrack::addAndFit(edm4hep::TrackerHit trkhit, double& chi2increment, double maxChi2Increment): trkhit == 0" << std::endl;
     //  return IMarlinTrack::bad_intputs ; 
     //}
     
     const ILDVMeasLayer* ml = _ktest->findMeasLayer( trkhit ) ;
     
-    if( ml == 0 ){  
+    if( ml == 0 ){
       // fg: not sure if ml should ever be 0 - but it seems to happen, 
       //     if point is not on surface and more than one surface exists ...
       
@@ -829,7 +822,7 @@ namespace MarlinTrk {
           _trackHitAtPositiveNDF = trkhit;
           _hitIndexAtPositiveNDF = _kaltrack->IndexOf( site );
           /*
-          streamlog_out( DEBUG2 ) << ">>>>>>>>>>>  Fit is now constrained at : "
+	  streamlog_out( DEBUG2 ) << ">>>>>>>>>>>  Fit is now constrained at : "
           << decodeILD( trkhit.getCellID() ) 
           << " pos " << trkhit.getPosition()
           << " trkhit = " << _trackHitAtPositiveNDF
@@ -837,7 +830,11 @@ namespace MarlinTrk {
           << " NDF = " << _kaltrack->GetNDF() 
           <<  std::endl; 
           */
+	  //std::cout << "ERROR<<<fit( double maxChi2Increment )" << _trackHitAtPositiveNDF.isAvailable() << " " << _kaltrack->GetNDF() << std::endl;
         }
+	else{
+	  //std::cout << "ERROR<<<fit( double maxChi2Increment )" << _trackHitAtPositiveNDF.isAvailable() << " " << _kaltrack->GetNDF() << std::endl;
+	}
             
       } 
       else { // hit rejected by the filter, so store in the list of rejected hits
@@ -903,7 +900,7 @@ namespace MarlinTrk {
   
   /** smooth track states from the last filtered hit back to the measurement site associated with the given hit 
    */
-  int MarlinKalTestTrack::smooth( edm4hep::ConstTrackerHit trkhit ) {
+  int MarlinKalTestTrack::smooth( edm4hep::ConstTrackerHit& trkhit ) {
     
     //streamlog_out( DEBUG2 )  << "MarlinKalTestTrack::smooth( edm4hep::TrackerHit " << trkhit << "  ) " << std::endl ;
 
@@ -944,7 +941,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::getTrackState( edm4hep::ConstTrackerHit trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
+  int MarlinKalTestTrack::getTrackState( edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
     
     //streamlog_out( DEBUG2 )  << "MarlinKalTestTrack::getTrackState(edm4hep::ConstTrackerHit trkhit, edm4hep::TrackState& ts ) using hit: " << trkhit << " with cellID0 = " << trkhit.getCellID() << std::endl ;
     
@@ -973,7 +970,7 @@ namespace MarlinTrk {
     // as they will be added to _hit_chi2_values in the order of fitting 
     // not in the order of time
 //    
-//    if( _fitDirection == IMarlinTrack::backward ){    
+//    if( _fitDirection == IMarlinTrack::backward ){
 //      std::reverse_copy( _hit_chi2_values.begin() , _hit_chi2_values.end() , std::back_inserter(  hits  )  ) ;
 //    } else {
 //      std::copy( _hit_chi2_values.begin() , _hit_chi2_values.end() , std::back_inserter(  hits  )  ) ;
@@ -992,7 +989,7 @@ namespace MarlinTrk {
 //    // as they will be added to _hit_chi2_values in the order of fitting 
 //    // not in the order of time
 //
-//    if( _fitDirection == IMarlinTrack::backward ){    
+//    if( _fitDirection == IMarlinTrack::backward ){
 //      std::reverse_copy( _outlier_chi2_values.begin() , _outlier_chi2_values.end() , std::back_inserter(  hits  )  ) ;
 //    } else {
 //      std::copy( _outlier_chi2_values.begin() , _outlier_chi2_values.end() , std::back_inserter(  hits  )  ) ;
@@ -1003,7 +1000,7 @@ namespace MarlinTrk {
   
   int MarlinKalTestTrack::getNDF( int& ndf ){
     
-    if( _initialised == false ) { 
+    if( _initialised == false ) {
       return error;
     } else {
       
@@ -1020,12 +1017,13 @@ namespace MarlinTrk {
       return success;    
     }
     else{
+      //std::cout << "WARNING<<<<<MarlinKalTestTrack::getTrackerHitAtPositiveNDF>>>>_trackHitAtPositiveNDF not available" << std::endl;
       return error;
     }
   }
   
   
-  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackState& ts, double& chi2, int& ndf ){  
+  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackState& ts, double& chi2, int& ndf ){
     
     const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(_kaltrack->Last())) ;
     
@@ -1033,7 +1031,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
+  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
     
     TKalTrackSite* site = 0 ;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1044,7 +1042,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, const TKalTrackSite& site ,edm4hep::TrackState& ts, double& chi2, int& ndf ){  
+  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, const TKalTrackSite& site ,edm4hep::TrackState& ts, double& chi2, int& ndf ){
     
     //streamlog_out(DEBUG2) << "MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackState& ts, double& chi2, int& ndf ) called " << std::endl ;
     
@@ -1076,7 +1074,7 @@ namespace MarlinTrk {
   } 
   
   
-  int MarlinKalTestTrack::extrapolateToLayer( int layerID, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) { 
+  int MarlinKalTestTrack::extrapolateToLayer( int layerID, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(_kaltrack->Last())) ;
     
@@ -1085,7 +1083,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::extrapolateToLayer( int layerID, edm4hep::ConstTrackerHit trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) { 
+  int MarlinKalTestTrack::extrapolateToLayer( int layerID, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1097,7 +1095,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::extrapolateToLayer( int layerID, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) { 
+  int MarlinKalTestTrack::extrapolateToLayer( int layerID, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     //streamlog_out(DEBUG2) << "MarlinKalTestTrack::extrapolateToLayer( int layerID, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID ) called " << std::endl ;
     
@@ -1113,7 +1111,7 @@ namespace MarlinTrk {
   } 
   
   
-  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) { 
+  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(_kaltrack->Last())) ;
     
@@ -1122,7 +1120,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, edm4hep::ConstTrackerHit trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) { 
+  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1134,7 +1132,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) { 
+  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     //streamlog_out(DEBUG2) << "MarlinKalTestTrack::extrapolateToDetElement( int detElementID, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) called " << std::endl ;
     
@@ -1163,7 +1161,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::propagate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ){
+  int MarlinKalTestTrack::propagate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ){
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1264,7 +1262,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::propagateToLayer( int layerID, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) { 
+  int MarlinKalTestTrack::propagateToLayer( int layerID, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(_kaltrack->Last())) ;
     
@@ -1273,7 +1271,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::propagateToLayer( int layerID, edm4hep::ConstTrackerHit trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) { 
+  int MarlinKalTestTrack::propagateToLayer( int layerID, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1285,7 +1283,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::propagateToLayer( int layerID, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) { 
+  int MarlinKalTestTrack::propagateToLayer( int layerID, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     //streamlog_out(DEBUG2) << "MarlinKalTestTrack::propagateToLayer( int layerID, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID ) called " << std::endl;
     
@@ -1302,7 +1300,7 @@ namespace MarlinTrk {
   } 
   
   
-  int MarlinKalTestTrack::propagateToDetElement( int detElementID, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) { 
+  int MarlinKalTestTrack::propagateToDetElement( int detElementID, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(_kaltrack->Last())) ;
     
@@ -1311,7 +1309,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::propagateToDetElement( int detElementID, edm4hep::ConstTrackerHit trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) { 
+  int MarlinKalTestTrack::propagateToDetElement( int detElementID, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1323,7 +1321,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::propagateToDetElement( int detElementID, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) { 
+  int MarlinKalTestTrack::propagateToDetElement( int detElementID, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     //streamlog_out(DEBUG2) << "MarlinKalTestTrack::propagateToDetElement( int detElementID, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) called " << std::endl ;
     
@@ -1339,7 +1337,7 @@ namespace MarlinTrk {
   } 
   
   
-  int MarlinKalTestTrack::intersectionWithDetElement( int detElementID, edm4hep::Vector3d& point, int mode ) {  
+  int MarlinKalTestTrack::intersectionWithDetElement( int detElementID, edm4hep::Vector3d& point, int mode ) {
     
     const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(_kaltrack->Last())) ;
     
@@ -1349,7 +1347,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::intersectionWithDetElement( int detElementID,  edm4hep::ConstTrackerHit trkhit, edm4hep::Vector3d& point, int mode ) {  
+  int MarlinKalTestTrack::intersectionWithDetElement( int detElementID,  edm4hep::ConstTrackerHit& trkhit, edm4hep::Vector3d& point, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1407,7 +1405,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::intersectionWithLayer( int layerID, edm4hep::Vector3d& point, int& detElementID, int mode ) {  
+  int MarlinKalTestTrack::intersectionWithLayer( int layerID, edm4hep::Vector3d& point, int& detElementID, int mode ) {
     
     const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(_kaltrack->Last())) ;
     const ILDVMeasLayer* ml = 0;
@@ -1416,7 +1414,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::intersectionWithLayer( int layerID,  edm4hep::ConstTrackerHit trkhit, edm4hep::Vector3d& point, int& detElementID, int mode ) {  
+  int MarlinKalTestTrack::intersectionWithLayer( int layerID,  edm4hep::ConstTrackerHit& trkhit, edm4hep::Vector3d& point, int& detElementID, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1429,7 +1427,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::intersectionWithLayer( int layerID, const TKalTrackSite& site, edm4hep::Vector3d& point, int& detElementID, const ILDVMeasLayer*& ml, int mode ) {  
+  int MarlinKalTestTrack::intersectionWithLayer( int layerID, const TKalTrackSite& site, edm4hep::Vector3d& point, int& detElementID, const ILDVMeasLayer*& ml, int mode ) {
     
     //streamlog_out(DEBUG2) << "MarlinKalTestTrack::intersectionWithLayer( int layerID, const TKalTrackSite& site, edm4hep::Vector3d& point, int& detElementID, int mode) called layerID = " << layerID << std::endl;
     
@@ -1508,7 +1506,7 @@ namespace MarlinTrk {
     //streamlog_out(DEBUG1) << std::endl ;
     
     
-    if( crossing_exist == 0 ) { 
+    if( crossing_exist == 0 ) {
       return no_intersection ;
     }
     else {
@@ -1545,8 +1543,7 @@ namespace MarlinTrk {
       if( error_code == success ) {
         
         // make sure we get the next crossing 
-        if( fabs(dphi) < dphi_min ) {     
-          
+        if( fabs(dphi) < dphi_min ) {
           dphi_min = fabs(dphi) ;
           surf_found = true ;
           ml = meas_modules[i];
@@ -1631,24 +1628,22 @@ namespace MarlinTrk {
     pivot[2] =  helix.GetPivot().Z() ;
     ts.referencePoint = pivot;
     /*
-    streamlog_out( DEBUG2 ) << " kaltest track parameters: "
-    << " chi2/ndf " << chi2 / ndf  
-    << " chi2 " <<  chi2 
-    << " ndf " <<  ndf
-    << " prob " <<  TMath::Prob(chi2, ndf)
-    << std::endl 
-    
-    << "\t D0 "          <<  d0         <<  "[+/-" << sqrt( covLCIO[0] ) << "] " 
-    << "\t Phi :"        <<  phi        <<  "[+/-" << sqrt( covLCIO[2] ) << "] " 
-    << "\t Omega "       <<  omega      <<  "[+/-" << sqrt( covLCIO[5] ) << "] " 
-    << "\t Z0 "          <<  z0         <<  "[+/-" << sqrt( covLCIO[9] ) << "] " 
-    << "\t tan(Lambda) " <<  tanLambda  <<  "[+/-" << sqrt( covLCIO[14]) << "] " 
-    
-    << "\t pivot : [" << pivot[0] << ", " << pivot[1] << ", "  << pivot[2] 
-    << " - r: " << std::sqrt( pivot[0]*pivot[0]+pivot[1]*pivot[1] ) << "]" 
-    << std::endl ;
+    std::cout << " kaltest track parameters: "
+	      << " chi2/ndf " << chi2 / ndf
+	      << " chi2 " <<  chi2
+	      << " ndf " <<  ndf
+	      << " prob " <<  TMath::Prob(chi2, ndf)
+	      << std::endl
+	      << "\t D0 "          <<  d0         <<  "[+/-" << sqrt( covLCIO[0] ) << "] "
+	      << "\t Phi :"        <<  phi        <<  "[+/-" << sqrt( covLCIO[2] ) << "] "
+	      << "\t Omega "       <<  omega      <<  "[+/-" << sqrt( covLCIO[5] ) << "] "
+	      << "\t Z0 "          <<  z0         <<  "[+/-" << sqrt( covLCIO[9] ) << "] "
+	      << "\t tan(Lambda) " <<  tanLambda  <<  "[+/-" << sqrt( covLCIO[14]) << "] "
+
+	      << "\t pivot : [" << pivot[0] << ", " << pivot[1] << ", "  << pivot[2]
+	      << " - r: " << std::sqrt( pivot[0]*pivot[0]+pivot[1]*pivot[1] ) << "]"
+	      << std::endl ;
     */
-    
   }
   
   
@@ -1667,7 +1662,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::getSiteFromLCIOHit( edm4hep::ConstTrackerHit trkhit, TKalTrackSite*& site ) const {
+  int MarlinKalTestTrack::getSiteFromLCIOHit( edm4hep::ConstTrackerHit& trkhit, TKalTrackSite*& site ) const {
     
     std::map<edm4hep::ConstTrackerHit,TKalTrackSite*>::const_iterator it;
     

--- a/Service/TrackSystemSvc/src/MarlinKalTestTrack.h
+++ b/Service/TrackSystemSvc/src/MarlinKalTestTrack.h
@@ -49,17 +49,17 @@ namespace MarlinTrk{
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */
-    int addHit(edm4hep::ConstTrackerHit hit) ;
+    int addHit(edm4hep::ConstTrackerHit& hit) ;
     
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */    
-    int addHit(edm4hep::ConstTrackerHit trkhit, const ILDVMeasLayer* ml) ;
+    int addHit(edm4hep::ConstTrackerHit& trkhit, const ILDVMeasLayer* ml) ;
     
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */    
-    int addHit( edm4hep::ConstTrackerHit trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) ;
+    int addHit( edm4hep::ConstTrackerHit& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) ;
     
     /** initialise the fit using the hits added up to this point -
      *  the fit direction has to be specified using IMarlinTrack::backward or IMarlinTrack::forward. 
@@ -90,13 +90,13 @@ namespace MarlinTrk{
     
     /** smooth track states from the last filtered hit back to the measurement site associated with the given hit 
      */
-    int smooth( edm4hep::ConstTrackerHit hit )  ;
+    int smooth( edm4hep::ConstTrackerHit& hit )  ;
     
     
     /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from adding the hit via reference. 
      *  the given hit will not be added if chi2increment > maxChi2Increment. 
      */
-    int addAndFit( edm4hep::ConstTrackerHit hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) ;
+    int addAndFit( edm4hep::ConstTrackerHit& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) ;
     
     /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from adding the hit via reference. 
      *  the given hit will not be added if chi2increment > maxChi2Increment. 
@@ -106,7 +106,7 @@ namespace MarlinTrk{
     
     /** obtain the chi2 increment which would result in adding the hit to the fit. This method will not alter the current fit, and the hit will not be stored in the list of hits or outliers
      */
-    int testChi2Increment( edm4hep::ConstTrackerHit hit, double& chi2increment ) ;
+    int testChi2Increment( edm4hep::ConstTrackerHit& hit, double& chi2increment ) ;
     
     
     // Track State Accessesors
@@ -118,7 +118,7 @@ namespace MarlinTrk{
     
     /** get track state at measurement associated with the given hit, returning TrackState, chi2 and ndf via reference 
      */
-    int getTrackState( edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
+    int getTrackState( edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
     
     
     /** get the list of hits included in the fit, together with the chi2 contributions of the hits. 
@@ -154,7 +154,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point,
      *  returning TrackState, chi2 and ndf via reference   
      */
-    int propagate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
+    int propagate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
     
     
     /** propagate the fit at the provided measurement site, to the point of closest approach to the given point,
@@ -170,7 +170,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
      */
-    int propagateToLayer( int layerID, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
+    int propagateToLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
     
     /** propagate the fit at the measurement site, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -184,7 +184,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
      */
-    int propagateToDetElement( int detEementID, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
+    int propagateToDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
   
     /** propagate the fit at the measurement site, to sensitive detector element, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -202,7 +202,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point, 
      *    returning TrackState, chi2 and ndf via reference   
      */
-    int extrapolate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
+    int extrapolate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
     
     /** extrapolate the fit at the measurement site, to the point of closest approach to the given point, 
      *    returning TrackState, chi2 and ndf via reference   
@@ -216,7 +216,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
      */
-    int extrapolateToLayer( int layerID, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
+    int extrapolateToLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
     
     /** extrapolate the fit at the measurement site, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -230,7 +230,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
    */
-    int extrapolateToDetElement( int detEementID, edm4hep::ConstTrackerHit hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
+    int extrapolateToDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
     
     /** extrapolate the fit at the measurement site, to sensitive detector element, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -250,7 +250,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer,
      *  returning intersection point in global coordinates and integer ID of the intersected sensitive detector element via reference 
      */
-    int intersectionWithLayer( int layerID, edm4hep::ConstTrackerHit hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest )  ;
+    int intersectionWithLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest )  ;
     
     /** extrapolate the fit at the measurement site, to numbered sensitive layer,
      *  returning intersection point in global coordinates and integer ID of the intersected sensitive detector element via reference 
@@ -265,7 +265,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element,
      *  returning intersection point in global coordinates via reference 
      */ 
-    int intersectionWithDetElement( int detElementID, edm4hep::ConstTrackerHit hit, edm4hep::Vector3d& point, int mode=modeClosest )  ;
+    int intersectionWithDetElement( int detElementID, edm4hep::ConstTrackerHit& hit, edm4hep::Vector3d& point, int mode=modeClosest )  ;
     
     /** extrapolate the fit at the measurement site, to sensitive detector element,
      *  returning intersection point in global coordinates via reference 
@@ -297,12 +297,13 @@ namespace MarlinTrk{
     
     /** get the measurement site associated with the given lcio TrackerHit trkhit
      */
-    int getSiteFromLCIOHit( edm4hep::ConstTrackerHit trkhit, TKalTrackSite*& site ) const ;
+    int getSiteFromLCIOHit( edm4hep::ConstTrackerHit& trkhit, TKalTrackSite*& site ) const ;
     
     
     
     /** helper function to restrict the range of the azimuthal angle to ]-pi,pi]*/
     inline double toBaseRange( double phi) const {
+      phi = fmod(phi, 2.*M_PI);
       while( phi <= -M_PI ){  phi += 2. * M_PI ; }
       while( phi >   M_PI ){  phi -= 2. * M_PI ; }
       return phi ;

--- a/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
+++ b/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
@@ -37,7 +37,7 @@ namespace MarlinTrk {
 //    
 //    int nrows = 5;
 //    
-//    TMatrixD cov(nrows,nrows) ; 
+//    TMatrixD cov(nrows,nrows) ;
 //    
 //    bool matrix_is_positive_definite = true;
 //    
@@ -148,16 +148,14 @@ namespace MarlinTrk {
     
     
     int fit_status = createFit(hit_list, marlinTrk, pre_fit, bfield_z, fit_backwards, maxChi2Increment);
-    
-    if( fit_status != IMarlinTrack::success ){ 
-      
-      //std::cout << "MarlinTrk::createFinalisedLCIOTrack fit failed: fit_status = " << fit_status << std::endl; 
-      
+    //std::cout << "createFit finished. status = " << fit_status << std::endl;
+    if( fit_status != IMarlinTrack::success ){
+      //std::cout << "MarlinTrk::createFinalisedLCIOTrack fit failed: fit_status = " << fit_status << std::endl;
       return fit_status;
     } 
     
     int error = finaliseLCIOTrack(marlinTrk, track, hit_list);
-        
+    //std::cout << "finaliseLCIOTrack. status = " << error << std::endl;
     return error;
   }
   
@@ -189,7 +187,7 @@ namespace MarlinTrk {
 //    
 //    if (( fit_backwards == IMarlinTrack::backward && pre_fit->getLocation() != lcio::TrackState::AtLastHit ) 
 //        ||  
-//        ( fit_backwards == IMarlinTrack::forward && pre_fit->getLocation() != lcio::TrackState::AtFirstHit )) {            
+//        ( fit_backwards == IMarlinTrack::forward && pre_fit->getLocation() != lcio::TrackState::AtFirstHit )) {
 //      std::stringstream ss ;
 //      
 //      ss << "MarlinTrk::createFinalisedLCIOTrack track state must be set at either first or last hit. Location = ";
@@ -214,7 +212,7 @@ namespace MarlinTrk {
     for( it = hit_list.begin() ; it != hit_list.end() ; ++it ) {
       
       edm4hep::ConstTrackerHit trkHit = *it;
-      bool isSuccessful = false; 
+      bool isSuccessful = false;
       //std::cout << "debug: TrackerHit pointer " << trkHit << std::endl;
       if( UTIL::BitSet32( trkHit.getType() )[ UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT ]   ){ //it is a composite spacepoint        
         //Split it up and add both hits to the MarlinTrk
@@ -227,7 +225,7 @@ namespace MarlinTrk {
 	  if( marlinTrk->addHit( rawHit ) == IMarlinTrack::success ){
 	    isSuccessful = true; //if at least one hit from the spacepoint gets added
             ++ndof_added;
-//            streamlog_out(DEBUG4) << "MarlinTrk::createFit ndof_added = " << ndof_added << std::endl;
+	    //std::cout << "DEBUG<<<<<MarlinTrk::createFit ndof_added = " << ndof_added << std::endl;
           }
         }
       }
@@ -235,7 +233,7 @@ namespace MarlinTrk {
         if (marlinTrk->addHit( trkHit ) == IMarlinTrack::success ) {
           isSuccessful = true;
           ndof_added += 2;
-//          streamlog_out(DEBUG4) << "MarlinTrk::createFit ndof_added = " << ndof_added << std::endl;          
+	  //std::cout << "DEBUG<<<<<MarlinTrk::createFit ndof_added = " << ndof_added << std::endl;
         }
       }
       
@@ -243,13 +241,13 @@ namespace MarlinTrk {
         added_hits.push_back(trkHit);
       }        
       else{
-	//std::cout << "MarlinTrkUtils::createFit Hit " << it - hit_list.begin() << " Dropped " << std::endl;
+	//std::cout << "DEBUG<<<<<MarlinTrkUtils::createFit Hit " << it - hit_list.begin() << " Dropped " << std::endl;
       }
       
     }
       
     if( ndof_added < MIN_NDF ) {
-      //streamlog_out(DEBUG2) << "MarlinTrk::createFit : Cannot fit less with less than " << MIN_NDF << " degrees of freedom. Number of hits =  " << added_hits.size() << " ndof = " << ndof_added << std::endl;
+      //std::cout << "ERROR<<<<<MarlinTrk::createFit : Cannot fit less with less than " << MIN_NDF << " degrees of freedom. Number of hits =  " << added_hits.size() << " ndof = " << ndof_added << std::endl;
       return IMarlinTrack::bad_intputs;
     }
       
@@ -262,12 +260,12 @@ namespace MarlinTrk {
     return_error = marlinTrk->initialise( *pre_fit, bfield_z, IMarlinTrack::backward ) ;
     if (return_error != IMarlinTrack::success) {
       
-      //streamlog_out(DEBUG5) << "MarlinTrk::createFit Initialisation of track fit failed with error : " << return_error << std::endl;
+      std::cout << "MarlinTrk::createFit Initialisation of track fit failed with error : " << return_error << std::endl;
       
       return return_error;
       
     }
-    
+    //std::cout << "debug:===================initialise " << return_error << std::endl;
     ///////////////////////////////////////////////////////
     // try fit and return error
     ///////////////////////////////////////////////////////
@@ -329,10 +327,10 @@ namespace MarlinTrk {
 
     if ( fit_backwards == IMarlinTrack::backward ) {
       pre_fit->location = MarlinTrk::Location::AtLastHit;
-      helixTrack.moveRefPoint(hit_list.back().getPosition()[0], hit_list.back().getPosition()[1], hit_list.back().getPosition()[2]);      
+      helixTrack.moveRefPoint(hit_list.back().getPosition()[0], hit_list.back().getPosition()[1], hit_list.back().getPosition()[2]);
     } else {
       pre_fit->location = MarlinTrk::Location::AtFirstHit;
-      helixTrack.moveRefPoint(hit_list.front().getPosition()[0], hit_list.front().getPosition()[1], hit_list.front().getPosition()[2]);      
+      helixTrack.moveRefPoint(hit_list.front().getPosition()[0], hit_list.front().getPosition()[1], hit_list.front().getPosition()[2]);
     }
     
     
@@ -435,8 +433,8 @@ namespace MarlinTrk {
 	  bool is_outlier = false;
 	  // here we loop over outliers as this will be faster than looping over the used hits
           for ( unsigned ohit = 0; ohit < outliers.size(); ++ohit) {
-	    if ( rawHit.id() == outliers[ohit].first.id() ) { 
-              is_outlier = true;                                    
+	    if ( rawHit.id() == outliers[ohit].first.id() ) {
+              is_outlier = true;
               break; // break out of loop over outliers
             }
           }
@@ -450,8 +448,8 @@ namespace MarlinTrk {
         bool is_outlier = false;
         // here we loop over outliers as this will be faster than looping over the used hits
         for ( unsigned ohit = 0; ohit < outliers.size(); ++ohit) {
-          if ( trkHit == outliers[ohit].first ) { 
-            is_outlier = true;                                    
+          if ( trkHit == outliers[ohit].first ) {
+            is_outlier = true;
             break; // break out of loop over outliers
           }
         }
@@ -484,12 +482,12 @@ namespace MarlinTrk {
     edm4hep::TrackState* trkStateAtLastHit = new edm4hep::TrackState() ;
     edm4hep::ConstTrackerHit lastHit = hits_in_fit.front().first;
           
-    edm4hep::ConstTrackerHit last_constrained_hit = 0 ;     
+    edm4hep::ConstTrackerHit last_constrained_hit(0);// = 0 ;
     marlintrk->getTrackerHitAtPositiveNDF(last_constrained_hit);
 
     return_error = marlintrk->smooth(lastHit);
     
-    if ( return_error != IMarlinTrack::success ) { 
+    if ( return_error != IMarlinTrack::success ) {
       //streamlog_out(DEBUG4) << "MarlinTrk::finaliseLCIOTrack: return_code for smoothing to " << lastHit << " = " << return_error << " NDF = " << ndf << std::endl;
       delete trkStateAtFirstHit;
       delete trkStateAtLastHit;
@@ -511,7 +509,7 @@ namespace MarlinTrk {
     
     return_error = marlintrk->propagate(point, firstHit, *trkStateIP, chi2, ndf ) ;
     
-    if ( return_error != IMarlinTrack::success ) { 
+    if ( return_error != IMarlinTrack::success ) {
       //streamlog_out(DEBUG4) << "MarlinTrk::finaliseLCIOTrack: return_code for propagation = " << return_error << " NDF = " << ndf << std::endl;
       delete trkStateIP;
       delete trkStateAtFirstHit;
@@ -569,7 +567,7 @@ namespace MarlinTrk {
         trkStateAtLastHit->location = MarlinTrk::Location::AtLastHit;
         track->addToTrackStates(*trkStateAtLastHit);
       } else {
-        //streamlog_out( DEBUG5 ) << "  >>>>>>>>>>> MarlinTrk::finaliseLCIOTrack:  could not get TrackState at Last Hit " << last_constrained_hit << std::endl ;
+	std::cout << "ERROR>>>>>>>>>>> MarlinTrk::finaliseLCIOTrack:  could not get TrackState at Last Hit " << last_constrained_hit.id() << std::endl ;
         delete trkStateAtLastHit;
       }
       
@@ -630,7 +628,7 @@ namespace MarlinTrk {
     double chi2 = -DBL_MAX;
     int ndf = 0;
     
-    UTIL::BitField64 encoder( lcio::ILDCellID0::encoder_string ) ; 
+    UTIL::BitField64 encoder( lcio::ILDCellID0::encoder_string );
     encoder.reset() ;  // reset to 0
     
     encoder[lcio::ILDCellID0::subdet] = lcio::ILDDetID::ECAL ;
@@ -669,7 +667,7 @@ namespace MarlinTrk {
     if( track == 0 ){
       throw std::runtime_error( std::string("MarlinTrk::addHitsToTrack: TrackImpl == NULL ")  ) ;
     }
-    std::map<int, int> hitNumbers; 
+    std::map<int, int> hitNumbers;
     
     hitNumbers[UTIL::ILDDetID::VXD] = 0;
     hitNumbers[UTIL::ILDDetID::SIT] = 0;
@@ -682,7 +680,7 @@ namespace MarlinTrk {
       cellID_encoder.setValue(hit_list.at(j).getCellID()) ;
       int detID = cellID_encoder[UTIL::ILDCellID0::subdet];
       ++hitNumbers[detID];
-      //std::cout << "debug: " << "Hit from Detector " << detID << std::endl;     
+      //std::cout << "debug: " << "Hit from Detector " << detID << std::endl;
     }
     
     int offset = 2 ;
@@ -713,7 +711,7 @@ namespace MarlinTrk {
       throw std::runtime_error( std::string("MarlinTrk::addHitsToTrack: TrackImpl == NULL ")  ) ;
     }
     
-    std::map<int, int> hitNumbers; 
+    std::map<int, int> hitNumbers;
     
     hitNumbers[lcio::ILDDetID::VXD] = 0;
     hitNumbers[lcio::ILDDetID::SIT] = 0;
@@ -726,7 +724,7 @@ namespace MarlinTrk {
       cellID_encoder.setValue(hit_list.at(j).first.getCellID()) ;
       int detID = cellID_encoder[UTIL::ILDCellID0::subdet];
       ++hitNumbers[detID];
-      //std::cout << "debug: Hit from Detector " << detID << std::endl;     
+      //std::cout << "debug: Hit from Detector " << detID << std::endl;
     }
     
     int offset = 2 ;


### PR DESCRIPTION
* class edm4hep::TrackState has not initilization while `edm4hep::TrackState ts;`, therefore change to tsBase to initilize
                                edm4hep::TrackState tsBase;
				tsBase.D0 = 0;
				tsBase.phi = 0;
				tsBase.omega = 0;
				tsBase.Z0 = 0;
				tsBase.tanLambda = 0;
				tsBase.referencePoint = edm4hep::Vector3f(0,0,0);
				tsBase.covMatrix = std::array<float, 15>{};
				edm4hep::TrackState tsIP(tsBase);
				edm4hep::TrackState tsFH(tsBase);
				edm4hep::TrackState tsLH(tsBase);
				edm4hep::TrackState tsCA(tsBase);
    * also change the method to convert phi into the range  (-pi,pi) to avoid this problem again if other unexpected value appears
* change some print information
* add protection to read TrackState from Track
* change edm4hep::ConstTrackerHit to edm4hep::ConstTrackerHit& for some functions which doesnot save object