### PR TITLE
SIM: add merge option by sub-detector name while SD

### DIFF
--- a/Simulation/DetSimSD/include/DetSimSD/CaloSensitiveDetector.h
+++ b/Simulation/DetSimSD/include/DetSimSD/CaloSensitiveDetector.h
@@ -15,7 +15,7 @@ public:
     typedef G4THitsCollection<CalorimeterHit> CaloHitCollection;
 
 public:
-    CaloSensitiveDetector(const std::string& name, dd4hep::Detector& description, bool unmerge=true);
+    CaloSensitiveDetector(const std::string& name, dd4hep::Detector& description, bool m_isMergeEnabled=true);
 
 public:
     // Geant4 interface
@@ -31,7 +31,7 @@ protected:
 
     HitCollection* m_hc;
     std::map<unsigned long, CalorimeterHit*> m_hitMap;
-    bool                                     m_unmerge;
+    bool                                     m_isMergeEnabled;
 };
 
 

--- a/Simulation/DetSimSD/src/CalorimeterSensDetTool.cpp
+++ b/Simulation/DetSimSD/src/CalorimeterSensDetTool.cpp
@@ -35,15 +35,15 @@ CalorimeterSensDetTool::createSD(const std::string& name) {
 
     dd4hep::Detector* dd4hep_geo = m_geosvc->lcdd();
 
-    bool flagUnmerge = false;
-    for(auto cal_name : m_unmergeCals){
+    bool is_merge_enabled = true;
+    for(auto cal_name : m_listCalsMergeDisable){
       if(cal_name==name){
-	flagUnmerge = true;
+	is_merge_enabled = false;
 	break;
       }
     }
-    G4VSensitiveDetector* sd = new CaloSensitiveDetector(name, *dd4hep_geo, flagUnmerge);
-    debug() << name << " set to merge true/false = " << !flagUnmerge << endmsg;
+    G4VSensitiveDetector* sd = new CaloSensitiveDetector(name, *dd4hep_geo, is_merge_enabled);
+    debug() << name << " set to merge true/false = " << is_merge_enabled << endmsg;
 
     return sd;
 }

--- a/Simulation/DetSimSD/src/CalorimeterSensDetTool.h
+++ b/Simulation/DetSimSD/src/CalorimeterSensDetTool.h
@@ -29,7 +29,7 @@ private:
     // in order to initialize SD, we need to get the lcdd()
     SmartIF<IGeomSvc> m_geosvc;
 
-    Gaudi::Property<std::vector<std::string> > m_unmergeCals{this, "UnmergedCalNames", {}};
+    Gaudi::Property<std::vector<std::string> > m_listCalsMergeDisable{this, "CalNamesMergeDisable", {}};
 };
 
 #endif


### PR DESCRIPTION
* this PR try to reduce the simulating time. Because contributions have not position, sometime contribution need to cheat as hit.
* add option through CalorimeterSensDetTool, name list of sub-detectors without merging, like
  * `from Configurables import CalorimeterSensDetTool`
    `cal_sensdettool = CalorimeterSensDetTool("CalorimeterSensDetTool")`
    `cal_sensdettool.CalNamesMergeDisable = ["EcalBarrel"]`
  * default option is to merge
* reduce CPU time much more: for 10 electrons (100GeV, theta:0-180, phi:0-360), 7 electrons enter the calorimeter (example as [`Detector/DetCRD/compact/CRD_common_v01/Ecal_Rotated_Crystal_v01_01.xml`](Detector/DetCRD/compact/CRD_common_v01/Ecal_Rotated_Crystal_v01_01.xml)), total real/user time spent
  * merge enable(by position):     68m13.253s/47m57.027s           #old case
  * merge disable(remove find):   3m48.536s/3m25.379s
  * merge enable(by cellID):         3m49.279s/  3m26.738s