### PR TITLE
Set pandorapfa cmake_modules_path in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "14|17")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
+list(PREPEND CMAKE_MODULE_PATH $ENV{PANDORAPFA}/cmakemodules)
 list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake") # (Find*.cmake)
 include(cmake/CEPCSWDependencies.cmake)
 


### PR DESCRIPTION
This makes it easier to build cepcsw on the command line - until now I always had to set the cmake_modules_path by hand.