### PR TITLE
WIP: generator interface for beam background simulation

### DIFF
--- a/Generator/CMakeLists.txt
+++ b/Generator/CMakeLists.txt
@@ -15,7 +15,7 @@ gaudi_add_module(GenAlgo
                          src/SLCIORdr.cpp
                          src/HepMCRdr.cpp
                          src/GtGunTool.cpp
-
+                         src/GtBeamBackgroundTool.cpp
                  LINK ${ROOT_LIBRARIES}
                       k4FWCore::k4FWCore 
                       Gaudi::GaudiAlgLib

--- a/Generator/CMakeLists.txt
+++ b/Generator/CMakeLists.txt
@@ -15,7 +15,9 @@ gaudi_add_module(GenAlgo
                          src/SLCIORdr.cpp
                          src/HepMCRdr.cpp
                          src/GtGunTool.cpp
+                         # ------- Beam Background -------
                          src/GtBeamBackgroundTool.cpp
+                         src/BeamBackgroundFileParserV0.cpp
                  LINK ${ROOT_LIBRARIES}
                       k4FWCore::k4FWCore 
                       Gaudi::GaudiAlgLib

--- a/Generator/src/BeamBackgroundFileParserV0.cpp
+++ b/Generator/src/BeamBackgroundFileParserV0.cpp
@@ -1,10 +1,65 @@
 
 #include "BeamBackgroundFileParserV0.h"
+#include <sstream>
+#include <cmath>
 
-BeamBackgroundFileParserV0::BeamBackgroundFileParserV0(const std::string& filename) {
+BeamBackgroundFileParserV0::BeamBackgroundFileParserV0(const std::string& filename,
+                                                       int pdgid,
+                                                       double beam_energy) {
     m_input.open(filename.c_str());
+    m_pdgid = pdgid;
+    m_beam_energy = beam_energy;
 }
 
 bool BeamBackgroundFileParserV0::load(IBeamBackgroundFileParser::BeamBackgroundData& result) {
-    return true;
+
+    if (not m_input.good()) {
+        return false;
+    }
+
+    // read one record
+    std::string tmpline;
+    // the format
+    double generation_point;
+    int loss_turn;
+    double z; // unit: m
+    double x; // unit: m
+    double y; // unit: m
+    double cosx; // 
+    double cosy; //
+    double dz; // unit: m
+    double dp; // unit: relative to the E
+
+    while(m_input.good()) {
+        std::getline(m_input, tmpline);
+        std::stringstream ss;
+        ss << tmpline;
+        ss >> generation_point; if (ss.fail()) { continue; }
+        ss >> loss_turn;        if (ss.fail()) { continue; }
+        ss >> z;                if (ss.fail()) { continue; }
+        ss >> x;                if (ss.fail()) { continue; }
+        ss >> y;                if (ss.fail()) { continue; }
+        ss >> cosx;             if (ss.fail()) { continue; }
+        ss >> cosy;             if (ss.fail()) { continue; }
+        ss >> dz;               if (ss.fail()) { continue; }
+        ss >> dp;               if (ss.fail()) { continue; }
+
+        double p = m_beam_energy*(1+dp);
+
+        // Now, we get a almost valid data
+        const double m2mm = 1e3; // convert from m to mm
+        result.pdgid = m_pdgid;
+        result.x     = x * m2mm; 
+        result.y     = y * m2mm; 
+        result.z     = (z+dz) * m2mm;
+
+        result.px    = p * cosx;
+        result.py    = p * cosy;
+        result.pz    = p * std::sqrt(1-cosx*cosx-cosy*cosy);
+
+        result.mass  = 0.000511; // assume e-/e+, mass is 0.511 MeV
+
+        return true;
+    }
+    return false;
 }

--- a/Generator/src/BeamBackgroundFileParserV0.cpp
+++ b/Generator/src/BeamBackgroundFileParserV0.cpp
@@ -1,0 +1,10 @@
+
+#include "BeamBackgroundFileParserV0.h"
+
+BeamBackgroundFileParserV0::BeamBackgroundFileParserV0(const std::string& filename) {
+    m_input.open(filename.c_str());
+}
+
+bool BeamBackgroundFileParserV0::load(IBeamBackgroundFileParser::BeamBackgroundData& result) {
+    return true;
+}

--- a/Generator/src/BeamBackgroundFileParserV0.h
+++ b/Generator/src/BeamBackgroundFileParserV0.h
@@ -1,0 +1,17 @@
+#ifndef BeamBackgroundFileParserV0_h
+#define BeamBackgroundFileParserV0_h
+
+#include "IBeamBackgroundFileParser.h"
+
+#include <fstream>
+
+class BeamBackgroundFileParserV0: public IBeamBackgroundFileParser {
+public:
+    BeamBackgroundFileParserV0(const std::string& filename);
+
+    bool load(IBeamBackgroundFileParser::BeamBackgroundData&);
+private:
+    std::ifstream m_input;
+};
+
+#endif

--- a/Generator/src/BeamBackgroundFileParserV0.h
+++ b/Generator/src/BeamBackgroundFileParserV0.h
@@ -7,11 +7,14 @@
 
 class BeamBackgroundFileParserV0: public IBeamBackgroundFileParser {
 public:
-    BeamBackgroundFileParserV0(const std::string& filename);
+    BeamBackgroundFileParserV0(const std::string& filename, int pdgid, double beam_energy);
 
     bool load(IBeamBackgroundFileParser::BeamBackgroundData&);
 private:
     std::ifstream m_input;
+
+    int m_pdgid;
+    double m_beam_energy;
 };
 
 #endif

--- a/Generator/src/GtBeamBackgroundTool.cpp
+++ b/Generator/src/GtBeamBackgroundTool.cpp
@@ -1,0 +1,29 @@
+#include "GtBeamBackgroundTool.h"
+
+DECLARE_COMPONENT(GtBeamBackgroundTool)
+
+StatusCode GtBeamBackgroundTool::initialize() {
+    // check the consistency of the properties
+
+    // create the instances of the background parsers
+
+    return StatusCode::SUCCESS;
+}
+
+StatusCode GtBeamBackgroundTool::finalize() {
+    return StatusCode::SUCCESS;
+}
+
+
+bool GtBeamBackgroundTool::mutate(MyHepMC::GenEvent& event) {
+    return true;
+}
+
+bool GtBeamBackgroundTool::finish() {
+    return true;
+}
+
+bool GtBeamBackgroundTool::configure_gentool() {
+
+    return true;
+}

--- a/Generator/src/GtBeamBackgroundTool.cpp
+++ b/Generator/src/GtBeamBackgroundTool.cpp
@@ -1,11 +1,23 @@
 #include "GtBeamBackgroundTool.h"
 #include "IBeamBackgroundFileParser.h"
+#include "BeamBackgroundFileParserV0.h"
 DECLARE_COMPONENT(GtBeamBackgroundTool)
 
 StatusCode GtBeamBackgroundTool::initialize() {
     // check the consistency of the properties
 
     // create the instances of the background parsers
+
+    for (auto& [label, inputfn]: m_inputmaps) {
+        
+        m_beaminputs[label] = std::make_shared<BeamBackgroundFileParserV0>(inputfn, 11, 125.);
+    }
+
+    // check the size
+    if (m_beaminputs.empty()) {
+        error() << "Empty Beam Background File Parser. " << endmsg;
+        return StatusCode::FAILURE;
+    }
 
     return StatusCode::SUCCESS;
 }
@@ -16,6 +28,34 @@ StatusCode GtBeamBackgroundTool::finalize() {
 
 
 bool GtBeamBackgroundTool::mutate(MyHepMC::GenEvent& event) {
+    if (m_beaminputs.empty()) {
+        return false;
+    }
+    // TODO: should sample according to the rates
+    // dummy: get one and stop to generate
+    for (auto& [label, parser]: m_beaminputs) {
+        IBeamBackgroundFileParser::BeamBackgroundData beamdata;
+        auto isok = parser->load(beamdata);
+        if (not isok) {
+            error() << "Failed to load beam background data from the parser " << label << endmsg;
+            return false;
+        }
+        // fill the value
+        float charge = beamdata.pdgid == 11 ? -1: 1;
+
+        // create the MC particle
+        edm4hep::MCParticle mcp = event.m_mc_vec.create();
+        mcp.setPDG(beamdata.pdgid);
+        mcp.setGeneratorStatus(1);
+        mcp.setSimulatorStatus(1);
+        mcp.setCharge(static_cast<float>(charge));
+        mcp.setTime(beamdata.t);
+        mcp.setMass(beamdata.mass);
+        mcp.setVertex(edm4hep::Vector3d(beamdata.x,beamdata.y,beamdata.z)); 
+        mcp.setMomentum(edm4hep::Vector3f(beamdata.px,beamdata.py,beamdata.pz));
+
+    }
+    
     return true;
 }
 

--- a/Generator/src/GtBeamBackgroundTool.cpp
+++ b/Generator/src/GtBeamBackgroundTool.cpp
@@ -1,6 +1,8 @@
 #include "GtBeamBackgroundTool.h"
 #include "IBeamBackgroundFileParser.h"
 #include "BeamBackgroundFileParserV0.h"
+
+#include "TVector3.h" // for rotation
 DECLARE_COMPONENT(GtBeamBackgroundTool)
 
 StatusCode GtBeamBackgroundTool::initialize() {
@@ -9,8 +11,17 @@ StatusCode GtBeamBackgroundTool::initialize() {
     // create the instances of the background parsers
 
     for (auto& [label, inputfn]: m_inputmaps) {
-        
-        m_beaminputs[label] = std::make_shared<BeamBackgroundFileParserV0>(inputfn, 11, 125.);
+        double beamE = 120.;
+        auto itBeamE = m_Ebeammaps.find(label);
+        if (itBeamE != m_Ebeammaps.end()) {
+            beamE = itBeamE->second;
+        }
+        info() << "Initializing beam background ... "
+               << label << " "
+               << beamE << " "
+               << inputfn
+               << endmsg;
+        m_beaminputs[label] = std::make_shared<BeamBackgroundFileParserV0>(inputfn, 11, beamE);
     }
 
     // check the size
@@ -43,6 +54,17 @@ bool GtBeamBackgroundTool::mutate(MyHepMC::GenEvent& event) {
         // fill the value
         float charge = beamdata.pdgid == 11 ? -1: 1;
 
+        TVector3 pos(beamdata.x,beamdata.y,beamdata.z);
+        TVector3 mom(beamdata.px,beamdata.py,beamdata.pz);
+
+        auto itrot = m_rotYmaps.find(label);
+        if (itrot  != m_rotYmaps.end() ) {
+            info() << "Apply rotation along Y " << itrot->second << endmsg;
+
+            pos.RotateY(itrot->second);
+            mom.RotateY(itrot->second);
+        }
+
         // create the MC particle
         edm4hep::MCParticle mcp = event.m_mc_vec.create();
         mcp.setPDG(beamdata.pdgid);
@@ -51,8 +73,8 @@ bool GtBeamBackgroundTool::mutate(MyHepMC::GenEvent& event) {
         mcp.setCharge(static_cast<float>(charge));
         mcp.setTime(beamdata.t);
         mcp.setMass(beamdata.mass);
-        mcp.setVertex(edm4hep::Vector3d(beamdata.x,beamdata.y,beamdata.z)); 
-        mcp.setMomentum(edm4hep::Vector3f(beamdata.px,beamdata.py,beamdata.pz));
+        mcp.setVertex(edm4hep::Vector3d(pos.X(), pos.Y(), pos.Z())); 
+        mcp.setMomentum(edm4hep::Vector3f(mom.X(), mom.Y(), mom.Z()));
 
     }
     

--- a/Generator/src/GtBeamBackgroundTool.cpp
+++ b/Generator/src/GtBeamBackgroundTool.cpp
@@ -1,5 +1,5 @@
 #include "GtBeamBackgroundTool.h"
-
+#include "IBeamBackgroundFileParser.h"
 DECLARE_COMPONENT(GtBeamBackgroundTool)
 
 StatusCode GtBeamBackgroundTool::initialize() {

--- a/Generator/src/GtBeamBackgroundTool.h
+++ b/Generator/src/GtBeamBackgroundTool.h
@@ -51,6 +51,12 @@ private:
     Gaudi::Property<std::map<std::string, std::string>> m_fomatmaps{this, "InputFormatMap"};
     Gaudi::Property<std::map<std::string, double>>      m_ratemaps {this, "InputRateMap"};
 
+    // unit of beam energy: GeV
+    Gaudi::Property<std::map<std::string, double>>      m_Ebeammaps{this, "InputBeamEnergyMap"};
+
+    // unit of the rotation along Y: rad
+    Gaudi::Property<std::map<std::string, double>>      m_rotYmaps {this, "RotationAlongYMap"};
+
 private:
     std::map<std::string, std::shared_ptr<IBeamBackgroundFileParser>> m_beaminputs;
 

--- a/Generator/src/GtBeamBackgroundTool.h
+++ b/Generator/src/GtBeamBackgroundTool.h
@@ -1,0 +1,59 @@
+#ifndef GtBeamBackgroundTool_h
+#define GtBeamBackgroundTool_h
+
+/*
+ * Description:
+ *   This tool is used to simulation the non-collision beam backgrounds.
+ *
+ *   The properties:
+ *     - InputFileMap
+ *         this is a map to store the label and the input filename
+ *     - InputFormatMap
+ *         this is a map to store the label and the input format
+ *     - InputRateMap
+ *         this is a map to store the label and the rate
+ * 
+ *     Note: the label (key) should be consistent
+ *
+ * About the design:
+ *   IBeamBackgroundFileParser is the interface to load the next event.
+ *   Different file formats should be implemented in the corresponding parsers. 
+ *   The format will be used to create the corresponding instance.
+ *
+ * Author:
+ *   Tao Lin <lintao AT ihep.ac.cn>
+ */
+
+#include <GaudiKernel/AlgTool.h>
+#include <Gaudi/Property.h>
+#include "IGenTool.h"
+
+#include <vector>
+#include <map>
+
+class IBeamBackgroundFileParser;
+
+class GtBeamBackgroundTool: public extends<AlgTool, IGenTool> {
+public:
+    using extends::extends;
+
+    // Overriding initialize and finalize
+    StatusCode initialize() override;
+    StatusCode finalize() override;
+
+    // IGenTool
+    bool mutate(MyHepMC::GenEvent& event) override;
+    bool finish() override;
+    bool configure_gentool() override;
+
+private:
+    Gaudi::Property<std::map<std::string, std::string>> m_inputmaps{this, "InputFileMap"};
+    Gaudi::Property<std::map<std::string, std::string>> m_fomatmaps{this, "InputFormatMap"};
+    Gaudi::Property<std::map<std::string, double>>      m_ratemaps {this, "InputRateMap"};
+
+private:
+    std::map<std::string, std::shared_ptr<IBeamBackgroundFileParser>> m_beaminputs;
+
+};
+
+#endif

--- a/Generator/src/GtBeamBackgroundTool.h
+++ b/Generator/src/GtBeamBackgroundTool.h
@@ -27,11 +27,11 @@
 #include <GaudiKernel/AlgTool.h>
 #include <Gaudi/Property.h>
 #include "IGenTool.h"
+#include "IBeamBackgroundFileParser.h"
 
 #include <vector>
 #include <map>
 
-class IBeamBackgroundFileParser;
 
 class GtBeamBackgroundTool: public extends<AlgTool, IGenTool> {
 public:

--- a/Generator/src/IBeamBackgroundFileParser.h
+++ b/Generator/src/IBeamBackgroundFileParser.h
@@ -1,0 +1,44 @@
+#ifndef IBeamBackgroundFileParser_h
+#define IBeamBackgroundFileParser_h
+
+/*
+ * Description:
+ *   This interface is used to load the beam background information, such as:
+ *     - pdgid (optional)
+ *         About the pdgid, it will be e+/e- in most cases.
+ *     - x/y/z
+ *     - t (optional) 
+ *     - px/py/pz
+ *         About the time, it could be set in the GtBeamBackgroundTool.
+ *
+ * Author:
+ *   Tao Lin <lintao AT ihep.ac.cn>
+ */
+
+class IBeamBackgroundFileParser {
+public:
+    // Internal used Data
+    struct BeamBackgroundData {
+        int pdgid;
+
+        double x; // unit: mm
+        double y; // unit: mm
+        double z; // unit: mm
+        double t; // unit: ns
+
+        double px; // unit: GeV
+        double py; // unit: GeV
+        double pz; // unit: GeV
+        double mass; // unit: GeV
+
+        BeamBackgroundData() 
+          : pdgid(11), x(0), y(0), z(0), t(0), 
+            px(0), py(0), pz(0), mass(0) {}
+        
+    };
+
+    // return false if failed to load the data
+    virtual bool load(BeamBackgroundData&) = 0;
+};
+
+#endif


### PR DESCRIPTION
In this PR, a simple beam background parser is implemented and the tool is used to load the data and rotate the position and momemtum. 

The python option could be configured as following:
```python
from Configurables import GtBeamBackgroundTool

beambackground = GtBeamBackgroundTool("GtBeamBackgroundTool")
beambackground.InputFileMap = {"default": "ToCEPCSW.out"}
beambackground.InputBeamEnergyMap = {"default": 120.} # GeV
beambackground.RotationAlongYMap = {"default": 16.5e-3} # radian
```

The input file `ToCEPCSW.out` contains:
```csv
Generation Position/Loss Turn/Z(m)/X(m)/Y(m)/COSX/COSY/DZ(m)/DP(相对)

.05 1 3.13 .0099031 .0015125 5.2244448856E-4 3.2319664286E-4 7.9379217745E-4 -.9283404
.06 1 .45 .0087919 4.1827066853E-5 -.0047124 -2.250601162E-5 -.0038878 -.9981363
.07 1 2.6 -.0098533 -8.663444181E-4 .0011546 -3.771734981E-4 -1.514607787E-4 -.9727916
.16 1 3.76 -.0097491 -.0016431 .0010998 4.3913115533E-5 .0031015 -.916231
.16 1 3.6 .0098465 .0019703 -3.525921016E-4 -1.276482926E-4 -1.469879258E-4 -.8801277
.31 1 3.93 .0099583 .0018898 7.628897907E-4 4.8905586168E-5 9.9398225094E-4 -.8938091
.6 1 2.31 .0096349 3.2225104948E-4 .0011916 -4.803281957E-5 -.0043484 -.9933451
.61 1 3.71 .0098166 .0015159 6.5752863363E-4 8.7605346629E-6 -.0044354 -.9297897
.68 1 4.17 -.0098875 -.0022476 -8.632797545E-4 -1.306586453E-4 .0029546 -.8476272
```