### PR TITLE
Adapt to new (v00-15) podio generated class names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build.*
+build
 spack*
 ./Generator/output/
 ./Generator/options/

--- a/Analysis/TrackInspect/src/TrackInspectAlg.cpp
+++ b/Analysis/TrackInspect/src/TrackInspectAlg.cpp
@@ -134,7 +134,7 @@ StatusCode TrackInspectAlg::execute(){
     for (auto relCol: relCols) {
     	if (relCol){
 	    for (auto rel: *relCol){
-		    std::pair<edm4hep::ConstTrackerHit, edm4hep::ConstMCParticle> p = std::make_pair(rel.getRec(), rel.getSim().getMCParticle());
+		    std::pair<edm4hep::TrackerHit, edm4hep::MCParticle> p = std::make_pair(rel.getRec(), rel.getSim().getMCParticle());
 		    if (hitmap.find(p) == hitmap.end()) hitmap[p] = 0.;
 		    hitmap[p] += rel.getWeight();
 	    }
@@ -163,7 +163,7 @@ StatusCode TrackInspectAlg::execute(){
             for (auto particle: *mcpCol){
                 double match_weight = match(particle, track);
                 if (match_weight > 0.2){
-                    std::tuple<edm4hep::ConstMCParticle, edm4hep::ConstTrack, double> tuple = std::make_tuple(particle, track, match_weight);
+                    std::tuple<edm4hep::MCParticle, edm4hep::Track, double> tuple = std::make_tuple(particle, track, match_weight);
                     matchvec.push_back(tuple);
                 }
             }
@@ -174,7 +174,7 @@ StatusCode TrackInspectAlg::execute(){
         // MCParticleHitAssociator(mcpCol);
         m_nParticles = 0;
         for (auto particle: *mcpCol) {
-            std::vector<edm4hep::ConstTrack> theTracks = MCParticleTrackAssociator(particle);
+            std::vector<edm4hep::Track> theTracks = MCParticleTrackAssociator(particle);
 
             if (theTracks.size() == 0) {
                 totalCandidates[m_nParticles] = 0;
@@ -199,16 +199,16 @@ StatusCode TrackInspectAlg::execute(){
     return StatusCode::SUCCESS;
 }
 
-double TrackInspectAlg::match(edm4hep::ConstMCParticle particle, edm4hep::ConstTrack track){
+double TrackInspectAlg::match(edm4hep::MCParticle particle, edm4hep::Track track){
 
     int NHits = track.trackerHits_size();
 
     double matchedHits = 0;
     double usedHits = 0;
     for (int i = 0; i < NHits; i++) {
-        edm4hep::ConstTrackerHit hit = track.getTrackerHits(i);
+        edm4hep::TrackerHit hit = track.getTrackerHits(i);
         usedHits++;
-        std::pair<edm4hep::ConstTrackerHit, edm4hep::ConstMCParticle> ele = std::make_pair(hit, particle);
+        std::pair<edm4hep::TrackerHit, edm4hep::MCParticle> ele = std::make_pair(hit, particle);
         //std::cout << "lookup --> " << ele.first << std::endl;
         //if (hitmap.find(ele) != hitmap.end() ) {
         //std::cout << "find --> " << hitmap[ele] << std::endl;
@@ -227,7 +227,7 @@ double TrackInspectAlg::match(edm4hep::ConstMCParticle particle, edm4hep::ConstT
     return matchedHits / usedHits;
 }
 
-void TrackInspectAlg::Fill(edm4hep::ConstMCParticle particle, edm4hep::ConstTrack theTrack) {
+void TrackInspectAlg::Fill(edm4hep::MCParticle particle, edm4hep::Track theTrack) {
     pid[m_nParticles] = particle.getPDG();
 
     vx[m_nParticles] = particle.getVertex().x;
@@ -287,8 +287,8 @@ void TrackInspectAlg::Fill(edm4hep::ConstMCParticle particle, edm4hep::ConstTrac
     }   
 }
 
-std::vector<edm4hep::ConstTrack> TrackInspectAlg::MCParticleTrackAssociator(edm4hep::ConstMCParticle theParticle) {
-    std::vector<edm4hep::ConstTrack> theTracks;
+std::vector<edm4hep::Track> TrackInspectAlg::MCParticleTrackAssociator(edm4hep::MCParticle theParticle) {
+    std::vector<edm4hep::Track> theTracks;
     // std::cout << "The particle: " << theParticle.getPDG() << " " << theParticle << std::endl;
     for (auto matchtuple: matchvec){
         if (std::get<0>(matchtuple) == theParticle){

--- a/Analysis/TrackInspect/src/TrackInspectAlg.h
+++ b/Analysis/TrackInspect/src/TrackInspectAlg.h
@@ -42,9 +42,9 @@ class TrackInspectAlg : public Algorithm {
         Gaudi::Property<bool> _useSET{this, "useSET", true};
         Gaudi::Property<bool> _useFTD{this, "useFTD", true};
 
-        std::map<std::pair<edm4hep::ConstTrackerHit, edm4hep::ConstMCParticle>, double> hitmap;
-        std::vector<std::tuple<edm4hep::ConstMCParticle, edm4hep::ConstTrack, double>> matchvec;
-        double match(edm4hep::ConstMCParticle, edm4hep::ConstTrack);
+        std::map<std::pair<edm4hep::TrackerHit, edm4hep::MCParticle>, double> hitmap;
+        std::vector<std::tuple<edm4hep::MCParticle, edm4hep::Track, double>> matchvec;
+        double match(edm4hep::MCParticle, edm4hep::Track);
 
         void initializeRelationCollections(std::vector<const edm4hep::MCRecoTrackerAssociationCollection*> &relCols);
 
@@ -52,10 +52,10 @@ class TrackInspectAlg : public Algorithm {
         std::string m_thisName;
 
         // TrackingEfficiency
-        void Fill(edm4hep::ConstMCParticle, edm4hep::ConstTrack);
-        std::vector<edm4hep::ConstTrack> MCParticleTrackAssociator(edm4hep::ConstMCParticle);
+        void Fill(edm4hep::MCParticle, edm4hep::Track);
+        std::vector<edm4hep::Track> MCParticleTrackAssociator(edm4hep::MCParticle);
 
-        std::map<edm4hep::ConstMCParticle, std::vector<edm4hep::ConstSimTrackerHit>> mcpHitMap;
+        std::map<edm4hep::MCParticle, std::vector<edm4hep::SimTrackerHit>> mcpHitMap;
         std::string treeFileName;
 
         NTuple::Tuple* m_tuple;

--- a/Digitisers/DCHDigi/src/DCHDigiAlg.cpp
+++ b/Digitisers/DCHDigi/src/DCHDigiAlg.cpp
@@ -103,7 +103,7 @@ StatusCode DCHDigiAlg::execute()
 
   auto SimHit0 = SimHitCol->at(0);
   std::map<unsigned long long, std::vector<decltype(SimHit0)> > id_hits_map;
-  //std::map<unsigned long long, std::vector<edm4hep::ConstSimTrackerhit> > id_hits_map;
+  //std::map<unsigned long long, std::vector<edm4hep::SimTrackerhit> > id_hits_map;
 
   for( int i = 0; i < SimHitCol->size(); i++ ) 
   {

--- a/Digitisers/G2CDArbor/src/G2CDArborAlg.cpp
+++ b/Digitisers/G2CDArbor/src/G2CDArborAlg.cpp
@@ -524,7 +524,7 @@ StatusCode G2CDArborAlg::execute()
 	       // for(int k=0; k<SimEcalhit->getNMCContributions(); k++)
 	       // {
 	       for(int k=0; k<SimEcalhit.contributions_size(); k++){
-		    edm4hep::ConstCaloHitContribution hitContribution = SimEcalhit.getContributions(k);
+		    edm4hep::CaloHitContribution hitContribution = SimEcalhit.getContributions(k);
 	  	    // HitStepEn = SimEcalhit->getEnergyCont(k);
 		    HitStepEn = hitContribution.getEnergy();
 	  	    if(HitStepEn > EmaxStep)
@@ -626,7 +626,7 @@ StatusCode G2CDArborAlg::execute()
      	  //      for(int k=0; k<SimHcalhit->getNMCContributions(); k++)
      	  //      {
      	       for(int k=0; k<SimHcalhit.contributions_size(); k++){
-     		    edm4hep::ConstCaloHitContribution hitContribution = SimHcalhit.getContributions(k);
+     		    edm4hep::CaloHitContribution hitContribution = SimHcalhit.getContributions(k);
 
      	  	    // HitStepEn = SimHcalhit->getEnergyCont(k);
      		    HitStepEn = hitContribution.getEnergy();

--- a/Digitisers/G2CDArbor/src/G2CDArborAlg.h
+++ b/Digitisers/G2CDArbor/src/G2CDArborAlg.h
@@ -6,7 +6,6 @@
 #include "Gaudi/Property.h"
 #include "edm4hep/EventHeader.h"
 #include "edm4hep/EventHeaderCollection.h"
-#include "edm4hep/SimCalorimeterHitConst.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/CalorimeterHit.h"
 #include "edm4hep/CalorimeterHitCollection.h"

--- a/Digitisers/SimHitMerge/src/SimHitMergeAlg.cpp
+++ b/Digitisers/SimHitMerge/src/SimHitMergeAlg.cpp
@@ -60,8 +60,8 @@ StatusCode SimHitMergeAlg::execute()
      
      for (unsigned int k0 = 0; k0 < m_inputColNames.size(); k0++)
      {
-          std::map<unsigned long long, edm4hep::SimCalorimeterHit> id_hit_map;
-          std::map<unsigned long long, std::vector<edm4hep::ConstCaloHitContribution> > id_vconb_map;
+          std::map<unsigned long long, edm4hep::MutableSimCalorimeterHit> id_hit_map;
+          std::map<unsigned long long, std::vector<edm4hep::CaloHitContribution> > id_vconb_map;
 	  edm4hep::SimCalorimeterHitCollection* mergedCol = m_OutputCollections[k0]->createAndPut();
 	  auto col = m_InputCollections[k0]->get();
           //std::cout<<"input="<<m_InputCollections[k0]->objKey()<<",size="<<col->size()<<std::endl;
@@ -78,10 +78,10 @@ StatusCode SimHitMergeAlg::execute()
               //std::cout<<"DD_sim_hit::ProcessHits, sp x="<<Simhit.getPosition()[0]<<", y="<<Simhit.getPosition()[1]<<", z="<<Simhit.getPosition()[2]<<",edep="<<Simhit.getEnergy()<<std::endl;
               if ( id_hit_map.find(id) != id_hit_map.end()) id_hit_map[id].setEnergy(id_hit_map[id].getEnergy() + Simhit.getEnergy());
               else {
-                  edm4hep::SimCalorimeterHit newSimhit(Simhit.getCellID(), Simhit.getEnergy(), Simhit.getPosition());
+                  edm4hep::MutableSimCalorimeterHit newSimhit(Simhit.getCellID(), Simhit.getEnergy(), Simhit.getPosition());
                   id_hit_map[id] = newSimhit;
               }
-              std::vector<edm4hep::ConstCaloHitContribution> tmp_vconb ;
+              std::vector<edm4hep::CaloHitContribution> tmp_vconb ;
               for(int kk=0; kk<Simhit.contributions_size(); kk++){
                   tmp_vconb.push_back(Simhit.getContributions(kk));
               }

--- a/Digitisers/SimHitMerge/src/SimHitMergeAlg.h
+++ b/Digitisers/SimHitMerge/src/SimHitMergeAlg.h
@@ -6,7 +6,6 @@
 #include "Gaudi/Property.h"
 #include "edm4hep/EventHeader.h"
 #include "edm4hep/EventHeaderCollection.h"
-#include "edm4hep/SimCalorimeterHitConst.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/SimCalorimeterHitCollection.h"
 #include "edm4hep/MCRecoCaloAssociationCollection.h"

--- a/Digitisers/SimpleDigi/src/PlanarDigiAlg.cpp
+++ b/Digitisers/SimpleDigi/src/PlanarDigiAlg.cpp
@@ -4,7 +4,7 @@
 #include "GearSvc/IGearSvc.h"
 #include "EventSeeder/IEventSeeder.h"
 #include "TrackSystemSvc/ITrackSystemSvc.h"
-#include "edm4hep/MCParticleConst.h"
+#include "edm4hep/MCParticle.h"
 #include "edm4hep/Vector3d.h"
 /*
 #include <EVENT/LCCollection.h>

--- a/Digitisers/SimpleDigi/src/TPCDigiAlg.cpp
+++ b/Digitisers/SimpleDigi/src/TPCDigiAlg.cpp
@@ -546,10 +546,10 @@ StatusCode TPCDigiAlg::execute()
 
     debug() << "number of Pad-Row based SimHits = " << n_sim_hits << endmsg;
     
-    edm4hep::ConstMCParticle nMinus2MCP;
-    edm4hep::ConstMCParticle previousMCP;
-    edm4hep::ConstSimTrackerHit nMinus2SimHit;
-    edm4hep::ConstSimTrackerHit previousSimTHit;
+    edm4hep::MCParticle nMinus2MCP;
+    edm4hep::MCParticle previousMCP;
+    edm4hep::SimTrackerHit nMinus2SimHit;
+    edm4hep::SimTrackerHit previousSimTHit;
 
     debug() << "processing nhit=" << n_sim_hits << endmsg;
     // loop over all the pad row based sim hits
@@ -578,7 +578,7 @@ StatusCode TPCDigiAlg::execute()
       // conversion constant. r = pt / (FCT*bField)
       const double FCT = 2.99792458E-4;
       bool found_mc = false;
-      edm4hep::ConstMCParticle mcp;
+      edm4hep::MCParticle mcp;
       try{ // protect crash while MCParticle unavailable
         mcp = SimTHit.getMCParticle() ;
       }
@@ -647,18 +647,18 @@ StatusCode TPCDigiAlg::execute()
           padPhi = CLHEP::twopi/4.0 ;
         }
         else{
-          edm4hep::ConstSimTrackerHit nextSimTHit;
-          edm4hep::ConstSimTrackerHit nPlus2SimHit;
-          edm4hep::ConstMCParticle nextMCP;
-          edm4hep::ConstMCParticle nPlus2MCP;
+          edm4hep::SimTrackerHit nextSimTHit;
+          edm4hep::SimTrackerHit nPlus2SimHit;
+          edm4hep::MCParticle nextMCP;
+          edm4hep::MCParticle nPlus2MCP;
           // if there is at least one more hit after this one, set the pointer to the MCParticle for the next hit
           if (i < (n_sim_hits-1) ) {
             nextSimTHit = STHcol->at( i+1 ) ;
             nextMCP     = nextSimTHit.getMCParticle() ;
           }
           else{ // set make sure that the pointers are set back to NULL so that the comparisons later hold
-            //nextSimTHit = edm4hep::ConstSimTrackerHit;
-            //nextMCP     = edm4hep::ConstMCParticle;
+            //nextSimTHit = edm4hep::SimTrackerHit;
+            //nextMCP     = edm4hep::MCParticle;
           }
           // if there is at least two more hits after this one, set the pointer to the MCParticle for the next but one hit
           if (i < (n_sim_hits-2) ) {
@@ -666,8 +666,8 @@ StatusCode TPCDigiAlg::execute()
             nPlus2MCP    = nPlus2SimHit.getMCParticle() ;
           }
           else{ // set make sure that the pointers are set back to NULL so that the comparisons later hold
-            //_nPlus2SimHit = edm4hep::ConstSimTrackerHit;
-            //_nPlus2MCP    = edm4hep::ConstMCParticle;
+            //_nPlus2SimHit = edm4hep::SimTrackerHit;
+            //_nPlus2MCP    = edm4hep::MCParticle;
           }
 
           if      ( mcp==previousMCP && mcp==nextMCP )    { // middle hit of 3 from the same MCParticle
@@ -1166,7 +1166,7 @@ void TPCDigiAlg::writeVoxelToHit( Voxel_tpc* aVoxel){
   //  if( seed_hit->getRowIndex() > 5 ) return ;
   debug() << "==============" << endmsg;
   //store hit variables
-  edm4hep::TrackerHit trkHit;// = _trkhitVec->create();
+  edm4hep::MutableTrackerHit trkHit;// = _trkhitVec->create();
   //now the hit pos has to be smeared
 
   double tpcRPhiRes = seed_hit->getRPhiRes();
@@ -1302,7 +1302,7 @@ void TPCDigiAlg::writeMergedVoxelsToHit( vector <Voxel_tpc*>* hitsToMerge){
   const gear::PadRowLayout2D& padLayout = gearTPC.getPadLayout() ;
   const gear::Vector2D padCoord = padLayout.getPadCenter(1) ;
 
-  edm4hep::TrackerHit trkHit;// = _trkhitVec->create();
+  edm4hep::MutableTrackerHit trkHit;// = _trkhitVec->create();
 
   double sumZ = 0;
   double sumPhi = 0;

--- a/Digitisers/SimpleDigi/src/TPCDigiAlg.h
+++ b/Digitisers/SimpleDigi/src/TPCDigiAlg.h
@@ -177,11 +177,11 @@ protected:
   int _nRun ;
   int _nEvt ;
 
-  //edm4hep::ConstMCParticle _mcp;
-  //edm4hep::ConstMCParticle _previousMCP;
-  //edm4hep::ConstMCParticle _nextMCP;
-  //edm4hep::ConstMCParticle _nMinus2MCP;
-  //edm4hep::ConstMCParticle _nPlus2MCP;
+  //edm4hep::MCParticle _mcp;
+  //edm4hep::MCParticle _previousMCP;
+  //edm4hep::MCParticle _nextMCP;
+  //edm4hep::MCParticle _nMinus2MCP;
+  //edm4hep::MCParticle _nPlus2MCP;
 
   //edm4hep::SimTrackerHit _SimTHit;
   //edm4hep::SimTrackerHit _previousSimTHit;
@@ -213,7 +213,7 @@ protected:
 
   std::vector< std::vector <Voxel_tpc *> > _tpcRowHits;
   // std::map< Voxel_tpc *,edm4hep::SimTrackerHit > _tpcHitMap;
-  std::map< Voxel_tpc *, edm4hep::ConstSimTrackerHit > _tpcHitMap;
+  std::map< Voxel_tpc *, edm4hep::SimTrackerHit > _tpcHitMap;
 
   UTIL::BitField64* _cellid_encoder;
 

--- a/Generator/src/GtBeamBackgroundTool.cpp
+++ b/Generator/src/GtBeamBackgroundTool.cpp
@@ -66,7 +66,7 @@ bool GtBeamBackgroundTool::mutate(MyHepMC::GenEvent& event) {
         }
 
         // create the MC particle
-        edm4hep::MCParticle mcp = event.m_mc_vec.create();
+        auto mcp = event.m_mc_vec.create();
         mcp.setPDG(beamdata.pdgid);
         mcp.setGeneratorStatus(1);
         mcp.setSimulatorStatus(1);

--- a/Generator/src/GtGunTool.cpp
+++ b/Generator/src/GtGunTool.cpp
@@ -125,7 +125,7 @@ GtGunTool::mutate(MyHepMC::GenEvent& event) {
         double energy = energy_min==energy_max ? energy_min : CLHEP::RandFlat::shoot(energy_min, energy_max);
 
         // create the MC particle
-        edm4hep::MCParticle mcp = event.m_mc_vec.create();
+        auto mcp = event.m_mc_vec.create();
         mcp.setPDG(pdgcode);
         mcp.setGeneratorStatus(1);
         mcp.setSimulatorStatus(1);

--- a/Generator/src/HepMCRdr.cpp
+++ b/Generator/src/HepMCRdr.cpp
@@ -39,7 +39,7 @@ bool HepMCRdr::mutate(MyHepMC::GenEvent& event){
     int index = 0 ;
     for ( HepMC::GenEvent::particle_iterator p = evt->particles_begin(); p != evt->particles_end(); ++p ) {
         //std::cout<<"start mc "<<index<<std::endl;
-        edm4hep::MCParticle mcp = event.m_mc_vec.create();
+        auto mcp = event.m_mc_vec.create();
         pmcid_lmcid.insert(std::pair<int, int>((*p)->barcode(),index));
         index++;
         //std::cout<<"map<id,i>:"<<mc->id()<<","<< i <<std::endl;
@@ -72,7 +72,7 @@ bool HepMCRdr::mutate(MyHepMC::GenEvent& event){
     // second loop for setting parents and daughters
     index = 0 ;
     for ( HepMC::GenEvent::particle_iterator p = evt->particles_begin(); p != evt->particles_end(); ++p ) {
-        edm4hep::MCParticle pmc = event.m_mc_vec.at(index);
+        auto pmc = event.m_mc_vec.at(index);
         index++;
         if ( (*p)->production_vertex() ) {
             for ( HepMC::GenVertex::particle_iterator mother = (*p)->production_vertex()-> particles_begin(HepMC::parents); mother != (*p)->production_vertex()-> particles_end(HepMC::parents); ++mother ) {

--- a/Generator/src/SLCIORdr.cpp
+++ b/Generator/src/SLCIORdr.cpp
@@ -106,7 +106,7 @@ bool SLCIORdr::mutate(MyHepMC::GenEvent& event){
     for (int i=0; i < n_mc; i++){
         MCParticleImpl* mc = (MCParticleImpl*) lcMCVec->getElementAt(i);
         //std::cout<<"At mc :"<< i <<std::endl;
-        edm4hep::MCParticle mcp = event.m_mc_vec.create();
+        auto mcp = event.m_mc_vec.create();
         pmcid_lmcid.insert(std::pair<int, int>(mc->id(),i));
         //std::cout<<"map<id,i>:"<<mc->id()<<","<< i <<std::endl;
                                  
@@ -129,7 +129,7 @@ bool SLCIORdr::mutate(MyHepMC::GenEvent& event){
         MCParticleImpl* mc = (MCParticleImpl*) lcMCVec->getElementAt(i);
         const MCParticleVec & mc_parents = mc->getParents();
         const MCParticleVec & mc_daughters = mc->getDaughters();
-        edm4hep::MCParticle pmc = event.m_mc_vec.at(i);
+        auto pmc = event.m_mc_vec.at(i);
         //std::cout<<"mc at "<< i<<", parent size "<<mc_parents.size() <<std::endl;
         for(unsigned int j=0; j< mc_parents.size(); j++){int p_id = mc_parents.at(j)->id();
                                                  //std::cout<<"parent id "<<p_id<<std::endl;

--- a/Generator/src/StdHepRdr.cpp
+++ b/Generator/src/StdHepRdr.cpp
@@ -40,7 +40,7 @@ bool StdHepRdr::mutate(MyHepMC::GenEvent& event){
     for (int i=0; i < n_mc; i++){
         MCParticleImpl* mc = (MCParticleImpl*) mc_vec->getElementAt(i);
         //std::cout<<"At mc :"<< i <<std::endl;
-        edm4hep::MCParticle mcp = event.m_mc_vec.create();
+        auto mcp = event.m_mc_vec.create();
         pmcid_lmcid.insert(std::pair<int, int>(mc->id(),i));
         //std::cout<<"map<id,i>:"<<mc->id()<<","<< i <<std::endl;
                                  
@@ -63,7 +63,7 @@ bool StdHepRdr::mutate(MyHepMC::GenEvent& event){
         MCParticleImpl* mc = (MCParticleImpl*) mc_vec->getElementAt(i);
         const MCParticleVec & mc_parents = mc->getParents();
         const MCParticleVec & mc_daughters = mc->getDaughters();
-        edm4hep::MCParticle pmc = event.m_mc_vec.at(i);
+        auto pmc = event.m_mc_vec.at(i);
         //std::cout<<"mc at "<< i<<", parent size "<<mc_parents.size() <<std::endl;
         for(unsigned int j=0; j< mc_parents.size(); j++){int p_id = mc_parents.at(j)->id();
                                                  //std::cout<<"parent id "<<p_id<<std::endl;

--- a/Reconstruction/DCHDedx/src/RecDCHDedxAlg.cpp
+++ b/Reconstruction/DCHDedx/src/RecDCHDedxAlg.cpp
@@ -86,7 +86,7 @@ StatusCode RecDCHDedxAlg::execute()
             return StatusCode::SUCCESS;
         }
         for(unsigned j=0; j<ptrkCol->size(); j++){
-            std::map< edm4hep::ConstMCParticle, int > map_mc_count;
+            std::map< edm4hep::MCParticle, int > map_mc_count;
             auto tmp_track = ptrkCol->at(j);
             for(unsigned k=0; k< tmp_track.trackerHits_size(); k++){
                 for(unsigned z=0; z< assoCol->size(); z++){
@@ -99,7 +99,7 @@ StatusCode RecDCHDedxAlg::execute()
                     
                 }
             }
-            edm4hep::MCParticle tmp_mc;
+            edm4hep::MutableMCParticle tmp_mc;
             int max_cout = 0;
             for(auto iter = map_mc_count.begin(); iter != map_mc_count.end(); iter++ ){
                 if(iter->second > max_cout){
@@ -154,7 +154,7 @@ StatusCode RecDCHDedxAlg::execute()
            return StatusCode::SUCCESS;
        }
        for(unsigned j=0; j<ptrkCol->size(); j++){
-           std::map< edm4hep::ConstMCParticle, int > map_mc_count;
+           std::map< edm4hep::MCParticle, int > map_mc_count;
            auto tmp_track = ptrkCol->at(j);
            for(unsigned k=0; k< tmp_track.trackerHits_size(); k++){
                for(unsigned z=0; z< assoCol->size(); z++){
@@ -167,7 +167,7 @@ StatusCode RecDCHDedxAlg::execute()
                    
                }
            }
-           edm4hep::MCParticle tmp_mc;
+           edm4hep::MutableMCParticle tmp_mc;
            int max_cout = 0;
            for(auto iter = map_mc_count.begin(); iter != map_mc_count.end(); iter++ ){
                if(iter->second > max_cout){

--- a/Reconstruction/Digi_Calo/src/CaloDigiAlg.cpp
+++ b/Reconstruction/Digi_Calo/src/CaloDigiAlg.cpp
@@ -45,7 +45,7 @@ StatusCode CaloDigiAlg::initialize()
 
 StatusCode CaloDigiAlg::execute()
 {
-  std::map<unsigned long long, edm4hep::SimCalorimeterHit> id_hit_map;
+  std::map<unsigned long long, edm4hep::MutableSimCalorimeterHit> id_hit_map;
   edm4hep::CalorimeterHitCollection* caloVec   = w_DigiCaloCol.createAndPut();
   edm4hep::MCRecoCaloAssociationCollection* caloAssoVec   = w_CaloAssociationCol.createAndPut();
   const edm4hep::SimCalorimeterHitCollection* SimHitCol =  r_SimCaloCol.get();
@@ -68,7 +68,7 @@ StatusCode CaloDigiAlg::execute()
       tot_e += en;
       if ( id_hit_map.find(id) != id_hit_map.end()) id_hit_map[id].setEnergy(id_hit_map[id].getEnergy() + en);
       else {
-        edm4hep::SimCalorimeterHit newSimHit(SimHit.getCellID(), SimHit.getEnergy(), SimHit.getPosition());
+        edm4hep::MutableSimCalorimeterHit newSimHit(SimHit.getCellID(), SimHit.getEnergy(), SimHit.getPosition());
         id_hit_map[id] = newSimHit ;
       }
 

--- a/Reconstruction/Digi_Calo/src/CaloDigiAlg.h
+++ b/Reconstruction/Digi_Calo/src/CaloDigiAlg.h
@@ -3,7 +3,6 @@
 
 #include "k4FWCore/DataHandle.h"
 #include "GaudiAlg/GaudiAlgorithm.h"
-#include "edm4hep/SimCalorimeterHitConst.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/CalorimeterHit.h"
 #include "edm4hep/CalorimeterHitCollection.h"

--- a/Reconstruction/PFA/Arbor/src/ArborToolLCIO.cc
+++ b/Reconstruction/PFA/Arbor/src/ArborToolLCIO.cc
@@ -402,7 +402,7 @@ TVector3 ArborToolLCIO::ClusterCoG(edm4hep::Cluster inputCluster)
 }
 
 
-edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecColl( std::vector<edm4hep::Cluster> inputClusters, DataHandle<edm4hep::ClusterCollection>& m_clucol )
+edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecColl( std::vector<edm4hep::MutableCluster> inputClusters, DataHandle<edm4hep::ClusterCollection>& m_clucol )
 {
 
 	edm4hep::ClusterCollection* vec_coll_Clusters = m_clucol.createAndPut();
@@ -461,7 +461,7 @@ std::vector<edm4hep::Cluster> ArborToolLCIO::CollClusterVec(const edm4hep::Clust
 }
 
 
-void ArborToolLCIO::NaiveCluConst(edm4hep::Cluster a0_clu,edm4hep::Cluster b0_clu)
+void ArborToolLCIO::NaiveCluConst(edm4hep::MutableCluster a0_clu,edm4hep::MutableCluster b0_clu)
 {
 	b0_clu.setPosition(a0_clu.getPosition());
 	b0_clu.setEnergy(a0_clu.getEnergy());
@@ -492,9 +492,9 @@ void ArborToolLCIO::NaiveCluConst(edm4hep::Cluster a0_clu,edm4hep::Cluster b0_cl
 }
 
 
-edm4hep::Cluster ArborToolLCIO::NaiveCluImpl(edm4hep::Cluster a0_clu)
+edm4hep::Cluster ArborToolLCIO::NaiveCluImpl(edm4hep::MutableCluster a0_clu)
 {
-	edm4hep::Cluster b0_clu;
+	edm4hep::MutableCluster b0_clu;
 	b0_clu.setPosition(a0_clu.getPosition());
 	b0_clu.setEnergy(a0_clu.getEnergy());
 	int NCaloHit = a0_clu.hits_size();
@@ -543,9 +543,9 @@ std::vector<edm4hep::CalorimeterHit> ArborToolLCIO::CollHitVec(const edm4hep::Ca
 }
 
 
-std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterHitAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::CalorimeterHit> IsoHits, float DisThreshold )	// Projective Distance + Hit Depth correlation; 
+std::vector<edm4hep::MutableCluster> ArborToolLCIO::ClusterHitAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::CalorimeterHit> IsoHits, float DisThreshold )	// Projective Distance + Hit Depth correlation; 
 {
-	std::vector<edm4hep::Cluster> outputClusterVec;
+	std::vector<edm4hep::MutableCluster> outputClusterVec;
 
 	int N_Core = MainClusters.size();
 	int N_Hit = IsoHits.size();
@@ -598,7 +598,7 @@ std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterHitAbsorbtion( std::vector<e
 				tomerge_hits.push_back(a_frag);
 			}
 		}
-		edm4hep::Cluster a_mergedfrag_core;
+		edm4hep::MutableCluster a_mergedfrag_core;
 		ClusterEn = 0; 
 
 		for(unsigned int j2 = 0; j2 < a_core.hits_size(); j2++)
@@ -628,7 +628,7 @@ std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterHitAbsorbtion( std::vector<e
 }
 
 
-void ArborToolLCIO::NaiveMergeCluConst(std::vector<edm4hep::Cluster> inputCluVec,edm4hep::Cluster MergedClu)
+void ArborToolLCIO::NaiveMergeCluConst(std::vector<edm4hep::Cluster> inputCluVec,edm4hep::MutableCluster MergedClu)
 {
 
 	int NClu = inputCluVec.size();
@@ -692,9 +692,9 @@ void ArborToolLCIO::NaiveMergeCluConst(std::vector<edm4hep::Cluster> inputCluVec
 	}
 
 }
-edm4hep::Cluster ArborToolLCIO::NaiveMergeClu(std::vector<edm4hep::Cluster> inputCluVec)
+edm4hep::MutableCluster ArborToolLCIO::NaiveMergeClu(std::vector<edm4hep::Cluster> inputCluVec)
 {
-	edm4hep::Cluster MergedClu;
+	edm4hep::MutableCluster MergedClu;
 
 	int NClu = inputCluVec.size();
 	float SeedDis = 1E9; 
@@ -761,9 +761,9 @@ edm4hep::Cluster ArborToolLCIO::NaiveMergeClu(std::vector<edm4hep::Cluster> inpu
 
 
 
-std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::Cluster> FragClusters, float DisThreshold, float DepthSlope )	//ProjectiveDis
+std::vector<edm4hep::MutableCluster> ArborToolLCIO::ClusterAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::MutableCluster> FragClusters, float DisThreshold, float DepthSlope )	//ProjectiveDis
 {
-	std::vector<edm4hep::Cluster> outputClusterVec;
+	std::vector<edm4hep::MutableCluster> outputClusterVec;
 
 	int N_Core = MainClusters.size();
 	int N_frag = FragClusters.size();
@@ -823,7 +823,7 @@ std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterAbsorbtion( std::vector<edm4
 			}
 		}
 		auto a_mergedfrag_core = NaiveMergeClu(tomerge_clu);
-		edm4hep::Cluster a_mergedfrag_coreCon=a_mergedfrag_core;
+		edm4hep::MutableCluster a_mergedfrag_coreCon=a_mergedfrag_core;
 		outputClusterVec.push_back(a_mergedfrag_core);
 	}
 

--- a/Reconstruction/PFA/Arbor/src/ArborToolLCIO.cc
+++ b/Reconstruction/PFA/Arbor/src/ArborToolLCIO.cc
@@ -18,7 +18,6 @@
 #include "Gaudi/Property.h"
 #include "edm4hep/EventHeader.h"
 #include "edm4hep/EventHeaderCollection.h"
-#include "edm4hep/SimCalorimeterHitConst.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/CalorimeterHit.h"
 #include "edm4hep/CalorimeterHitCollection.h"
@@ -122,7 +121,7 @@ ArborToolLCIO::ArborToolLCIO(const std::string& name,ISvcLocator* svcLoc)
 ArborToolLCIO::~ArborToolLCIO()
 {
 }
-void ArborToolLCIO::ClusterBuilding( DataHandle<edm4hep::ClusterCollection>& _currbranchcoll, std::vector<edm4hep::ConstCalorimeterHit> Hits, branchcoll BranchOrder, int DHCALFlag )
+void ArborToolLCIO::ClusterBuilding( DataHandle<edm4hep::ClusterCollection>& _currbranchcoll, std::vector<edm4hep::CalorimeterHit> Hits, branchcoll BranchOrder, int DHCALFlag )
 {
 	//DataHandle<edm4hep::ClusterCollection> _currbranchcoll {"Name",Gaudi::DataHandle::Writer, this};
 	//DataHandle<edm4hep::ClusterCollection> _currbranchcoll=new ClusterType(Name, Gaudi::DataHandle::Writer, this);
@@ -192,7 +191,7 @@ void ArborToolLCIO::ClusterBuilding( DataHandle<edm4hep::ClusterCollection>& _cu
 
 
 
-int ArborToolLCIO::NHScaleV2( std::vector<edm4hep::ConstCalorimeterHit> clu0, int RatioX, int RatioY, int RatioZ )
+int ArborToolLCIO::NHScaleV2( std::vector<edm4hep::CalorimeterHit> clu0, int RatioX, int RatioY, int RatioZ )
 {
 
 	int ReScaledNH = 0;
@@ -237,7 +236,7 @@ int ArborToolLCIO::NHScaleV2( std::vector<edm4hep::ConstCalorimeterHit> clu0, in
 	return ReScaledNH;
 }
 
-float ArborToolLCIO::FDV2( std::vector<edm4hep::ConstCalorimeterHit> clu)
+float ArborToolLCIO::FDV2( std::vector<edm4hep::CalorimeterHit> clu)
 {
 	float FractalDim = 0;
 	int NReSizeHit[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -257,7 +256,7 @@ float ArborToolLCIO::FDV2( std::vector<edm4hep::ConstCalorimeterHit> clu)
 }
 
 
-int ArborToolLCIO::NHScaleV3( edm4hep::ConstCluster clu0, int RatioX, int RatioY, int RatioZ )
+int ArborToolLCIO::NHScaleV3( edm4hep::Cluster clu0, int RatioX, int RatioY, int RatioZ )
 {
 
 	int ReScaledNH = 0;
@@ -305,7 +304,7 @@ int ArborToolLCIO::NHScaleV3( edm4hep::ConstCluster clu0, int RatioX, int RatioY
 
 }
 
-float ArborToolLCIO::FDV3( edm4hep::ConstCluster clu ){
+float ArborToolLCIO::FDV3( edm4hep::Cluster clu ){
 
 	float FractalDim = -1;
         int NReSizeHit[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -324,7 +323,7 @@ float ArborToolLCIO::FDV3( edm4hep::ConstCluster clu ){
 }
 
 
-float ArborToolLCIO::BushDis( edm4hep::ConstCluster clu1, edm4hep::ConstCluster clu2)
+float ArborToolLCIO::BushDis( edm4hep::Cluster clu1, edm4hep::Cluster clu2)
 {
 	float DisBetweenBush = 1.0E10; 
 
@@ -355,7 +354,7 @@ float ArborToolLCIO::BushDis( edm4hep::ConstCluster clu1, edm4hep::ConstCluster 
 }
 
 
-float ArborToolLCIO::DisPointToBush(TVector3 Pos1, edm4hep::ConstCluster clu1)
+float ArborToolLCIO::DisPointToBush(TVector3 Pos1, edm4hep::Cluster clu1)
 {
 	float Dis = 1.0E9; 
 	float HitDis = 1.0E8;
@@ -377,7 +376,7 @@ float ArborToolLCIO::DisPointToBush(TVector3 Pos1, edm4hep::ConstCluster clu1)
 }
 
 
-TVector3 ArborToolLCIO::ClusterCoG(edm4hep::ConstCluster inputCluster)
+TVector3 ArborToolLCIO::ClusterCoG(edm4hep::Cluster inputCluster)
 {
 	TVector3 CenterOfGravity; 
 
@@ -403,7 +402,7 @@ TVector3 ArborToolLCIO::ClusterCoG(edm4hep::ConstCluster inputCluster)
 }
 
 
-edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecColl( std::vector<edm4hep::ConstCluster> inputClusters, DataHandle<edm4hep::ClusterCollection>& m_clucol )
+edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecColl( std::vector<edm4hep::Cluster> inputClusters, DataHandle<edm4hep::ClusterCollection>& m_clucol )
 {
 
 	edm4hep::ClusterCollection* vec_coll_Clusters = m_clucol.createAndPut();
@@ -445,9 +444,9 @@ edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecColl( std::vector<edm4hep::
 	return vec_coll_Clusters;
 }
 
-std::vector<edm4hep::ConstCluster> ArborToolLCIO::CollClusterVec(const edm4hep::ClusterCollection * input_coll )
+std::vector<edm4hep::Cluster> ArborToolLCIO::CollClusterVec(const edm4hep::ClusterCollection * input_coll )
 {
-	std::vector<edm4hep::ConstCluster> outputClusterVec; 
+	std::vector<edm4hep::Cluster> outputClusterVec; 
 
 
 	outputClusterVec.clear();
@@ -462,7 +461,7 @@ std::vector<edm4hep::ConstCluster> ArborToolLCIO::CollClusterVec(const edm4hep::
 }
 
 
-void ArborToolLCIO::NaiveCluConst(edm4hep::ConstCluster a0_clu,edm4hep::Cluster b0_clu)
+void ArborToolLCIO::NaiveCluConst(edm4hep::Cluster a0_clu,edm4hep::Cluster b0_clu)
 {
 	b0_clu.setPosition(a0_clu.getPosition());
 	b0_clu.setEnergy(a0_clu.getEnergy());
@@ -493,7 +492,7 @@ void ArborToolLCIO::NaiveCluConst(edm4hep::ConstCluster a0_clu,edm4hep::Cluster 
 }
 
 
-edm4hep::Cluster ArborToolLCIO::NaiveCluImpl(edm4hep::ConstCluster a0_clu)
+edm4hep::Cluster ArborToolLCIO::NaiveCluImpl(edm4hep::Cluster a0_clu)
 {
 	edm4hep::Cluster b0_clu;
 	b0_clu.setPosition(a0_clu.getPosition());
@@ -525,9 +524,9 @@ edm4hep::Cluster ArborToolLCIO::NaiveCluImpl(edm4hep::ConstCluster a0_clu)
 	return b0_clu; 
 }
 
-std::vector<edm4hep::ConstCalorimeterHit> ArborToolLCIO::CollHitVec(const edm4hep::CalorimeterHitCollection * input_coll, float EnergyThreshold)
+std::vector<edm4hep::CalorimeterHit> ArborToolLCIO::CollHitVec(const edm4hep::CalorimeterHitCollection * input_coll, float EnergyThreshold)
 {
-	std::vector<edm4hep::ConstCalorimeterHit> outputHitVec;
+	std::vector<edm4hep::CalorimeterHit> outputHitVec;
 
 	outputHitVec.clear();
 
@@ -544,7 +543,7 @@ std::vector<edm4hep::ConstCalorimeterHit> ArborToolLCIO::CollHitVec(const edm4he
 }
 
 
-std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterHitAbsorbtion( std::vector<edm4hep::ConstCluster> MainClusters, std::vector<edm4hep::ConstCalorimeterHit> IsoHits, float DisThreshold )	// Projective Distance + Hit Depth correlation; 
+std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterHitAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::CalorimeterHit> IsoHits, float DisThreshold )	// Projective Distance + Hit Depth correlation; 
 {
 	std::vector<edm4hep::Cluster> outputClusterVec;
 
@@ -582,7 +581,7 @@ std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterHitAbsorbtion( std::vector<e
 	}
 
 	int N_frag_core_links = Frag_Core_Links.size();
-	std::vector<edm4hep::ConstCalorimeterHit> tomerge_hits;
+	std::vector<edm4hep::CalorimeterHit> tomerge_hits;
 	float ClusterEn = 0; 
 
 	for(int i2 = 0; i2 < N_Core; i2 ++)
@@ -629,7 +628,7 @@ std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterHitAbsorbtion( std::vector<e
 }
 
 
-void ArborToolLCIO::NaiveMergeCluConst(std::vector<edm4hep::ConstCluster> inputCluVec,edm4hep::Cluster MergedClu)
+void ArborToolLCIO::NaiveMergeCluConst(std::vector<edm4hep::Cluster> inputCluVec,edm4hep::Cluster MergedClu)
 {
 
 	int NClu = inputCluVec.size();
@@ -693,7 +692,7 @@ void ArborToolLCIO::NaiveMergeCluConst(std::vector<edm4hep::ConstCluster> inputC
 	}
 
 }
-edm4hep::Cluster ArborToolLCIO::NaiveMergeClu(std::vector<edm4hep::ConstCluster> inputCluVec)
+edm4hep::Cluster ArborToolLCIO::NaiveMergeClu(std::vector<edm4hep::Cluster> inputCluVec)
 {
 	edm4hep::Cluster MergedClu;
 
@@ -762,9 +761,9 @@ edm4hep::Cluster ArborToolLCIO::NaiveMergeClu(std::vector<edm4hep::ConstCluster>
 
 
 
-std::vector<edm4hep::ConstCluster> ArborToolLCIO::ClusterAbsorbtion( std::vector<edm4hep::ConstCluster> MainClusters, std::vector<edm4hep::ConstCluster> FragClusters, float DisThreshold, float DepthSlope )	//ProjectiveDis
+std::vector<edm4hep::Cluster> ArborToolLCIO::ClusterAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::Cluster> FragClusters, float DisThreshold, float DepthSlope )	//ProjectiveDis
 {
-	std::vector<edm4hep::ConstCluster> outputClusterVec;
+	std::vector<edm4hep::Cluster> outputClusterVec;
 
 	int N_Core = MainClusters.size();
 	int N_frag = FragClusters.size();
@@ -805,7 +804,7 @@ std::vector<edm4hep::ConstCluster> ArborToolLCIO::ClusterAbsorbtion( std::vector
 	}
 
 	int N_frag_core_links = Frag_Core_Links.size();
-	std::vector<edm4hep::ConstCluster> tomerge_clu;
+	std::vector<edm4hep::Cluster> tomerge_clu;
 
 	for(int i4 = 0; i4 < N_Core; i4 ++)
 	{
@@ -824,7 +823,7 @@ std::vector<edm4hep::ConstCluster> ArborToolLCIO::ClusterAbsorbtion( std::vector
 			}
 		}
 		auto a_mergedfrag_core = NaiveMergeClu(tomerge_clu);
-		edm4hep::ConstCluster a_mergedfrag_coreCon=a_mergedfrag_core;
+		edm4hep::Cluster a_mergedfrag_coreCon=a_mergedfrag_core;
 		outputClusterVec.push_back(a_mergedfrag_core);
 	}
 
@@ -842,7 +841,7 @@ std::vector<edm4hep::ConstCluster> ArborToolLCIO::ClusterAbsorbtion( std::vector
 }
 
 
-edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecMerge( std::vector<edm4hep::ConstCluster> inputClusters, TMatrixF ConnectorMatrix, DataHandle<edm4hep::ClusterCollection>& clucol  )
+edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecMerge( std::vector<edm4hep::Cluster> inputClusters, TMatrixF ConnectorMatrix, DataHandle<edm4hep::ClusterCollection>& clucol  )
 {
 	edm4hep::ClusterCollection* mergedbranches = clucol.createAndPut();
 
@@ -856,11 +855,11 @@ edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecMerge( std::vector<edm4hep:
 		cout<<"Size of Connector Matrix and inputClusterColl is not match"<<endl;
 	}
 
-	vector<edm4hep::ConstCluster> branchToMerge;
-	edm4hep::ConstCluster Mergebranch_A;
-	edm4hep::ConstCluster Mergebranch_B;
-	edm4hep::ConstCluster tmpMergebranch;
-	edm4hep::ConstCluster Mainbranch (0);
+	vector<edm4hep::Cluster> branchToMerge;
+	edm4hep::Cluster Mergebranch_A;
+	edm4hep::Cluster Mergebranch_B;
+	edm4hep::Cluster tmpMergebranch;
+	edm4hep::Cluster Mainbranch (0);
 
 	TVector3 tmpClusterSeedPos, MBSeedPos;	
 
@@ -934,7 +933,7 @@ edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecMerge( std::vector<edm4hep:
 	return mergedbranches;
 
 }
-int ArborToolLCIO::JointsBetweenBush(edm4hep::ConstCluster a_Clu, edm4hep::ConstCluster b_Clu, float CellSize)
+int ArborToolLCIO::JointsBetweenBush(edm4hep::Cluster a_Clu, edm4hep::Cluster b_Clu, float CellSize)
 {
 	int NJoint = 0; 
 	int a_CluSize = a_Clu.hits_size();
@@ -964,7 +963,7 @@ int ArborToolLCIO::JointsBetweenBush(edm4hep::ConstCluster a_Clu, edm4hep::Const
 }
 
 
-float* ArborToolLCIO::SimpleDisTrackClu( edm4hep::ConstTrack a_trk, edm4hep::ConstCluster a_clu)
+float* ArborToolLCIO::SimpleDisTrackClu( edm4hep::Track a_trk, edm4hep::Cluster a_clu)
 {
 	float* Distance = new float[3];
        	Distance[0]	= 1.0E9;
@@ -995,7 +994,7 @@ float* ArborToolLCIO::SimpleDisTrackClu( edm4hep::ConstTrack a_trk, edm4hep::Con
 
 	return Distance;
 }
-float ArborToolLCIO::SimpleBushTimeTrackClu(edm4hep::ConstTrack a_trk, edm4hep::ConstCluster  a_clu)
+float ArborToolLCIO::SimpleBushTimeTrackClu(edm4hep::Track a_trk, edm4hep::Cluster  a_clu)
 {
         float Distance = 1.0E9;
         float Time = 0;
@@ -1020,7 +1019,7 @@ float ArborToolLCIO::SimpleBushTimeTrackClu(edm4hep::ConstTrack a_trk, edm4hep::
         return Time;
 }
 
-int ArborToolLCIO::SimpleBushNC(edm4hep::ConstTrack  a_trk, edm4hep::ConstCluster  a_clu)
+int ArborToolLCIO::SimpleBushNC(edm4hep::Track  a_trk, edm4hep::Cluster  a_clu)
 {
 	float Distance = 1.0E9;
 	//float Time = 0; 
@@ -1049,7 +1048,7 @@ int ArborToolLCIO::SimpleBushNC(edm4hep::ConstTrack  a_trk, edm4hep::ConstCluste
 	return NC;
 }
 
-int ArborToolLCIO::ClusterFlag(edm4hep::ConstCluster a_tree, edm4hep::ConstTrack a_trk)
+int ArborToolLCIO::ClusterFlag(edm4hep::Cluster a_tree, edm4hep::Track a_trk)
 {
 	// give each charged core cluster a flag
 	//  Fragmentation:       999
@@ -1110,26 +1109,26 @@ int ArborToolLCIO::ClusterFlag(edm4hep::ConstCluster a_tree, edm4hep::ConstTrack
 		EEClu_L10 = 0;
 
 
-		std::vector<edm4hep::ConstCalorimeterHit> Ecalhits;
-		std::vector<edm4hep::ConstCalorimeterHit> Hcalhits;
-		std::vector<edm4hep::ConstCalorimeterHit> allhits;
-		std::vector<edm4hep::ConstCalorimeterHit> EH_1;
-		std::vector<edm4hep::ConstCalorimeterHit> EH_2;
-		std::vector<edm4hep::ConstCalorimeterHit> EH_3;
-		std::vector<edm4hep::ConstCalorimeterHit> EH_4;
-		std::vector<edm4hep::ConstCalorimeterHit> EH_5;
-		std::vector<edm4hep::ConstCalorimeterHit> EH_6;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_1;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_2;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_3;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_4;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_5;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_6;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_7;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_8;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_9;
-		std::vector<edm4hep::ConstCalorimeterHit> HH_0;
-		std::vector<edm4hep::ConstCalorimeterHit> Ecalf10hits;
+		std::vector<edm4hep::CalorimeterHit> Ecalhits;
+		std::vector<edm4hep::CalorimeterHit> Hcalhits;
+		std::vector<edm4hep::CalorimeterHit> allhits;
+		std::vector<edm4hep::CalorimeterHit> EH_1;
+		std::vector<edm4hep::CalorimeterHit> EH_2;
+		std::vector<edm4hep::CalorimeterHit> EH_3;
+		std::vector<edm4hep::CalorimeterHit> EH_4;
+		std::vector<edm4hep::CalorimeterHit> EH_5;
+		std::vector<edm4hep::CalorimeterHit> EH_6;
+		std::vector<edm4hep::CalorimeterHit> HH_1;
+		std::vector<edm4hep::CalorimeterHit> HH_2;
+		std::vector<edm4hep::CalorimeterHit> HH_3;
+		std::vector<edm4hep::CalorimeterHit> HH_4;
+		std::vector<edm4hep::CalorimeterHit> HH_5;
+		std::vector<edm4hep::CalorimeterHit> HH_6;
+		std::vector<edm4hep::CalorimeterHit> HH_7;
+		std::vector<edm4hep::CalorimeterHit> HH_8;
+		std::vector<edm4hep::CalorimeterHit> HH_9;
+		std::vector<edm4hep::CalorimeterHit> HH_0;
+		std::vector<edm4hep::CalorimeterHit> Ecalf10hits;
 
 
 
@@ -1531,7 +1530,7 @@ int ArborToolLCIO::ClusterFlag(edm4hep::ConstCluster a_tree, edm4hep::ConstTrack
 }
 
 
-int ArborToolLCIO::ActiveLayers(  std::vector<edm4hep::ConstCalorimeterHit> clu )
+int ArborToolLCIO::ActiveLayers(  std::vector<edm4hep::CalorimeterHit> clu )
 {
 	std::vector<int> hitlayers; 
 	hitlayers.clear();
@@ -1560,7 +1559,7 @@ int ArborToolLCIO::ActiveLayers(  std::vector<edm4hep::ConstCalorimeterHit> clu 
 }
 
 
-float ArborToolLCIO::ClusterT0(edm4hep::ConstCluster a_Clu)
+float ArborToolLCIO::ClusterT0(edm4hep::Cluster a_Clu)
 {
 	float T0 = 1E9; 
 	float tmpTime = 0; 
@@ -1580,7 +1579,7 @@ float ArborToolLCIO::ClusterT0(edm4hep::ConstCluster a_Clu)
 }
 
 
-int ArborToolLCIO::newPhotonTag(edm4hep::ConstCluster a_clu)
+int ArborToolLCIO::newPhotonTag(edm4hep::Cluster a_clu)
 {
 	int flag=0;
 
@@ -1606,7 +1605,7 @@ int ArborToolLCIO::newPhotonTag(edm4hep::ConstCluster a_clu)
 }
 
 
-int ArborToolLCIO::ClusterFlag1st(edm4hep::ConstCluster a_tree)
+int ArborToolLCIO::ClusterFlag1st(edm4hep::Cluster a_tree)
 {
 	int ClusterID = 211;
 	int EcalNHit, HcalNHit, NH_ECALF10;
@@ -1627,10 +1626,10 @@ int ArborToolLCIO::ClusterFlag1st(edm4hep::ConstCluster a_tree)
 	maxDepth = -100;
 	minDepth = 1E6;
 
-	std::vector<edm4hep::ConstCalorimeterHit> allhits;
-	std::vector<edm4hep::ConstCalorimeterHit> Ecalhits;
-	std::vector<edm4hep::ConstCalorimeterHit> Hcalhits;
-	std::vector<edm4hep::ConstCalorimeterHit> Ecalf10hits;
+	std::vector<edm4hep::CalorimeterHit> allhits;
+	std::vector<edm4hep::CalorimeterHit> Ecalhits;
+	std::vector<edm4hep::CalorimeterHit> Hcalhits;
+	std::vector<edm4hep::CalorimeterHit> Ecalf10hits;
 
 	allhits.clear();
 	Ecalhits.clear();
@@ -1804,7 +1803,7 @@ int ArborToolLCIO::ClusterFlag1st(edm4hep::ConstCluster a_tree)
 	return ClusterID;
 }
 
-float ArborToolLCIO::ClusterEE(edm4hep::ConstCluster inputCluster)
+float ArborToolLCIO::ClusterEE(edm4hep::Cluster inputCluster)
 {
 	float ClusterEnergy = 0;
 	float tmpCluEn = 0;
@@ -1857,7 +1856,7 @@ float ArborToolLCIO::ClusterEE(edm4hep::ConstCluster inputCluster)
 }
 
 
-float ArborToolLCIO::EMClusterEE( edm4hep::ConstCluster inputCluster )
+float ArborToolLCIO::EMClusterEE( edm4hep::Cluster inputCluster )
 {
 	float aaa = -50.2288, ab = 219.398,ac =0.17679,ad =  0.00241144;
 	float ba =  -56.6164,bbb = 162.647,bc = 0.679974,bd  = 0.00423267,be  = -0.324786;
@@ -1945,7 +1944,7 @@ float ArborToolLCIO::EMClusterEE( edm4hep::ConstCluster inputCluster )
 	return EMC;
 }
 
-std::vector<float> ArborToolLCIO::ClusterTime(edm4hep::ConstCluster inputCluster)
+std::vector<float> ArborToolLCIO::ClusterTime(edm4hep::Cluster inputCluster)
 {
 	std::vector<float> CluTimeVector; 
 	CluTimeVector.clear();

--- a/Reconstruction/PFA/Arbor/src/ArborToolLCIO.hh
+++ b/Reconstruction/PFA/Arbor/src/ArborToolLCIO.hh
@@ -39,7 +39,7 @@ public:
     CollectionMaps();
     void clear();
     std::map<std::string, std::vector<edm4hep::MCParticle> >     collectionMap_MC;
-    std::map<std::string, std::vector<edm4hep::ConstCalorimeterHit> > collectionMap_CaloHit;
+    std::map<std::string, std::vector<edm4hep::CalorimeterHit> > collectionMap_CaloHit;
     std::map<std::string, std::vector<edm4hep::Vertex> >         collectionMap_Vertex;
     std::map<std::string, std::vector<edm4hep::Track> >          collectionMap_Track;
     std::map<std::string, std::vector<edm4hep::MCRecoCaloAssociation> > collectionMap_CaloRel;
@@ -58,65 +58,65 @@ class ArborToolLCIO  : public GaudiAlgorithm
 
 
 		void Clean(); 
-	void ClusterBuilding(DataHandle<edm4hep::ClusterCollection>& _currbranchcoll, std::vector<edm4hep::ConstCalorimeterHit> Hits, branchcoll BranchOrder, int DHCALFlag);
+	void ClusterBuilding(DataHandle<edm4hep::ClusterCollection>& _currbranchcoll, std::vector<edm4hep::CalorimeterHit> Hits, branchcoll BranchOrder, int DHCALFlag);
 	
-	float ClusterT0(edm4hep::ConstCluster a_Clu);
+	float ClusterT0(edm4hep::Cluster a_Clu);
 
-	int NHScaleV2( std::vector<edm4hep::ConstCalorimeterHit> clu0, int RatioX, int RatioY, int RatioZ );
-	float FDV2( std::vector<edm4hep::ConstCalorimeterHit> clu);
+	int NHScaleV2( std::vector<edm4hep::CalorimeterHit> clu0, int RatioX, int RatioY, int RatioZ );
+	float FDV2( std::vector<edm4hep::CalorimeterHit> clu);
 	
-	int NHScaleV3( edm4hep::ConstCluster clu0, int RatioX, int RatioY, int RatioZ );
+	int NHScaleV3( edm4hep::Cluster clu0, int RatioX, int RatioY, int RatioZ );
 	
-	float FDV3( edm4hep::ConstCluster clu);
+	float FDV3( edm4hep::Cluster clu);
 	
-	int ActiveLayers(  std::vector<edm4hep::ConstCalorimeterHit> clu );
+	int ActiveLayers(  std::vector<edm4hep::CalorimeterHit> clu );
 	
-	float BushDis( edm4hep::ConstCluster clu1, edm4hep::ConstCluster clu2);
+	float BushDis( edm4hep::Cluster clu1, edm4hep::Cluster clu2);
 	
 	
-	float* SimpleDisTrackClu(edm4hep::ConstTrack a_trk, edm4hep::ConstCluster a_clu);
+	float* SimpleDisTrackClu(edm4hep::Track a_trk, edm4hep::Cluster a_clu);
 	
-	float SimpleBushTimeTrackClu(edm4hep::ConstTrack a_trk, edm4hep::ConstCluster a_clu);
+	float SimpleBushTimeTrackClu(edm4hep::Track a_trk, edm4hep::Cluster a_clu);
 	
-	int SimpleBushNC(edm4hep::ConstTrack a_trk, edm4hep::ConstCluster a_clu);
+	int SimpleBushNC(edm4hep::Track a_trk, edm4hep::Cluster a_clu);
 	
-	float DisPointToBush( TVector3 Pos1, edm4hep::ConstCluster clu1);
+	float DisPointToBush( TVector3 Pos1, edm4hep::Cluster clu1);
 	
-	TVector3 ClusterCoG(edm4hep::ConstCluster inputCluser);
+	TVector3 ClusterCoG(edm4hep::Cluster inputCluser);
 	
-	edm4hep::ClusterCollection* ClusterVecMerge( std::vector<edm4hep::ConstCluster> inputClusters, TMatrixF ConnectorMatrix, DataHandle<edm4hep::ClusterCollection>& clucol );
+	edm4hep::ClusterCollection* ClusterVecMerge( std::vector<edm4hep::Cluster> inputClusters, TMatrixF ConnectorMatrix, DataHandle<edm4hep::ClusterCollection>& clucol );
 	
-	edm4hep::ClusterCollection* ClusterVecColl( std::vector<edm4hep::ConstCluster> inputClusters, DataHandle<edm4hep::ClusterCollection>& m_clucol);
+	edm4hep::ClusterCollection* ClusterVecColl( std::vector<edm4hep::Cluster> inputClusters, DataHandle<edm4hep::ClusterCollection>& m_clucol);
 
-	edm4hep::Cluster NaiveCluImpl(edm4hep::ConstCluster a0_clu);
-	void NaiveCluConst(edm4hep::ConstCluster a0_clu, edm4hep::Cluster);
+	edm4hep::Cluster NaiveCluImpl(edm4hep::Cluster a0_clu);
+	void NaiveCluConst(edm4hep::Cluster a0_clu, edm4hep::Cluster);
 	
-	std::vector<edm4hep::ConstCluster> CollClusterVec(const edm4hep::ClusterCollection * input_coll );
+	std::vector<edm4hep::Cluster> CollClusterVec(const edm4hep::ClusterCollection * input_coll );
 	
-	std::vector<edm4hep::ConstCalorimeterHit> CollHitVec(const edm4hep::CalorimeterHitCollection * input_coll, float EnergyThreshold);
+	std::vector<edm4hep::CalorimeterHit> CollHitVec(const edm4hep::CalorimeterHitCollection * input_coll, float EnergyThreshold);
 	
-	std::vector<edm4hep::Cluster> ClusterHitAbsorbtion( std::vector<edm4hep::ConstCluster> MainClusters, std::vector<edm4hep::ConstCalorimeterHit> IsoHits, float DisThreshold );
+	std::vector<edm4hep::Cluster> ClusterHitAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::CalorimeterHit> IsoHits, float DisThreshold );
 	
-	edm4hep::Cluster NaiveMergeClu(std::vector<edm4hep::ConstCluster> inputCluVec);
+	edm4hep::Cluster NaiveMergeClu(std::vector<edm4hep::Cluster> inputCluVec);
 
-	void NaiveMergeCluConst(std::vector<edm4hep::ConstCluster> inputCluVec,edm4hep::Cluster MergedClu);
-	std::vector<edm4hep::ConstCluster> ClusterAbsorbtion( std::vector<edm4hep::ConstCluster> MainClusters, std::vector<edm4hep::ConstCluster> FragClusters, float thresholds, float DepthSlope );
+	void NaiveMergeCluConst(std::vector<edm4hep::Cluster> inputCluVec,edm4hep::Cluster MergedClu);
+	std::vector<edm4hep::Cluster> ClusterAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::Cluster> FragClusters, float thresholds, float DepthSlope );
 	
 	
-	int JointsBetweenBush(edm4hep::ConstCluster a_Clu, edm4hep::ConstCluster b_Clu, float CellSize);
+	int JointsBetweenBush(edm4hep::Cluster a_Clu, edm4hep::Cluster b_Clu, float CellSize);
 	
-	TVector3 CluEndP(edm4hep::ConstCluster a_clu);
+	TVector3 CluEndP(edm4hep::Cluster a_clu);
 	
-	int ClusterFlag(edm4hep::ConstCluster a_tree, edm4hep::ConstTrack a_trk);
+	int ClusterFlag(edm4hep::Cluster a_tree, edm4hep::Track a_trk);
 	
-	int ClusterFlag1st(edm4hep::ConstCluster a_tree);
+	int ClusterFlag1st(edm4hep::Cluster a_tree);
 	
-	int newPhotonTag(edm4hep::ConstCluster a_clu);
-	float ClusterEE(edm4hep::ConstCluster inputCluster);
+	int newPhotonTag(edm4hep::Cluster a_clu);
+	float ClusterEE(edm4hep::Cluster inputCluster);
 	
-	float EMClusterEE( edm4hep::ConstCluster inputCluster );
+	float EMClusterEE( edm4hep::Cluster inputCluster );
 	
-	std::vector<float> ClusterTime(edm4hep::ConstCluster inputCluster);
+	std::vector<float> ClusterTime(edm4hep::Cluster inputCluster);
 
 	private:
 	SmartIF<IGeomSvc> m_geosvc;//=service<IGeomSvc>("GeomSvc");

--- a/Reconstruction/PFA/Arbor/src/ArborToolLCIO.hh
+++ b/Reconstruction/PFA/Arbor/src/ArborToolLCIO.hh
@@ -86,21 +86,21 @@ class ArborToolLCIO  : public GaudiAlgorithm
 	
 	edm4hep::ClusterCollection* ClusterVecMerge( std::vector<edm4hep::Cluster> inputClusters, TMatrixF ConnectorMatrix, DataHandle<edm4hep::ClusterCollection>& clucol );
 	
-	edm4hep::ClusterCollection* ClusterVecColl( std::vector<edm4hep::Cluster> inputClusters, DataHandle<edm4hep::ClusterCollection>& m_clucol);
+	edm4hep::ClusterCollection* ClusterVecColl( std::vector<edm4hep::MutableCluster> inputClusters, DataHandle<edm4hep::ClusterCollection>& m_clucol);
 
-	edm4hep::Cluster NaiveCluImpl(edm4hep::Cluster a0_clu);
-	void NaiveCluConst(edm4hep::Cluster a0_clu, edm4hep::Cluster);
+	edm4hep::Cluster NaiveCluImpl(edm4hep::MutableCluster a0_clu);
+	void NaiveCluConst(edm4hep::MutableCluster a0_clu, edm4hep::MutableCluster b0_clu);
 	
 	std::vector<edm4hep::Cluster> CollClusterVec(const edm4hep::ClusterCollection * input_coll );
 	
 	std::vector<edm4hep::CalorimeterHit> CollHitVec(const edm4hep::CalorimeterHitCollection * input_coll, float EnergyThreshold);
 	
-	std::vector<edm4hep::Cluster> ClusterHitAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::CalorimeterHit> IsoHits, float DisThreshold );
+	std::vector<edm4hep::MutableCluster> ClusterHitAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::CalorimeterHit> IsoHits, float DisThreshold );
 	
-	edm4hep::Cluster NaiveMergeClu(std::vector<edm4hep::Cluster> inputCluVec);
+	edm4hep::MutableCluster NaiveMergeClu(std::vector<edm4hep::Cluster> inputCluVec);
 
-	void NaiveMergeCluConst(std::vector<edm4hep::Cluster> inputCluVec,edm4hep::Cluster MergedClu);
-	std::vector<edm4hep::Cluster> ClusterAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::Cluster> FragClusters, float thresholds, float DepthSlope );
+	void NaiveMergeCluConst(std::vector<edm4hep::Cluster> inputCluVec,edm4hep::MutableCluster MergedClu);
+	std::vector<edm4hep::MutableCluster> ClusterAbsorbtion( std::vector<edm4hep::Cluster> MainClusters, std::vector<edm4hep::MutableCluster> FragClusters, float thresholds, float DepthSlope );
 	
 	
 	int JointsBetweenBush(edm4hep::Cluster a_Clu, edm4hep::Cluster b_Clu, float CellSize);

--- a/Reconstruction/PFA/Arbor/src/BushConnect.cc
+++ b/Reconstruction/PFA/Arbor/src/BushConnect.cc
@@ -8,7 +8,6 @@
 #include "Gaudi/Property.h"
 #include "edm4hep/EventHeader.h"
 #include "edm4hep/EventHeaderCollection.h"
-#include "edm4hep/SimCalorimeterHitConst.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/CalorimeterHit.h"
 #include "edm4hep/CalorimeterHitCollection.h"
@@ -105,18 +104,18 @@ void BushConnect::TrackSort() //, &std::map<Track*, int>Track_Tpye, &std::map<Tr
 		TVector3 EndPointPos, StartPointPos; 
 		int TrackType = 0; 
 
-		std::vector<edm4hep::ConstTrack> tracks_HQ_Barrel; 
-		std::vector<edm4hep::ConstTrack> tracks_HQ_Endcap;
-		std::vector<edm4hep::ConstTrack> tracks_HQ_Shoulder;
-		std::vector<edm4hep::ConstTrack> tracks_HQ_Forward; 
-		std::vector<edm4hep::ConstTrack> tracks_MQ_Barrel;
-		std::vector<edm4hep::ConstTrack> tracks_MQ_Endcap;
-		std::vector<edm4hep::ConstTrack> tracks_MQ_Shoulder;
-		std::vector<edm4hep::ConstTrack> tracks_MQ_Forward;
-		std::vector<edm4hep::ConstTrack> tracks_Vtx; 
-		std::vector<edm4hep::ConstTrack> tracks_LQ; 
-		std::vector<edm4hep::ConstTrack> tracks_LE; 
-		std::vector<edm4hep::ConstTrack> curr_tracks;
+		std::vector<edm4hep::Track> tracks_HQ_Barrel; 
+		std::vector<edm4hep::Track> tracks_HQ_Endcap;
+		std::vector<edm4hep::Track> tracks_HQ_Shoulder;
+		std::vector<edm4hep::Track> tracks_HQ_Forward; 
+		std::vector<edm4hep::Track> tracks_MQ_Barrel;
+		std::vector<edm4hep::Track> tracks_MQ_Endcap;
+		std::vector<edm4hep::Track> tracks_MQ_Shoulder;
+		std::vector<edm4hep::Track> tracks_MQ_Forward;
+		std::vector<edm4hep::Track> tracks_Vtx; 
+		std::vector<edm4hep::Track> tracks_LQ; 
+		std::vector<edm4hep::Track> tracks_LE; 
+		std::vector<edm4hep::Track> curr_tracks;
 	
 		Track_EndPoint.clear();
 	
@@ -132,15 +131,15 @@ void BushConnect::TrackSort() //, &std::map<Track*, int>Track_Tpye, &std::map<Tr
 		tracks_LQ.clear();
 		tracks_LE.clear();
 
-		std::vector<edm4hep::ConstTrack> tracks_ILL;
+		std::vector<edm4hep::Track> tracks_ILL;
 		tracks_ILL.clear();
-		std::vector<edm4hep::ConstTrack> tracks_preInteraction;
+		std::vector<edm4hep::Track> tracks_preInteraction;
 		tracks_preInteraction.clear();	//Used to denote pion and electron interaction inside TPC/Tracker. Simply vetoed for avoid double counting... but muon may still be problematic. Better way of treating would be find the cascade photons & tracks - clusters, and veto all the daughters instead of mother. Similar can done for Kshort...
 	// Condition, tracks_head to others tail. head position far from boundary. and, track energy >= sum of cascade
 
 		std::vector<int> TrackOrder; 
 		TrackOrder.clear();	
-		std::map<edm4hep::ConstTrack, int> Track_Index; 
+		std::map<edm4hep::Track, int> Track_Index; 
 		Track_Index.clear();
 		Track_Energy.clear();
 		Track_Type.clear();
@@ -349,9 +348,9 @@ void BushConnect::BushSelfMerge()
 	auto CaloClu = m_clucol.get();
 	int NClu = CaloClu->size();
 
-	std::vector<edm4hep::ConstCluster > Core_1st; 
-	std::vector<edm4hep::ConstCluster > Frag_1st;
-	std::vector<edm4hep::ConstCluster > UnId_1st; 
+	std::vector<edm4hep::Cluster > Core_1st; 
+	std::vector<edm4hep::MutableCluster > Frag_1st;
+	std::vector<edm4hep::Cluster > UnId_1st; 
 	Core_1st.clear();
 	Frag_1st.clear();
 	UnId_1st.clear();
@@ -425,11 +424,11 @@ void BushConnect::BushSelfMerge()
 		}
 	}
 
-	std::vector<edm4hep::ConstCluster> OriInputEHBushes = m_ArborToolLCIO->CollClusterVec(CaloClu);
+	std::vector<edm4hep::Cluster> OriInputEHBushes = m_ArborToolLCIO->CollClusterVec(CaloClu);
 	TMatrixF MergeSYM = MatrixSummarize(FlagMerge);
 	auto CloseMergedCaloClu = m_ArborToolLCIO->ClusterVecMerge( OriInputEHBushes, MergeSYM, clucol_merged);
 
-	std::map<edm4hep::ConstCluster,float> MinDisSeedToBush;
+	std::map<edm4hep::Cluster,float> MinDisSeedToBush;
 	MinDisSeedToBush.clear();
 	for(int i0 = 0; i0 < CloseMergedCaloClu->size(); i0++)
 	{
@@ -474,7 +473,7 @@ void BushConnect::BushSelfMerge()
 		}
 	}
 
-	std::vector<edm4hep::ConstCluster > UndefFrag_1stAB = m_ArborToolLCIO->ClusterAbsorbtion(UnId_1st, Frag_1st, 50, 0.02);
+	std::vector<edm4hep::MutableCluster > UndefFrag_1stAB = m_ArborToolLCIO->ClusterAbsorbtion(UnId_1st, Frag_1st, 50, 0.02);
 	selfmergedcluster = m_ArborToolLCIO->ClusterAbsorbtion(Core_1st, UndefFrag_1stAB, 50, 0.02);
 	auto CluAB_1st=m_ArborToolLCIO->ClusterVecColl(selfmergedcluster,m_1stclucol);
 }
@@ -492,11 +491,11 @@ void BushConnect::TagCore()
 
 	TVector3 TrkEndPoint(0, 0, 0);	
 	TVector3 CluPos(0, 0, 0);
-	std::map<edm4hep::ConstCluster, int> BushTouchFlag; 
-	std::map<edm4hep::ConstTrack, edm4hep::ConstCluster> FCMap_Track_CHCore;
-	std::map<edm4hep::ConstTrack, std::vector<edm4hep::ConstCluster>> FCMap_Track_CHCore_new;
+	std::map<edm4hep::Cluster, int> BushTouchFlag; 
+	std::map<edm4hep::Track, edm4hep::MutableCluster> FCMap_Track_CHCore;
+	std::map<edm4hep::Track, std::vector<edm4hep::Cluster>> FCMap_Track_CHCore_new;
 	std::map<int, int> Closest_Trk_Clu_Map;
-	std::vector<edm4hep::ConstCluster> TightLinkedCluster;
+	std::vector<edm4hep::Cluster> TightLinkedCluster;
 	TightLinkedCluster.clear();
 	Closest_Trk_Clu_Map.clear();
 	BushTouchFlag.clear();
@@ -651,7 +650,7 @@ void BushConnect::TagCore()
 		if(FCMap_Track_CHCore_new[a_trk].size() > 0 ) // && EcalCoreEnergy + HcalCoreEnergy < 2.0*currTrkEn )...
 		{
 			auto chcorecluster_eh =  m_ArborToolLCIO->NaiveMergeClu(FCMap_Track_CHCore_new[a_trk]);
-			edm4hep::ConstCluster chcorecluster_ehCon=chcorecluster_eh;
+			edm4hep::MutableCluster chcorecluster_ehCon=chcorecluster_eh;
 			FCMap_Track_CHCore[a_trk] = chcorecluster_ehCon;
 			chargedclustercore.push_back(chcorecluster_ehCon);
 		}
@@ -686,10 +685,10 @@ void BushConnect::TagCore()
 		auto a_clu = FCMap_Track_CHCore[a_trk];
 		if( FCMap_Track_CHCore[a_trk].hits_size()>0 )		// No really need to pertect, as quality will be controled in Part.Reco
 		{
-			edm4hep::Cluster chargedcorecluster = chargedcoreclusterCol->create();
+			auto chargedcorecluster = chargedcoreclusterCol->create();
 
 			m_ArborToolLCIO->NaiveCluConst(FCMap_Track_CHCore[a_trk],chargedcorecluster);
-			edm4hep::ConstCluster chargedcoreclusterCon=chargedcorecluster;
+			edm4hep::Cluster chargedcoreclusterCon=chargedcorecluster;
 			chargeparticle.addToClusters(chargedcoreclusterCon);
 			Track_Core_ID = m_ArborToolLCIO->ClusterFlag(a_clu, a_trk);
 		}
@@ -704,7 +703,7 @@ void BushConnect::ParticleReco()
 {
 
 	auto col_IsoHit = m_col_IsoHit.get();
-	std::vector<edm4hep::ConstCalorimeterHit> IsoHits = m_ArborToolLCIO->CollHitVec(col_IsoHit, 0);
+	std::vector<edm4hep::CalorimeterHit> IsoHits = m_ArborToolLCIO->CollHitVec(col_IsoHit, 0);
 
 	edm4hep::ReconstructedParticleCollection* arborrecoparticleCol = m_arborrecoparticleCol.createAndPut();
 
@@ -717,21 +716,21 @@ void BushConnect::ParticleReco()
 	double DisMatrix_Core_Neutral[NChargedObj][NNeutralCluster][2];		//Define different types of distances; 
 
 	float CluDepth = 0;
-	std::map<edm4hep::ConstCluster, double> CluDepthMap; 
+	std::map<edm4hep::Cluster, double> CluDepthMap; 
 	CluDepthMap.clear();
 	int currChargeCoreType = 0;  
 	TVector3 CluPos; 
 
-	std::vector<edm4hep::ConstCluster> loosecandicluster; 
-	std::vector<edm4hep::ConstCluster> tightcandicluster;		//Muon potential candi?
-	std::vector<edm4hep::ConstCluster> mergedcluster; 			//tmp for each charged P
-	std::vector<edm4hep::ConstCluster> chargedclustercore_merged; 	//overall
+	std::vector<edm4hep::Cluster> loosecandicluster; 
+	std::vector<edm4hep::Cluster> tightcandicluster;		//Muon potential candi?
+	std::vector<edm4hep::Cluster> mergedcluster; 			//tmp for each charged P
+	std::vector<edm4hep::Cluster> chargedclustercore_merged; 	//overall
 	chargedclustercore_merged.clear();
 
 	std::vector<double> reftightdis; 
 	std::vector<double> refloosedis; 
-	std::map<edm4hep::ConstCluster, int> NNCTouchFlag; 
-	std::vector<edm4hep::ConstTrack> SecondIterTracks;
+	std::map<edm4hep::Cluster, int> NNCTouchFlag; 
+	std::vector<edm4hep::Track> SecondIterTracks;
 	SecondIterTracks.clear();
 
 	TVector3 currTrkEnd, neighbourTrkEnd, LeadP; 
@@ -752,7 +751,7 @@ void BushConnect::ParticleReco()
 
 		float CurrClusterEnergy = 0;
 		float CurrTrackEnergy = Track_Energy[a_chargedTrk];
-		edm4hep::ConstCluster a_chargedClu;
+		edm4hep::Cluster a_chargedClu;
 		if(a_recoP_ch.clusters_size() != 0)
 		{
 			a_chargedClu = a_recoP_ch.getClusters(0);
@@ -1075,7 +1074,7 @@ void BushConnect::ParticleReco()
 
 			auto chclustermerged = mergedclu_chCol->create();
 			m_ArborToolLCIO->NaiveMergeCluConst(mergedcluster,chclustermerged);
-			edm4hep::ConstCluster chclustermergedCon=chclustermerged;
+			edm4hep::Cluster chclustermergedCon=chclustermerged;
 			chargeparticle.addToClusters(chclustermergedCon);
 			chargedclustercore_merged.push_back(chclustermerged);
 			currChargeCoreType2 = m_ArborToolLCIO->ClusterFlag(chclustermerged, a_chargedTrk);
@@ -1137,7 +1136,7 @@ void BushConnect::ParticleReco()
 		}	
 	}
 
-	std::vector<edm4hep::ConstCluster> BBCore; 
+	std::vector<edm4hep::MutableCluster> BBCore; 
 	BBCore.clear();
 	for(int p6 = 0; p6 < NNeutralCluster; p6 ++)
 	{
@@ -1151,7 +1150,7 @@ void BushConnect::ParticleReco()
 	float NAMom[3] = {0, 0, 0};
 
 	//Final Re-absorption
-	std::vector<edm4hep::ConstCluster> NBBNeutral; 
+	std::vector<edm4hep::Cluster> NBBNeutral; 
 	NBBNeutral.clear();
 
 	for(int s = 0; s < int (BBCore.size()); s++)
@@ -1178,7 +1177,7 @@ void BushConnect::ParticleReco()
 			auto a_neclu =  mergedclu_neCol->create();
 			m_ArborToolLCIO->NaiveCluConst(a_clu,a_neclu);
 			a_neclu.setEnergy( CoreEnCorr );	//Reset...
-			edm4hep::ConstCluster a_necluCon=a_neclu;
+			edm4hep::Cluster a_necluCon=a_neclu;
 			neutralparticle.addToClusters(a_neclu);
 		}
 		else	// Distance to Charged Core > sth;
@@ -1205,7 +1204,7 @@ void BushConnect::ParticleReco()
 	}
 
 	// Add: Neural Core Remerge & Energy Scale Recalculate, IsoHit Abso
-	std::vector<edm4hep::Cluster> NBBAbs = m_ArborToolLCIO->ClusterHitAbsorbtion(NBBNeutral, IsoHits, 100); //_HitAbsCut);	// Huge??
+	std::vector<edm4hep::MutableCluster> NBBAbs = m_ArborToolLCIO->ClusterHitAbsorbtion(NBBNeutral, IsoHits, 100); //_HitAbsCut);	// Huge??
 
 	std::vector<float> BBAbsEn; 
 	BBAbsEn.clear();
@@ -1217,8 +1216,8 @@ void BushConnect::ParticleReco()
 
 	std::vector<int> BBAbsIndex = SortMeasure(BBAbsEn, 1);
 
-	std::vector<edm4hep::ConstCluster > NeutronCore;
-	std::vector<edm4hep::ConstCluster > NeutronFlag;
+	std::vector<edm4hep::Cluster > NeutronCore;
+	std::vector<edm4hep::MutableCluster > NeutronFlag;
 	NeutronCore.clear();
 	NeutronFlag.clear();	
 
@@ -1237,7 +1236,7 @@ void BushConnect::ParticleReco()
 		}
 	}
 
-	std::vector<edm4hep::ConstCluster > Neutrons = m_ArborToolLCIO->ClusterAbsorbtion(NeutronCore, NeutronFlag, 200, 0.01);
+	std::vector<edm4hep::MutableCluster > Neutrons = m_ArborToolLCIO->ClusterAbsorbtion(NeutronCore, NeutronFlag, 200, 0.01);
 
 	for(unsigned int s3 = 0; s3 < Neutrons.size(); s3++)
 	{
@@ -1300,7 +1299,7 @@ void BushConnect::ParticleReco()
 			auto a_neclu =  mergedclu_neCol->create();
 			m_ArborToolLCIO->NaiveCluConst(a_clu,a_neclu);
 			a_neclu.setEnergy( CoreEnCorr );       //Reset...
-			edm4hep::ConstCluster a_necluCon=a_neclu;
+			edm4hep::Cluster a_necluCon=a_neclu;
 			neutralparticle.addToClusters(a_necluCon);
 		}
 	}

--- a/Reconstruction/PFA/Arbor/src/BushConnect.hh
+++ b/Reconstruction/PFA/Arbor/src/BushConnect.hh
@@ -6,7 +6,6 @@
 #include "Gaudi/Property.h"
 #include "edm4hep/EventHeader.h"
 #include "edm4hep/EventHeaderCollection.h"
-#include "edm4hep/SimCalorimeterHitConst.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/CalorimeterHit.h"
 #include "edm4hep/CalorimeterHitCollection.h"
@@ -51,49 +50,49 @@ class BushConnect  : public GaudiAlgorithm
 
 	protected:
 
-		std::vector<edm4hep::ConstCluster> SortedSMBushes;
-		std::vector<edm4hep::ConstTrack> SortedTracks;
-		std::map<edm4hep::ConstTrack, float> Track_Energy;
-		std::map<edm4hep::ConstTrack, TVector3> Track_P3;
-		std::map<edm4hep::ConstTrack, int> Track_Type;
-		std::map<edm4hep::ConstTrack, float> Track_Theta;
-		std::map<edm4hep::ConstTrack, float> Track_Phi;	
+		std::vector<edm4hep::Cluster> SortedSMBushes;
+		std::vector<edm4hep::Track> SortedTracks;
+		std::map<edm4hep::Track, float> Track_Energy;
+		std::map<edm4hep::Track, TVector3> Track_P3;
+		std::map<edm4hep::Track, int> Track_Type;
+		std::map<edm4hep::Track, float> Track_Theta;
+		std::map<edm4hep::Track, float> Track_Phi;	
 
-		std::map<edm4hep::ConstCluster, int> ClusterType_1stID;
-		std::map<edm4hep::ConstReconstructedParticle, int> ChCoreID; 
+		std::map<edm4hep::Cluster, int> ClusterType_1stID;
+		std::map<edm4hep::ReconstructedParticle, int> ChCoreID; 
 
-		std::vector<edm4hep::ConstCluster> ecalchcore_tight;         //TightCores
-		std::vector<edm4hep::ConstCluster> ecalchcore_medium;
-		std::vector<edm4hep::ConstCluster> ecalchcore_loose;         //LooseCores    Let's also get
-		std::vector<edm4hep::ConstCluster> ecalchcore; 		    //Above three
-		std::vector<edm4hep::ConstCluster> ecalnecore;
-		std::vector<edm4hep::ConstCluster> ecalnecore_EM;
-		std::vector<edm4hep::ConstCluster> ecalnecore_NonEM;
-		std::vector<edm4hep::ConstCluster> ecalfrag;
-		std::vector<edm4hep::ConstCluster> ecalundef;
-		std::vector<edm4hep::ConstCluster> ecalfrag_TBM_CH;
-		std::vector<edm4hep::ConstCluster> ecalfrag_TBM_NE_EM;
-		std::vector<edm4hep::ConstCluster> ecalfrag_TBM_NE_NonEM;
-		std::vector<edm4hep::ConstCluster> ecalundef_iso;
-		std::vector<edm4hep::ConstCluster> ecalpotentialbackscattering;
+		std::vector<edm4hep::Cluster> ecalchcore_tight;         //TightCores
+		std::vector<edm4hep::Cluster> ecalchcore_medium;
+		std::vector<edm4hep::Cluster> ecalchcore_loose;         //LooseCores    Let's also get
+		std::vector<edm4hep::Cluster> ecalchcore; 		    //Above three
+		std::vector<edm4hep::Cluster> ecalnecore;
+		std::vector<edm4hep::Cluster> ecalnecore_EM;
+		std::vector<edm4hep::Cluster> ecalnecore_NonEM;
+		std::vector<edm4hep::Cluster> ecalfrag;
+		std::vector<edm4hep::Cluster> ecalundef;
+		std::vector<edm4hep::Cluster> ecalfrag_TBM_CH;
+		std::vector<edm4hep::Cluster> ecalfrag_TBM_NE_EM;
+		std::vector<edm4hep::Cluster> ecalfrag_TBM_NE_NonEM;
+		std::vector<edm4hep::Cluster> ecalundef_iso;
+		std::vector<edm4hep::Cluster> ecalpotentialbackscattering;
 
-		std::vector<edm4hep::ConstCluster> chargedclustercore;
-		std::vector<edm4hep::ConstCluster> chargedclustercore_abs;
+		std::vector<edm4hep::Cluster> chargedclustercore;
+		std::vector<edm4hep::Cluster> chargedclustercore_abs;
 
-		std::vector<edm4hep::ConstCluster> selfmergedcluster; 
-		std::vector<edm4hep::ConstCluster> non_chargedclustercore;
-		std::vector<edm4hep::ConstCluster> onlyNeutralCore;
+		std::vector<edm4hep::MutableCluster> selfmergedcluster; 
+		std::vector<edm4hep::MutableCluster> non_chargedclustercore;
+		std::vector<edm4hep::Cluster> onlyNeutralCore;
 
-		std::vector<edm4hep::ConstCluster> non_charged_pem_neutral_core;
-		std::vector<edm4hep::ConstCluster> pem_neutral_core;
+		std::vector<edm4hep::Cluster> non_charged_pem_neutral_core;
+		std::vector<edm4hep::Cluster> pem_neutral_core;
 
-		std::map<edm4hep::ConstTrack, int>MCPTrack_Type;
-		std::map<edm4hep::ConstTrack, TVector3> Track_EndPoint;       //Last hit
-		std::map<edm4hep::ConstTrack, TVector3> TrackStartPoint;
-		std::map<edm4hep::ConstCluster, float> CluFD; 
-		std::map<edm4hep::ConstCluster, float> CluT0;
-		std::map<edm4hep::ConstCluster, float> Clu_Depth; 
-		std::map<edm4hep::ConstCluster, TVector3> CluCoG;
+		std::map<edm4hep::Track, int>MCPTrack_Type;
+		std::map<edm4hep::Track, TVector3> Track_EndPoint;       //Last hit
+		std::map<edm4hep::Track, TVector3> TrackStartPoint;
+		std::map<edm4hep::Cluster, float> CluFD; 
+		std::map<edm4hep::Cluster, float> CluT0;
+		std::map<edm4hep::Cluster, float> Clu_Depth; 
+		std::map<edm4hep::Cluster, TVector3> CluCoG;
 	typedef DataHandle<edm4hep::MCParticleCollection> MCParticleColHandler;
 	MCParticleColHandler m_mcParticle{"MCParticle", Gaudi::DataHandle::Reader, this};
 

--- a/Reconstruction/PFA/Arbor/src/MarlinArbor.cc
+++ b/Reconstruction/PFA/Arbor/src/MarlinArbor.cc
@@ -8,7 +8,6 @@
 #include "Gaudi/Property.h"
 #include "edm4hep/EventHeader.h"
 #include "edm4hep/EventHeaderCollection.h"
-#include "edm4hep/SimCalorimeterHitConst.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/CalorimeterHit.h"
 #include "edm4hep/CalorimeterHitCollection.h"
@@ -95,7 +94,7 @@ void MarlinArbor::HitsPreparation()
 	cout<<"Start to prepare Hits"<<endl;
 }
 
-void MarlinArbor::MakeIsoHits( std::vector<edm4hep::ConstCalorimeterHit> inputCaloHits, DataHandle<edm4hep::CalorimeterHitCollection>& m_hitcol)
+void MarlinArbor::MakeIsoHits( std::vector<edm4hep::CalorimeterHit> inputCaloHits, DataHandle<edm4hep::CalorimeterHitCollection>& m_hitcol)
 {
 	edm4hep::CalorimeterHitCollection* isohitcoll = m_hitcol.createAndPut();
 
@@ -124,9 +123,9 @@ StatusCode MarlinArbor::execute()
 
 	std::vector< TVector3 > inputHitsPos;
 	std::vector< ArborHit > inputABHit; 
-	std::vector< edm4hep::ConstCalorimeterHit > inputHits;  
-	std::vector< edm4hep::ConstCalorimeterHit > inputECALHits;  
-	std::vector< edm4hep::ConstCalorimeterHit > inputHCALHits;  
+	std::vector< edm4hep::CalorimeterHit > inputHits;  
+	std::vector< edm4hep::CalorimeterHit > inputECALHits;  
+	std::vector< edm4hep::CalorimeterHit > inputHCALHits;  
 	std::vector< std::vector<int> > Sequence; 
 	int LayerNum = 0; 
 	int StaveNum = 0; 
@@ -134,7 +133,7 @@ StatusCode MarlinArbor::execute()
 	float Depth = 0; 
 	int KShift = 0; 
 	TVector3 TrkEndPointPos; 
-	std::vector<edm4hep::ConstCalorimeterHit> IsoHits;
+	std::vector<edm4hep::CalorimeterHit> IsoHits;
 
 	for(unsigned int i1 = 0; i1 < _calCollections.size(); i1++)
 	{

--- a/Reconstruction/PFA/Arbor/src/MarlinArbor.hh
+++ b/Reconstruction/PFA/Arbor/src/MarlinArbor.hh
@@ -9,7 +9,6 @@
 #include "Gaudi/Property.h"
 #include "edm4hep/EventHeader.h"
 #include "edm4hep/EventHeaderCollection.h"
-#include "edm4hep/SimCalorimeterHitConst.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/CalorimeterHit.h"
 #include "edm4hep/CalorimeterHitCollection.h"
@@ -57,7 +56,7 @@ class MarlinArbor  : public GaudiAlgorithm
 		virtual StatusCode finalize() ;
 		void HitsPreparation(); // LCEvent * evtP);
 
-		void MakeIsoHits(std::vector<edm4hep::ConstCalorimeterHit> inputCaloHits, DataHandle<edm4hep::CalorimeterHitCollection>& m_isohitcol);
+		void MakeIsoHits(std::vector<edm4hep::CalorimeterHit> inputCaloHits, DataHandle<edm4hep::CalorimeterHitCollection>& m_isohitcol);
 	protected:
 		std::string _colName;
 		std::vector<std::string> _CalCollections;

--- a/Reconstruction/PFA/Pandora/GaudiPandora/include/CaloHitCreator.h
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/include/CaloHitCreator.h
@@ -25,7 +25,7 @@
 
 #include <string>
 
-typedef std::vector<edm4hep::ConstCalorimeterHit *> CalorimeterHitVector;
+typedef std::vector<edm4hep::CalorimeterHit *> CalorimeterHitVector;
 
 namespace gear { class GearMgr; }
 
@@ -174,25 +174,25 @@ private:
      *  @brief  Get common calo hit properties: position, parent address, input energy and time
      * 
      */
-    void GetCommonCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, PandoraApi::CaloHit::Parameters &caloHitParameters) const;
+    void GetCommonCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, PandoraApi::CaloHit::Parameters &caloHitParameters) const;
 
     /**
      *  @brief  Get end cap specific calo hit properties: cell size, absorber radiation and interaction lengths, normal vector
      * 
      */
-    void GetEndCapCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
+    void GetEndCapCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
         PandoraApi::CaloHit::Parameters &caloHitParameters, float &absorberCorrection) const;
-    void GetEndCapCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer> &layers,
+    void GetEndCapCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer> &layers,
     PandoraApi::CaloHit::Parameters &caloHitParameters, float &absorberCorrection) const;
 
     /**
      *  @brief  Get barrel specific calo hit properties: cell size, absorber radiation and interaction lengths, normal vector
      * 
      */
-    void GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
+    void GetBarrelCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
         unsigned int barrelSymmetryOrder, float barrelPhi0, unsigned int staveNumber, PandoraApi::CaloHit::Parameters &caloHitParameters,
         float &absorberCorrection) const;
-    void GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer> &layers,
+    void GetBarrelCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer> &layers,
         unsigned int barrelSymmetryOrder, float barrelPhi0, unsigned int staveNumber, PandoraApi::CaloHit::Parameters &caloHitParameters,
         float &absorberCorrection) const;
 
@@ -200,13 +200,13 @@ private:
      *  @brief  Get number of active layers from position of a calo hit to the edge of the detector
      * 
      */
-    int GetNLayersFromEdge(edm4hep::ConstCalorimeterHit *const pCaloHit) const;
+    int GetNLayersFromEdge(edm4hep::CalorimeterHit *const pCaloHit) const;
 
     /**
      *  @brief  Get the maximum radius of a calo hit in a polygonal detector structure
      * 
      */
-    float GetMaximumRadius(edm4hep::ConstCalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const;
+    float GetMaximumRadius(edm4hep::CalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const;
 
     /**
      *  @brief  Get the layer coding string from the provided cell id encoding string

--- a/Reconstruction/PFA/Pandora/GaudiPandora/include/MCParticleCreator.h
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/include/MCParticleCreator.h
@@ -78,7 +78,7 @@ private:
     const Settings          m_settings;                         ///< The mc particle creator settings
     const pandora::Pandora *m_pPandora;                         ///< Address of the pandora object to create the mc particles
     const float             m_bField;                           ///< The bfield
-    std::map<unsigned int, edm4hep::ConstMCParticle*>*  m_id_pMC_map;
+    std::map<unsigned int, edm4hep::MCParticle*>*  m_id_pMC_map;
 };
 
 inline void MCParticleCreator::Reset()

--- a/Reconstruction/PFA/Pandora/GaudiPandora/include/PandoraPFAlg.h
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/include/PandoraPFAlg.h
@@ -54,12 +54,12 @@ class CollectionMaps
 public:
     CollectionMaps();
     void clear();
-    std::map<std::string, std::vector<edm4hep::ConstMCParticle> >     collectionMap_MC;
-    std::map<std::string, std::vector<edm4hep::ConstCalorimeterHit> > collectionMap_CaloHit;
-    std::map<std::string, std::vector<edm4hep::ConstVertex> >         collectionMap_Vertex;
-    std::map<std::string, std::vector<edm4hep::ConstTrack> >          collectionMap_Track;
-    std::map<std::string, std::vector<edm4hep::ConstMCRecoCaloAssociation> > collectionMap_CaloRel;
-    std::map<std::string, std::vector<edm4hep::ConstMCRecoTrackerAssociation> > collectionMap_TrkRel;
+    std::map<std::string, std::vector<edm4hep::MCParticle> >     collectionMap_MC;
+    std::map<std::string, std::vector<edm4hep::CalorimeterHit> > collectionMap_CaloHit;
+    std::map<std::string, std::vector<edm4hep::Vertex> >         collectionMap_Vertex;
+    std::map<std::string, std::vector<edm4hep::Track> >          collectionMap_Track;
+    std::map<std::string, std::vector<edm4hep::MCRecoCaloAssociation> > collectionMap_CaloRel;
+    std::map<std::string, std::vector<edm4hep::MCRecoTrackerAssociation> > collectionMap_TrkRel;
 };
 
 

--- a/Reconstruction/PFA/Pandora/GaudiPandora/include/PfoCreator.h
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/include/PfoCreator.h
@@ -105,7 +105,7 @@ private:
      *  @param  hitY the vector to receive the y position of hits
      *  @param  hitZ the vector to receive the z position of hits
      */
-    void SetClusterSubDetectorEnergies(const pandora::StringVector &subDetectorNames, edm4hep::Cluster *const pLcioCluster,
+    void SetClusterSubDetectorEnergies(const pandora::StringVector &subDetectorNames, edm4hep::MutableCluster *const pLcioCluster,
         const pandora::CaloHitList &pandoraCaloHitList, pandora::FloatVector &hitE, pandora::FloatVector &hitX, pandora::FloatVector &hitY,
         pandora::FloatVector &hitZ) const;
 
@@ -118,7 +118,7 @@ private:
      *  @param  clusterCorrectEnergy a number to receive the cluster correct energy
      */
     void SetClusterEnergyAndError(const pandora::ParticleFlowObject *const pPandoraPfo, const pandora::Cluster *const pPandoraCluster, 
-        edm4hep::Cluster *const pLcioCluster, float &clusterCorrectEnergy) const;
+        edm4hep::MutableCluster *const pLcioCluster, float &clusterCorrectEnergy) const;
 
     /**
      *  @brief  Set cluster position, errors and other shape info, by calculating culster shape first
@@ -132,7 +132,7 @@ private:
      *  @param  clusterPosition a CartesianVector to receive the cluster position
      */
     void SetClusterPositionAndError(const unsigned int nHitsInCluster, pandora::FloatVector &hitE, pandora::FloatVector &hitX, 
-        pandora::FloatVector &hitY, pandora::FloatVector &hitZ, edm4hep::Cluster *const pLcioCluster, pandora::CartesianVector &clusterPositionVec) const;
+        pandora::FloatVector &hitY, pandora::FloatVector &hitZ, edm4hep::MutableCluster *const pLcioCluster, pandora::CartesianVector &clusterPositionVec) const;
 
     /**
      *  @brief  Calculate reference point for pfo with tracks
@@ -148,7 +148,7 @@ private:
      *  @param  referencePoint a CartesianVector of the reference point
      *  @param  pReconstructedParticle the address of the reconstructed particle to be reference point
      */
-    void SetRecoParticleReferencePoint(const pandora::CartesianVector &referencePoint, edm4hep::ReconstructedParticle *const pReconstructedParticle) const;
+    void SetRecoParticleReferencePoint(const pandora::CartesianVector &referencePoint, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const;
 
     /**
      *  @brief  Add tracks to reconstructed particle
@@ -156,7 +156,7 @@ private:
      *  @param  pPandoraPfo the address of the pandora pfo
      *  @param  pReconstructedParticle the address of the reconstructed particle to be added tracks
      */
-    void AddTracksToRecoParticle(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::ReconstructedParticle *const pReconstructedParticle) const;
+    void AddTracksToRecoParticle(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const;
 
     /**
      *  @brief  Set properties of reconstructed particle from pandora pfo
@@ -164,7 +164,7 @@ private:
      *  @param  pPandoraPfo the address of the pandora pfo 
      *  @param  pReconstructedParticle the address of the reconstructed particle to be set properties
      */
-    void SetRecoParticlePropertiesFromPFO(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::ReconstructedParticle *const pReconstructedParticle) const;
+    void SetRecoParticlePropertiesFromPFO(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const;
 
     /**
      *  @brief  Whether parent and daughter tracks are associated with the same pfo

--- a/Reconstruction/PFA/Pandora/GaudiPandora/include/TrackCreator.h
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/include/TrackCreator.h
@@ -13,9 +13,7 @@
 #include "GaudiKernel/ISvcLocator.h"
 
 #include "edm4hep/Track.h"
-#include "edm4hep/TrackConst.h"
 #include "edm4hep/TrackState.h"
-#include "edm4hep/ReconstructedParticleConst.h"
 
 #include "Api/PandoraApi.h"
 #include "Objects/Helix.h"
@@ -24,9 +22,9 @@ namespace gear { class GearMgr; }
 
 class CollectionMaps;
 
-typedef std::vector<edm4hep::ConstTrack *> TrackVector;
+typedef std::vector<edm4hep::Track *> TrackVector;
 typedef std::set<unsigned int> TrackList;
-typedef std::map<edm4hep::ConstTrack, int> TrackToPidMap;
+typedef std::map<edm4hep::Track, int> TrackToPidMap;
 /*
 inline LCCollectionVec *newTrkCol(const std::string &name, LCEvent *evt , bool isSubset)
 {
@@ -125,7 +123,7 @@ public:
      */
     pandora::StatusCode CreateTrackAssociations(const CollectionMaps& collectionMaps);
 
-    edm4hep::ConstTrack* GetTrackAddress(const CollectionMaps& collectionMaps, const edm4hep::ConstTrack& pTrack );
+    edm4hep::Track* GetTrackAddress(const CollectionMaps& collectionMaps, const edm4hep::Track& pTrack );
     /**
      *  @brief  Create tracks, insert user code here
      * 
@@ -172,7 +170,7 @@ private:
      * 
      *  @param  trackVec the vector of tracks associated with the vertex
      */
-    bool IsConflictingRelationship(const edm4hep::ConstReconstructedParticle &Particle) const;
+    bool IsConflictingRelationship(const edm4hep::ReconstructedParticle &Particle) const;
 
     /**
      *  @brief  Whether a track is a v0 track
@@ -198,7 +196,7 @@ private:
      *  @brief  Copy track states stored in tracks to pandora track parameters
      * 
      */
-    void GetTrackStates(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
+    void GetTrackStates(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
 
     /**
      *  @brief  Copy track state from track state instance to pandora input track state
@@ -210,13 +208,13 @@ private:
      *  @brief  Obtain track time when it reaches ECAL
      * 
      */
-    float CalculateTrackTimeAtCalorimeter(edm4hep::ConstTrack *const pTrack) const;
+    float CalculateTrackTimeAtCalorimeter(edm4hep::Track *const pTrack) const;
 
     /**
      *  @brief  Decide whether track reaches the ecal surface
      * 
      */
-    void TrackReachesECAL(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
+    void TrackReachesECAL(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
 
     /**
      *  @brief  Determine whether a track can be used to form a pfo under the following conditions:
@@ -224,7 +222,7 @@ private:
      *          2) if the track proves to have no cluster associations
      * 
      */
-    void DefineTrackPfoUsage(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
+    void DefineTrackPfoUsage(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
 
     /**
      *  @brief  Whether track passes the quality cuts required in order to be used to form a pfo
@@ -232,19 +230,19 @@ private:
      * 
      *  @return boolean
      */
-    bool PassesQualityCuts(edm4hep::ConstTrack *const pTrack, const PandoraApi::Track::Parameters &trackParameters) const;
+    bool PassesQualityCuts(edm4hep::Track *const pTrack, const PandoraApi::Track::Parameters &trackParameters) const;
 
     /**
      *  @brief  Get number of hits in TPC of a track
      * 
      */
-    int GetNTpcHits(edm4hep::ConstTrack *const pTrack) const;
+    int GetNTpcHits(edm4hep::Track *const pTrack) const;
 
     /**
      *  @brief  Get number of hits in FTD of a track
      * 
      */
-    int GetNFtdHits(edm4hep::ConstTrack *const pTrack) const;
+    int GetNFtdHits(edm4hep::Track *const pTrack) const;
 
     const Settings          m_settings;                     ///< The track creator settings
     const pandora::Pandora *m_pPandora;                     ///< Address of the pandora object to create tracks and track relationships

--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/CaloHitCreator.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/CaloHitCreator.cpp
@@ -802,7 +802,7 @@ pandora::StatusCode CaloHitCreator::CreateLHCalCaloHits(const CollectionMaps& co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CaloHitCreator::GetCommonCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, PandoraApi::CaloHit::Parameters &caloHitParameters) const
+void CaloHitCreator::GetCommonCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, PandoraApi::CaloHit::Parameters &caloHitParameters) const
 {
     const float pCaloHitPosition[3]={pCaloHit->getPosition()[0], pCaloHit->getPosition()[1], pCaloHit->getPosition()[2]};
     const pandora::CartesianVector positionVector(pCaloHitPosition[0], pCaloHitPosition[1], pCaloHitPosition[2]);
@@ -817,7 +817,7 @@ void CaloHitCreator::GetCommonCaloHitProperties(edm4hep::ConstCalorimeterHit *co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CaloHitCreator::GetEndCapCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
+void CaloHitCreator::GetEndCapCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
     PandoraApi::CaloHit::Parameters &caloHitParameters, float &absorberCorrection) const
 {
     caloHitParameters.m_hitRegion = pandora::ENDCAP;
@@ -862,7 +862,7 @@ void CaloHitCreator::GetEndCapCaloHitProperties(edm4hep::ConstCalorimeterHit *co
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
-void CaloHitCreator::GetEndCapCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer> &layers,
+void CaloHitCreator::GetEndCapCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer> &layers,
     PandoraApi::CaloHit::Parameters &caloHitParameters, float &absorberCorrection) const
 {
     caloHitParameters.m_hitRegion = pandora::ENDCAP;
@@ -914,7 +914,7 @@ void CaloHitCreator::GetEndCapCaloHitProperties(edm4hep::ConstCalorimeterHit *co
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
+void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
     unsigned int barrelSymmetryOrder, float barrelPhi0, unsigned int staveNumber, PandoraApi::CaloHit::Parameters &caloHitParameters,
     float &absorberCorrection) const
 {
@@ -977,7 +977,7 @@ void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *co
     }
 }
 
-void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer> &layers,
+void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterStruct::Layer> &layers,
     unsigned int barrelSymmetryOrder, float barrelPhi0, unsigned int staveNumber, PandoraApi::CaloHit::Parameters &caloHitParameters,
     float &absorberCorrection) const
 {
@@ -1054,7 +1054,7 @@ void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-int CaloHitCreator::GetNLayersFromEdge(edm4hep::ConstCalorimeterHit *const pCaloHit) const
+int CaloHitCreator::GetNLayersFromEdge(edm4hep::CalorimeterHit *const pCaloHit) const
 {
     // Calo hit coordinate calculations
     const float barrelMaximumRadius(this->GetMaximumRadius(pCaloHit, m_hCalBarrelOuterSymmetry, m_hCalBarrelOuterPhi0));
@@ -1096,7 +1096,7 @@ int CaloHitCreator::GetNLayersFromEdge(edm4hep::ConstCalorimeterHit *const pCalo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float CaloHitCreator::GetMaximumRadius(edm4hep::ConstCalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const
+float CaloHitCreator::GetMaximumRadius(edm4hep::CalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const
 {
     
     const float pCaloHitPosition[3]={pCaloHit->getPosition()[0], pCaloHit->getPosition()[1], pCaloHit->getPosition()[2]};

--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/MCParticleCreator.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/MCParticleCreator.cpp
@@ -6,14 +6,10 @@
  */
 
 
-#include "edm4hep/MCParticleConst.h"
 #include "edm4hep/MCParticle.h" 
 #include "edm4hep/MCRecoCaloAssociation.h" 
-#include "edm4hep/SimCalorimeterHitConst.h" 
-#include "edm4hep/CaloHitContributionConst.h" 
 #include "edm4hep/Track.h" 
 #include "edm4hep/MCRecoTrackerAssociation.h" 
-#include "edm4hep/SimTrackerHitConst.h" 
 #include "PandoraPFAlg.h"
 #include "MCParticleCreator.h"
 
@@ -26,7 +22,7 @@ MCParticleCreator::MCParticleCreator(const Settings &settings, const pandora::Pa
     m_pPandora(pPandora),
     m_bField(settings.m_bField)
 {
-m_id_pMC_map = new std::map<unsigned int, edm4hep::ConstMCParticle*>;
+m_id_pMC_map = new std::map<unsigned int, edm4hep::MCParticle*>;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -70,7 +66,7 @@ pandora::StatusCode MCParticleCreator::CreateMCParticles(const CollectionMaps& c
                     PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::MCParticle::Create(*m_pPandora, mcParticleParameters));
 
                     // Create parent-daughter relationships
-                    for(std::vector<edm4hep::ConstMCParticle>::const_iterator itDaughter = pMcParticle.daughters_begin(),
+                    for(std::vector<edm4hep::MCParticle>::const_iterator itDaughter = pMcParticle.daughters_begin(),
                         itDaughterEnd = pMcParticle.daughters_end(); itDaughter != itDaughterEnd; ++itDaughter)
                     {   
                         for (int ida = 0; ida < pMCParticleCollection.size(); ida++)
@@ -108,7 +104,7 @@ pandora::StatusCode MCParticleCreator::CreateMCParticles(const CollectionMaps& c
 
 pandora::StatusCode MCParticleCreator::CreateCaloHitToMCParticleRelationships(const CollectionMaps& collectionMaps, const CalorimeterHitVector &calorimeterHitVector) const
 {
-    typedef std::map<edm4hep::ConstMCParticle *, float> MCParticleToEnergyWeightMap;
+    typedef std::map<edm4hep::MCParticle *, float> MCParticleToEnergyWeightMap;
     MCParticleToEnergyWeightMap mcParticleToEnergyWeightMap;
 
     for (StringVector::const_iterator iter = m_settings.m_CaloHitRelationCollections.begin(), iterEnd = m_settings.m_CaloHitRelationCollections.end();
@@ -177,7 +173,7 @@ pandora::StatusCode MCParticleCreator::CreateTrackToMCParticleRelationships(cons
         const pandora::Helix helixFit(pTrack->getTrackStates(0).phi, pTrack->getTrackStates(0).D0, pTrack->getTrackStates(0).Z0, pTrack->getTrackStates(0).omega, pTrack->getTrackStates(0).tanLambda, m_bField);
         const float recoMomentum(helixFit.GetMomentum().GetMagnitude());
         // Use momentum magnitude to identify best mc particle
-        edm4hep::ConstMCParticle *pBestMCParticle = NULL;
+        edm4hep::MCParticle *pBestMCParticle = NULL;
         float bestDeltaMomentum(std::numeric_limits<float>::max());
         try
         {

--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/PandoraPFAlg.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/PandoraPFAlg.cpp
@@ -5,7 +5,6 @@
 #include "edm4hep/Vector3d.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/CaloHitContribution.h"
-#include "edm4hep/ClusterConst.h"
 #include <cmath>
 #include <algorithm>
 #include "gear/BField.h"
@@ -653,16 +652,16 @@ StatusCode PandoraPFAlg::CreateMCRecoParticleAssociation()
     const edm4hep::ReconstructedParticleCollection* reco_col = m_ReconstructedParticleCollection_w.get();
     for(int i=0; i<reco_col->size();i++)
     {
-        std::map<int, edm4hep::ConstMCParticle> mc_map;
+        std::map<int, edm4hep::MCParticle> mc_map;
         std::map<int, float > id_edep_map;
         float tot_en = 0 ;
         auto pReco = reco_col->at(i);
         for(int j=0; j < pReco.clusters_size(); j++)
         {
-            edm4hep::ConstCluster cluster = pReco.getClusters(j);
+            edm4hep::Cluster cluster = pReco.getClusters(j);
             for(int k=0; k < cluster.hits_size(); k++)
             {
-                edm4hep::ConstCalorimeterHit hit = cluster.getHits(k);
+                edm4hep::CalorimeterHit hit = cluster.getHits(k);
                 for(auto iter = m_CollectionMaps->collectionMap_CaloRel.begin(); iter != m_CollectionMaps->collectionMap_CaloRel.end(); iter++)
                 {
                     for(auto it = iter->second.begin(); it != iter->second.end(); it ++)
@@ -681,7 +680,7 @@ StatusCode PandoraPFAlg::CreateMCRecoParticleAssociation()
         }
         for(auto it = mc_map.begin(); it != mc_map.end(); it ++)
         {      
-            edm4hep::MCRecoParticleAssociation association = pMCRecoParticleAssociationCollection->create();
+            auto association = pMCRecoParticleAssociationCollection->create();
             association.setRec(pReco);
             association.setSim(it->second);
             if(tot_en==0) 

--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/PfoCreator.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/PfoCreator.cpp
@@ -49,8 +49,8 @@ pandora::StatusCode PfoCreator::CreateParticleFlowObjects(CollectionMaps& collec
     for (pandora::PfoList::const_iterator pIter = pPandoraPfoList->begin(), pIterEnd = pPandoraPfoList->end(); pIter != pIterEnd; ++pIter)
     {
         const pandora::ParticleFlowObject *const pPandoraPfo(*pIter);
-        edm4hep::ReconstructedParticle pReconstructedParticle0 = pReconstructedParticleCollection->create();
-        edm4hep::ReconstructedParticle* pReconstructedParticle = &pReconstructedParticle0;
+        auto pReconstructedParticle0 = pReconstructedParticleCollection->create();
+        edm4hep::MutableReconstructedParticle* pReconstructedParticle = &pReconstructedParticle0;
 
         const bool hasTrack(!pPandoraPfo->GetTrackList().empty());
         const pandora::ClusterList &clusterList(pPandoraPfo->GetClusterList());
@@ -65,8 +65,8 @@ pandora::StatusCode PfoCreator::CreateParticleFlowObjects(CollectionMaps& collec
             pandoraCaloHitList.insert(pandoraCaloHitList.end(), pPandoraCluster->GetIsolatedCaloHitList().begin(), pPandoraCluster->GetIsolatedCaloHitList().end());
 
             pandora::FloatVector hitE, hitX, hitY, hitZ;
-            edm4hep::Cluster p_Cluster0 = pClusterCollection->create();
-            edm4hep::Cluster* p_Cluster = &p_Cluster0;
+            auto p_Cluster0 = pClusterCollection->create();
+            edm4hep::MutableCluster* p_Cluster = &p_Cluster0;
             this->SetClusterSubDetectorEnergies(subDetectorNames, p_Cluster, pandoraCaloHitList, hitE, hitX, hitY, hitZ);
 
             float clusterCorrectEnergy(0.f);
@@ -82,7 +82,7 @@ pandora::StatusCode PfoCreator::CreateParticleFlowObjects(CollectionMaps& collec
                 clustersTotalEnergy += clusterCorrectEnergy;
             }
 
-            edm4hep::ConstCluster p_ClusterCon = *p_Cluster;
+            edm4hep::Cluster p_ClusterCon = *p_Cluster;
             pReconstructedParticle->addToClusters(p_ClusterCon);
         }
 
@@ -107,8 +107,8 @@ pandora::StatusCode PfoCreator::CreateParticleFlowObjects(CollectionMaps& collec
         this->AddTracksToRecoParticle(pPandoraPfo, pReconstructedParticle);
         this->SetRecoParticlePropertiesFromPFO(pPandoraPfo, pReconstructedParticle);
 
-        edm4hep::Vertex pStartVertex0 = pStartVertexCollection->create();
-        edm4hep::Vertex* pStartVertex = &pStartVertex0;
+        auto pStartVertex0 = pStartVertexCollection->create();
+        edm4hep::MutableVertex* pStartVertex = &pStartVertex0;
         pStartVertex->setAlgorithmType(0);
         const float ref_value[3] = {referencePoint.GetX(),referencePoint.GetY(),referencePoint.GetZ()};
         pStartVertex->setPosition(edm4hep::Vector3f(ref_value));
@@ -132,7 +132,7 @@ void PfoCreator::InitialiseSubDetectorNames(pandora::StringVector &subDetectorNa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PfoCreator::SetClusterSubDetectorEnergies(const pandora::StringVector &subDetectorNames, edm4hep::Cluster *const p_Cluster,
+void PfoCreator::SetClusterSubDetectorEnergies(const pandora::StringVector &subDetectorNames, edm4hep::MutableCluster *const p_Cluster,
     const pandora::CaloHitList &pandoraCaloHitList, pandora::FloatVector &hitE, pandora::FloatVector &hitX, pandora::FloatVector &hitY,
     pandora::FloatVector &hitZ) const
 {
@@ -170,7 +170,7 @@ void PfoCreator::SetClusterSubDetectorEnergies(const pandora::StringVector &subD
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void PfoCreator::SetClusterEnergyAndError(const pandora::ParticleFlowObject *const pPandoraPfo, const pandora::Cluster *const pPandoraCluster, 
-    edm4hep::Cluster *const p_Cluster, float &clusterCorrectEnergy) const
+    edm4hep::MutableCluster *const p_Cluster, float &clusterCorrectEnergy) const
 {
     const bool isEmShower((pandora::PHOTON == pPandoraPfo->GetParticleId()) || (pandora::E_MINUS == std::abs(pPandoraPfo->GetParticleId())));
     clusterCorrectEnergy = (isEmShower ? pPandoraCluster->GetCorrectedElectromagneticEnergy(*m_pPandora) : pPandoraCluster->GetCorrectedHadronicEnergy(*m_pPandora));
@@ -189,7 +189,7 @@ void PfoCreator::SetClusterEnergyAndError(const pandora::ParticleFlowObject *con
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void PfoCreator::SetClusterPositionAndError(const unsigned int nHitsInCluster, pandora::FloatVector &hitE, pandora::FloatVector &hitX, 
-    pandora::FloatVector &hitY, pandora::FloatVector &hitZ, edm4hep::Cluster *const p_Cluster, pandora::CartesianVector &clusterPositionVec) const
+    pandora::FloatVector &hitY, pandora::FloatVector &hitZ, edm4hep::MutableCluster *const p_Cluster, pandora::CartesianVector &clusterPositionVec) const
 {
     ClusterShapes *const pClusterShapes(new ClusterShapes(nHitsInCluster, hitE.data(), hitX.data(), hitY.data(), hitZ.data()));//this need GSL/1.14 
 
@@ -365,7 +365,7 @@ bool PfoCreator::AreAnyOtherSiblingsInList(const pandora::Track *const pPandoraT
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PfoCreator::SetRecoParticleReferencePoint(const pandora::CartesianVector &referencePoint, edm4hep::ReconstructedParticle *const pReconstructedParticle) const
+void PfoCreator::SetRecoParticleReferencePoint(const pandora::CartesianVector &referencePoint, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const
 {
     const float referencePointArray[3] = {referencePoint.GetX(), referencePoint.GetY(), referencePoint.GetZ()};
     pReconstructedParticle->setReferencePoint(referencePointArray);
@@ -373,7 +373,7 @@ void PfoCreator::SetRecoParticleReferencePoint(const pandora::CartesianVector &r
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PfoCreator::AddTracksToRecoParticle(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::ReconstructedParticle *const pReconstructedParticle) const
+void PfoCreator::AddTracksToRecoParticle(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const
 {
     const pandora::TrackList &trackList(pPandoraPfo->GetTrackList());
 
@@ -389,7 +389,7 @@ void PfoCreator::AddTracksToRecoParticle(const pandora::ParticleFlowObject *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PfoCreator::SetRecoParticlePropertiesFromPFO(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::ReconstructedParticle *const pReconstructedParticle) const
+void PfoCreator::SetRecoParticlePropertiesFromPFO(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const
 {
     const float momentum[3] = {pPandoraPfo->GetMomentum().GetX(), pPandoraPfo->GetMomentum().GetY(), pPandoraPfo->GetMomentum().GetZ()};
     pReconstructedParticle->setMomentum(momentum);

--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/TrackCreator.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/TrackCreator.cpp
@@ -405,14 +405,14 @@ pandora::StatusCode TrackCreator::ExtractProngsAndSplits(const CollectionMaps& c
                     auto pVertex  = &(pVertex0);
 
                     if (NULL == pVertex) throw ("Collection type mismatch");
-                    const edm4hep::ConstReconstructedParticle pReconstructedParticle = pVertex->getAssociatedParticle();
+                    const edm4hep::ReconstructedParticle pReconstructedParticle = pVertex->getAssociatedParticle();
 
                     if (this->IsConflictingRelationship(pReconstructedParticle))continue;
 
                     // Extract the prong/split vertex information
                     for (unsigned int iTrack = 0, nTracks = pReconstructedParticle.tracks_size(); iTrack < nTracks; ++iTrack)
                     {
-                        edm4hep::ConstTrack pTrack = pReconstructedParticle.getTracks(iTrack);
+                        edm4hep::Track pTrack = pReconstructedParticle.getTracks(iTrack);
                         (0 == iTrack) ? m_parentTrackList.insert(pTrack.id()) : m_daughterTrackList.insert(pTrack.id());
 
                         if (0 == m_settings.m_shouldFormTrackRelationships) continue;
@@ -472,7 +472,7 @@ pandora::StatusCode TrackCreator::ExtractV0s(const CollectionMaps& collectionMap
 
                     if (NULL == pVertex) throw ("Collection type mismatch");
 
-                    const edm4hep::ConstReconstructedParticle pReconstructedParticle = pVertex->getAssociatedParticle();
+                    const edm4hep::ReconstructedParticle pReconstructedParticle = pVertex->getAssociatedParticle();
 
                     if (this->IsConflictingRelationship(pReconstructedParticle))continue;
 
@@ -481,7 +481,7 @@ pandora::StatusCode TrackCreator::ExtractV0s(const CollectionMaps& collectionMap
 
                     for (unsigned int iTrack = 0, nTracks = pReconstructedParticle.tracks_size(); iTrack < nTracks; ++iTrack)
                     {
-                        edm4hep::ConstTrack pTrack = pReconstructedParticle.getTracks(iTrack);
+                        edm4hep::Track pTrack = pReconstructedParticle.getTracks(iTrack);
                         m_v0TrackList.insert(pTrack.id());
 
                         int trackPdgCode = pandora::UNKNOWN_PARTICLE_TYPE;
@@ -533,11 +533,11 @@ pandora::StatusCode TrackCreator::ExtractV0s(const CollectionMaps& collectionMap
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackCreator::IsConflictingRelationship(const edm4hep::ConstReconstructedParticle &Particle) const
+bool TrackCreator::IsConflictingRelationship(const edm4hep::ReconstructedParticle &Particle) const
 {
     for (unsigned int iTrack = 0, nTracks = Particle.tracks_size(); iTrack < nTracks; ++iTrack)
     {
-        edm4hep::ConstTrack pTrack = Particle.getTracks(iTrack) ;
+        edm4hep::Track pTrack = Particle.getTracks(iTrack) ;
         unsigned int pTrack_id = pTrack.id() ;
 
         if (this->IsDaughter(pTrack_id) || this->IsParent(pTrack_id) || this->IsV0(pTrack_id))
@@ -547,7 +547,7 @@ bool TrackCreator::IsConflictingRelationship(const edm4hep::ConstReconstructedPa
     return false;
 }
 
-edm4hep::ConstTrack* TrackCreator::GetTrackAddress(const CollectionMaps& collectionMaps, const edm4hep::ConstTrack& pTrack )
+edm4hep::Track* TrackCreator::GetTrackAddress(const CollectionMaps& collectionMaps, const edm4hep::Track& pTrack )
 {
     for (StringVector::const_iterator iter = m_settings.m_trackCollections.begin(), iterEnd = m_settings.m_trackCollections.end(); iter != iterEnd; ++iter)
     {
@@ -665,7 +665,7 @@ pandora::StatusCode TrackCreator::CreateTracks(const CollectionMaps& collectionM
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackCreator::GetTrackStates(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
+void TrackCreator::GetTrackStates(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
 {
     // for DD4HEP, 0 is IP, 1 is AtFirstHit, 2 is AtLastHit, 3 is AtCalo
     edm4hep::TrackState pTrackState = pTrack->getTrackStates(0); 
@@ -691,7 +691,7 @@ void TrackCreator::GetTrackStates(edm4hep::ConstTrack *const pTrack, PandoraApi:
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float TrackCreator::CalculateTrackTimeAtCalorimeter(edm4hep::ConstTrack *const pTrack) const
+float TrackCreator::CalculateTrackTimeAtCalorimeter(edm4hep::Track *const pTrack) const
 {
     const pandora::Helix helix(pTrack->getTrackStates(0).phi, pTrack->getTrackStates(0).D0, pTrack->getTrackStates(0).Z0, pTrack->getTrackStates(0).omega, pTrack->getTrackStates(0).tanLambda, m_bField);
     const pandora::CartesianVector &referencePoint(helix.GetReferencePoint());
@@ -764,7 +764,7 @@ void TrackCreator::CopyTrackState(const edm4hep::TrackState & pTrackState, pando
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackCreator::TrackReachesECAL(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
+void TrackCreator::TrackReachesECAL(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
 {
     
     // Calculate hit position information
@@ -779,7 +779,7 @@ void TrackCreator::TrackReachesECAL(edm4hep::ConstTrack *const pTrack, PandoraAp
     for (unsigned int i = 0; i < nTrackHits; ++i)
     {
         
-        const edm4hep::ConstTrackerHit Hit ( pTrack->getTrackerHits(i) );
+        const edm4hep::TrackerHit Hit ( pTrack->getTrackerHits(i) );
         const edm4hep::Vector3d pos = Hit.getPosition();
         
         float x = float(pos[0]);
@@ -847,7 +847,7 @@ void TrackCreator::TrackReachesECAL(edm4hep::ConstTrack *const pTrack, PandoraAp
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackCreator::DefineTrackPfoUsage(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
+void TrackCreator::DefineTrackPfoUsage(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
 {
     bool canFormPfo(false);
     bool canFormClusterlessPfo(false);
@@ -932,7 +932,7 @@ void TrackCreator::DefineTrackPfoUsage(edm4hep::ConstTrack *const pTrack, Pandor
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackCreator::PassesQualityCuts(edm4hep::ConstTrack *const pTrack, const PandoraApi::Track::Parameters &trackParameters) const
+bool TrackCreator::PassesQualityCuts(edm4hep::Track *const pTrack, const PandoraApi::Track::Parameters &trackParameters) const
 {
     // First simple sanity checks
     if (trackParameters.m_trackStateAtCalorimeter.Get().GetPosition().GetMagnitude() < m_settings.m_minTrackECalDistanceFromIp)
@@ -1009,7 +1009,7 @@ bool TrackCreator::PassesQualityCuts(edm4hep::ConstTrack *const pTrack, const Pa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-int TrackCreator::GetNTpcHits(edm4hep::ConstTrack *const pTrack) const
+int TrackCreator::GetNTpcHits(edm4hep::Track *const pTrack) const
 {
     // ATTN
     //fg: hit numbers are now given in different order wrt LOI:  
@@ -1028,7 +1028,7 @@ int TrackCreator::GetNTpcHits(edm4hep::ConstTrack *const pTrack) const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-int TrackCreator::GetNFtdHits(edm4hep::ConstTrack *const pTrack) const
+int TrackCreator::GetNFtdHits(edm4hep::Track *const pTrack) const
 {
     // ATTN
     //fg: hit numbers are now given in different order wrt LOI:  

--- a/Reconstruction/PFA/Pandora/MatrixPandora/include/CaloHitCreator.h
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/include/CaloHitCreator.h
@@ -25,7 +25,7 @@
 
 #include <string>
 
-typedef std::vector<edm4hep::ConstCalorimeterHit *> CalorimeterHitVector;
+typedef std::vector<edm4hep::CalorimeterHit *> CalorimeterHitVector;
 
 namespace gear { class GearMgr; }
 
@@ -165,7 +165,7 @@ private:
      *  @brief  Get common calo hit properties: position, parent address, input energy and time
      * 
      */
-    void GetCommonCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, PandoraApi::CaloHit::Parameters &caloHitParameters) const;
+    void GetCommonCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, PandoraApi::CaloHit::Parameters &caloHitParameters) const;
 
     /**
      *  @brief  Get end cap specific calo hit properties: cell size, absorber radiation and interaction lengths, normal vector
@@ -175,7 +175,7 @@ private:
      *  @param  caloHitParameters the calo hit parameters to populate
      *  @param  absorberCorrection to receive the absorber thickness correction for the mip equivalent energy
      */
-    void GetEndCapCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
+    void GetEndCapCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
         PandoraApi::CaloHit::Parameters &caloHitParameters, float &absorberCorrection) const;
 
     /**
@@ -189,11 +189,11 @@ private:
      *  @param  caloHitParameters the calo hit parameters to populate
      *  @param  absorberCorrection to receive the absorber thickness correction for the mip equivalent energy
      */
-    void GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
+    void GetBarrelCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
         unsigned int barrelSymmetryOrder, float barrelPhi0, unsigned int staveNumber, PandoraApi::CaloHit::Parameters &caloHitParameters,
         float &absorberCorrection) const;
 
-    void GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterData::Layer> &layerLayout,
+    void GetBarrelCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterData::Layer> &layerLayout,
         unsigned int barrelSymmetryOrder, float barrelPhi0, unsigned int staveNumber, PandoraApi::CaloHit::Parameters &caloHitParameters,
         float &absorberCorrection) const;
     /**
@@ -201,7 +201,7 @@ private:
      * 
      *  @param  pCaloHit the lcio calorimeter hit
      */
-    int GetNLayersFromEdge(edm4hep::ConstCalorimeterHit *const pCaloHit) const;
+    int GetNLayersFromEdge(edm4hep::CalorimeterHit *const pCaloHit) const;
 
     /**
      *  @brief  Get the maximum radius of a calo hit in a polygonal detector structure
@@ -212,10 +212,10 @@ private:
      * 
      *  @return the maximum radius
      */
-    float GetMaximumRadius(edm4hep::ConstCalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const;
+    float GetMaximumRadius(edm4hep::CalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const;
 
-    void GetCoding(edm4hep::ConstCalorimeterHit* pCaloHit, long& sys, long& x, long& y, long& z) const ;
-    int GetBarrelLayer(edm4hep::ConstCalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterData::Layer> &layerLayout) const;
+    void GetCoding(edm4hep::CalorimeterHit* pCaloHit, long& sys, long& x, long& y, long& z) const ;
+    int GetBarrelLayer(edm4hep::CalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterData::Layer> &layerLayout) const;
     /**
      *  @brief  Get the layer coding string from the provided cell id encoding string
      * 

--- a/Reconstruction/PFA/Pandora/MatrixPandora/include/MCParticleCreator.h
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/include/MCParticleCreator.h
@@ -86,7 +86,7 @@ private:
     const Settings          m_settings;                         ///< The mc particle creator settings
     const pandora::Pandora *m_pPandora;                         ///< Address of the pandora object to create the mc particles
     const float             m_bField;                           ///< The bfield
-    std::map<unsigned int, edm4hep::ConstMCParticle*>*  m_id_pMC_map;
+    std::map<unsigned int, edm4hep::MCParticle*>*  m_id_pMC_map;
 };
 
 inline void MCParticleCreator::Reset()

--- a/Reconstruction/PFA/Pandora/MatrixPandora/include/PandoraMatrixAlg.h
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/include/PandoraMatrixAlg.h
@@ -59,12 +59,12 @@ public:
     CollectionMaps();
     void clear();
 
-    std::map<std::string, std::vector<edm4hep::ConstMCParticle> >     collectionMap_MC;
-    std::map<std::string, std::vector<edm4hep::ConstCalorimeterHit> > collectionMap_CaloHit;
-    std::map<std::string, std::vector<edm4hep::ConstVertex> >         collectionMap_Vertex;
-    std::map<std::string, std::vector<edm4hep::ConstTrack> >          collectionMap_Track;
-    std::map<std::string, std::vector<edm4hep::ConstMCRecoCaloAssociation> > collectionMap_CaloRel;
-    std::map<std::string, std::vector<edm4hep::ConstMCRecoTrackerAssociation> > collectionMap_TrkRel;
+    std::map<std::string, std::vector<edm4hep::MCParticle> >     collectionMap_MC;
+    std::map<std::string, std::vector<edm4hep::CalorimeterHit> > collectionMap_CaloHit;
+    std::map<std::string, std::vector<edm4hep::Vertex> >         collectionMap_Vertex;
+    std::map<std::string, std::vector<edm4hep::Track> >          collectionMap_Track;
+    std::map<std::string, std::vector<edm4hep::MCRecoCaloAssociation> > collectionMap_CaloRel;
+    std::map<std::string, std::vector<edm4hep::MCRecoTrackerAssociation> > collectionMap_TrkRel;
 };
 
 

--- a/Reconstruction/PFA/Pandora/MatrixPandora/include/PfoCreator.h
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/include/PfoCreator.h
@@ -110,7 +110,7 @@ private:
      *  @param  hitY the vector to receive the y position of hits
      *  @param  hitZ the vector to receive the z position of hits
      */
-    void SetClusterSubDetectorEnergies(const pandora::StringVector &subDetectorNames, edm4hep::Cluster *const pLcioCluster,
+    void SetClusterSubDetectorEnergies(const pandora::StringVector &subDetectorNames, edm4hep::MutableCluster *const pLcioCluster,
         const pandora::CaloHitList &pandoraCaloHitList, pandora::FloatVector &hitE, pandora::FloatVector &hitX, pandora::FloatVector &hitY,
         pandora::FloatVector &hitZ) const;
 
@@ -123,7 +123,7 @@ private:
      *  @param  clusterCorrectEnergy a number to receive the cluster correct energy
      */
     void SetClusterEnergyAndError(const pandora::ParticleFlowObject *const pPandoraPfo, const pandora::Cluster *const pPandoraCluster, 
-        edm4hep::Cluster *const pLcioCluster, float &clusterCorrectEnergy) const;
+        edm4hep::MutableCluster *const pLcioCluster, float &clusterCorrectEnergy) const;
 
     /**
      *  @brief  Set cluster position, errors and other shape info, by calculating culster shape first
@@ -137,7 +137,7 @@ private:
      *  @param  clusterPosition a CartesianVector to receive the cluster position
      */
     void SetClusterPositionAndError(const unsigned int nHitsInCluster, pandora::FloatVector &hitE, pandora::FloatVector &hitX, 
-        pandora::FloatVector &hitY, pandora::FloatVector &hitZ, edm4hep::Cluster *const pLcioCluster, pandora::CartesianVector &clusterPositionVec) const;
+        pandora::FloatVector &hitY, pandora::FloatVector &hitZ, edm4hep::MutableCluster *const pLcioCluster, pandora::CartesianVector &clusterPositionVec) const;
 
     /**
      *  @brief  Calculate reference point for pfo with tracks
@@ -153,7 +153,7 @@ private:
      *  @param  referencePoint a CartesianVector of the reference point
      *  @param  pReconstructedParticle the address of the reconstructed particle to be reference point
      */
-    void SetRecoParticleReferencePoint(const pandora::CartesianVector &referencePoint, edm4hep::ReconstructedParticle *const pReconstructedParticle) const;
+    void SetRecoParticleReferencePoint(const pandora::CartesianVector &referencePoint, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const;
 
     /**
      *  @brief  Add tracks to reconstructed particle
@@ -161,7 +161,7 @@ private:
      *  @param  pPandoraPfo the address of the pandora pfo
      *  @param  pReconstructedParticle the address of the reconstructed particle to be added tracks
      */
-    void AddTracksToRecoParticle(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::ReconstructedParticle *const pReconstructedParticle) const;
+    void AddTracksToRecoParticle(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const;
 
     /**
      *  @brief  Set properties of reconstructed particle from pandora pfo
@@ -169,7 +169,7 @@ private:
      *  @param  pPandoraPfo the address of the pandora pfo 
      *  @param  pReconstructedParticle the address of the reconstructed particle to be set properties
      */
-    void SetRecoParticlePropertiesFromPFO(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::ReconstructedParticle *const pReconstructedParticle) const;
+    void SetRecoParticlePropertiesFromPFO(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const;
 
     /**
      *  @brief  Whether parent and daughter tracks are associated with the same pfo

--- a/Reconstruction/PFA/Pandora/MatrixPandora/include/TrackCreator.h
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/include/TrackCreator.h
@@ -14,9 +14,7 @@
 #include "GaudiKernel/ISvcLocator.h"
 
 #include "edm4hep/Track.h"
-#include "edm4hep/TrackConst.h"
 #include "edm4hep/TrackState.h"
-#include "edm4hep/ReconstructedParticleConst.h"
 
 #include "Api/PandoraApi.h"
 #include "Objects/Helix.h"
@@ -25,9 +23,9 @@ namespace gear { class GearMgr; }
 
 class CollectionMaps;
 
-typedef std::vector<edm4hep::ConstTrack *> TrackVector;
+typedef std::vector<edm4hep::Track *> TrackVector;
 typedef std::set<unsigned int> TrackList;
-typedef std::map<edm4hep::ConstTrack, int> TrackToPidMap;
+typedef std::map<edm4hep::Track, int> TrackToPidMap;
 /*
 inline LCCollectionVec *newTrkCol(const std::string &name, LCEvent *evt , bool isSubset)
 {
@@ -127,7 +125,7 @@ public:
      */
     pandora::StatusCode CreateTrackAssociations(const CollectionMaps& collectionMaps);
 
-    edm4hep::ConstTrack* GetTrackAddress(const CollectionMaps& collectionMaps, const edm4hep::ConstTrack& pTrack );
+    edm4hep::Track* GetTrackAddress(const CollectionMaps& collectionMaps, const edm4hep::Track& pTrack );
     /**
      *  @brief  Create tracks, insert user code here
      * 
@@ -199,7 +197,7 @@ private:
      *  @brief  Copy track states stored in lcio tracks to pandora track parameters
      * 
      */
-    void GetTrackStates(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
+    void GetTrackStates(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
 
     /**
      *  @brief  Copy track state from lcio track state instance to pandora input track state
@@ -211,13 +209,13 @@ private:
      *  @brief  Obtain track time when it reaches ECAL
      * 
      */
-    float CalculateTrackTimeAtCalorimeter(edm4hep::ConstTrack *const pTrack) const;
+    float CalculateTrackTimeAtCalorimeter(edm4hep::Track *const pTrack) const;
 
     /**
      *  @brief  Decide whether track reaches the ecal surface
      * 
      */
-    void TrackReachesECAL(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
+    void TrackReachesECAL(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
 
     /**
      *  @brief  Determine whether a track can be used to form a pfo under the following conditions:
@@ -225,7 +223,7 @@ private:
      *          2) if the track proves to have no cluster associations
      * 
      */
-    void DefineTrackPfoUsage(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
+    void DefineTrackPfoUsage(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const;
 
     /**
      *  @brief  Whether track passes the quality cuts required in order to be used to form a pfo
@@ -233,20 +231,20 @@ private:
      * 
      *  @return boolean
      */
-    bool PassesQualityCuts(edm4hep::ConstTrack *const pTrack, const PandoraApi::Track::Parameters &trackParameters) const;
+    bool PassesQualityCuts(edm4hep::Track *const pTrack, const PandoraApi::Track::Parameters &trackParameters) const;
 
     /**
      *  @brief  Get number of hits in TPC of a track
      * 
      */
-    int GetNTpcHits(edm4hep::ConstTrack *const pTrack) const;
+    int GetNTpcHits(edm4hep::Track *const pTrack) const;
 
     /**
      *  @brief  Get number of hits in FTD of a track
      * 
      * 
      */
-    int GetNFtdHits(edm4hep::ConstTrack *const pTrack) const;
+    int GetNFtdHits(edm4hep::Track *const pTrack) const;
 
     const Settings          m_settings;                     ///< The track creator settings
     const pandora::Pandora *m_pPandora;                     ///< Address of the pandora object to create tracks and track relationships

--- a/Reconstruction/PFA/Pandora/MatrixPandora/include/TrackCreator.h
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/include/TrackCreator.h
@@ -167,7 +167,7 @@ private:
      *  @brief  Whether the track vertex conflicts with previously provided relationship information
      * 
      */
-    bool IsConflictingRelationship(const edm4hep::ConstReconstructedParticle &Particle) const;
+    bool IsConflictingRelationship(const edm4hep::ReconstructedParticle &Particle) const;
 
     /**
      *  @brief  Whether a track is a v0 track

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/CaloHitCreator.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/CaloHitCreator.cpp
@@ -598,7 +598,7 @@ pandora::StatusCode CaloHitCreator::CreateLHCalCaloHits(const CollectionMaps& co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CaloHitCreator::GetCommonCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, PandoraApi::CaloHit::Parameters &caloHitParameters) const
+void CaloHitCreator::GetCommonCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, PandoraApi::CaloHit::Parameters &caloHitParameters) const
 {
     const float pCaloHitPosition[3]={pCaloHit->getPosition()[0], pCaloHit->getPosition()[1], pCaloHit->getPosition()[2]};
     const pandora::CartesianVector positionVector(pCaloHitPosition[0], pCaloHitPosition[1], pCaloHitPosition[2]);
@@ -613,7 +613,7 @@ void CaloHitCreator::GetCommonCaloHitProperties(edm4hep::ConstCalorimeterHit *co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CaloHitCreator::GetEndCapCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
+void CaloHitCreator::GetEndCapCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
     PandoraApi::CaloHit::Parameters &caloHitParameters, float &absorberCorrection) const
 {
     caloHitParameters.m_hitRegion = pandora::ENDCAP;
@@ -659,7 +659,7 @@ void CaloHitCreator::GetEndCapCaloHitProperties(edm4hep::ConstCalorimeterHit *co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
+void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const gear::LayerLayout &layerLayout,
     unsigned int barrelSymmetryOrder, float barrelPhi0, unsigned int staveNumber, PandoraApi::CaloHit::Parameters &caloHitParameters,
     float &absorberCorrection) const
 {
@@ -724,7 +724,7 @@ void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *co
     }
 }
 
-void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterData::Layer> &layerLayout,
+void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::CalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterData::Layer> &layerLayout,
     unsigned int barrelSymmetryOrder, float barrelPhi0, unsigned int staveNumber, PandoraApi::CaloHit::Parameters &caloHitParameters,
     float &absorberCorrection) const
 {
@@ -789,7 +789,7 @@ void CaloHitCreator::GetBarrelCaloHitProperties(edm4hep::ConstCalorimeterHit *co
     }
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
-int CaloHitCreator::GetBarrelLayer(edm4hep::ConstCalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterData::Layer> &layerLayout) const
+int CaloHitCreator::GetBarrelLayer(edm4hep::CalorimeterHit *const pCaloHit, const std::vector<dd4hep::rec::LayeredCalorimeterData::Layer> &layerLayout) const
 {
     int layer = -1 ;   
     for (unsigned int i = 0, iMax = layerLayout.size(); i < iMax; ++i)
@@ -807,7 +807,7 @@ int CaloHitCreator::GetBarrelLayer(edm4hep::ConstCalorimeterHit *const pCaloHit,
     return layer;
 }
 
-int CaloHitCreator::GetNLayersFromEdge(edm4hep::ConstCalorimeterHit *const pCaloHit) const
+int CaloHitCreator::GetNLayersFromEdge(edm4hep::CalorimeterHit *const pCaloHit) const
 {
     // Calo hit coordinate calculations
     const float barrelMaximumRadius(this->GetMaximumRadius(pCaloHit, m_hCalBarrelOuterSymmetry, m_hCalBarrelOuterPhi0));
@@ -849,7 +849,7 @@ int CaloHitCreator::GetNLayersFromEdge(edm4hep::ConstCalorimeterHit *const pCalo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float CaloHitCreator::GetMaximumRadius(edm4hep::ConstCalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const
+float CaloHitCreator::GetMaximumRadius(edm4hep::CalorimeterHit *const pCaloHit, const unsigned int symmetryOrder, const float phi0) const
 {
     
     const float pCaloHitPosition[3]={pCaloHit->getPosition()[0], pCaloHit->getPosition()[1], pCaloHit->getPosition()[2]};
@@ -871,7 +871,7 @@ float CaloHitCreator::GetMaximumRadius(edm4hep::ConstCalorimeterHit *const pCalo
     return maximumRadius;
 }
 
-void CaloHitCreator::GetCoding(edm4hep::ConstCalorimeterHit* pCaloHit, long& sys, long& x, long& y, long& z) const
+void CaloHitCreator::GetCoding(edm4hep::CalorimeterHit* pCaloHit, long& sys, long& x, long& y, long& z) const
 {
     //sys = (pCaloHit->getCellID() << (64-8)) >> (64-8) ;
     //x   = (pCaloHit->getCellID() << (64-(8+16))) >> (64-(8+16)) ;

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/MCParticleCreator.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/MCParticleCreator.cpp
@@ -6,14 +6,10 @@
  */
 
 
-#include "edm4hep/MCParticleConst.h"
 #include "edm4hep/MCParticle.h" 
 #include "edm4hep/MCRecoCaloAssociation.h" 
-#include "edm4hep/SimCalorimeterHitConst.h" 
-#include "edm4hep/CaloHitContributionConst.h" 
 #include "edm4hep/Track.h" 
 #include "edm4hep/MCRecoTrackerAssociation.h" 
-#include "edm4hep/SimTrackerHitConst.h" 
 
 
 
@@ -30,7 +26,7 @@ MCParticleCreator::MCParticleCreator(const Settings &settings, const pandora::Pa
     m_pPandora(pPandora),
     m_bField(settings.m_bField)
 {
-m_id_pMC_map = new std::map<unsigned int, edm4hep::ConstMCParticle*>;
+m_id_pMC_map = new std::map<unsigned int, edm4hep::MCParticle*>;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -249,7 +245,7 @@ pandora::StatusCode MCParticleCreator::CreateCaloHitToMCParticleRelationships(co
 pandora::StatusCode MCParticleCreator::CreateCaloHitToMCParticleRelationships(const CollectionMaps& collectionMaps, const CalorimeterHitVector &calorimeterHitVector) const
 {
     std::cout<<"Do CreateCaloHitToMCParticleRelationships"<<std::endl;
-    typedef std::map<edm4hep::ConstMCParticle *, float> MCParticleToEnergyWeightMap;
+    typedef std::map<edm4hep::MCParticle *, float> MCParticleToEnergyWeightMap;
     MCParticleToEnergyWeightMap mcParticleToEnergyWeightMap;
 
     for (StringVector::const_iterator iter = m_settings.m_CaloHitRelationCollections.begin(), iterEnd = m_settings.m_CaloHitRelationCollections.end();
@@ -272,7 +268,7 @@ pandora::StatusCode MCParticleCreator::CreateCaloHitToMCParticleRelationships(co
                         auto pSimHit = pMCRecoCaloAssociationCollection.at(ic).getSim();
                         for (int iCont = 0, iEnd = pSimHit.contributions_size(); iCont < iEnd; ++iCont)
                         {
-                            edm4hep::ConstCaloHitContribution conb = pSimHit.getContributions(iCont);
+                            edm4hep::CaloHitContribution conb = pSimHit.getContributions(iCont);
                             auto ipa = conb.getParticle();
                             float  ien = conb.getEnergy();
                             if( m_id_pMC_map->find(ipa.id()) == m_id_pMC_map->end() ) continue;
@@ -320,7 +316,7 @@ pandora::StatusCode MCParticleCreator::CreateTrackToMCParticleRelationships(cons
         const pandora::Helix helixFit(pTrack->getTrackStates(0).phi, pTrack->getTrackStates(0).D0, pTrack->getTrackStates(0).Z0, pTrack->getTrackStates(0).omega, pTrack->getTrackStates(0).tanLambda, m_bField);
         const float recoMomentum(helixFit.GetMomentum().GetMagnitude());
         // Use momentum magnitude to identify best mc particle
-        edm4hep::ConstMCParticle *pBestMCParticle = NULL;
+        edm4hep::MCParticle *pBestMCParticle = NULL;
         float bestDeltaMomentum(std::numeric_limits<float>::max());
         try
         {

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/PandoraMatrixAlg.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/PandoraMatrixAlg.cpp
@@ -6,7 +6,6 @@
 #include "edm4hep/Vector3d.h"
 #include "edm4hep/SimCalorimeterHit.h"
 #include "edm4hep/CaloHitContribution.h"
-#include "edm4hep/ClusterConst.h"
 #include "UTIL/ILDConf.h"
 #include <cmath>
 #include <algorithm>
@@ -639,16 +638,16 @@ StatusCode PandoraMatrixAlg::CreateMCRecoParticleAssociation()
     std::cout<<"CreateMCRecoParticleAssociation, reco_col size="<<reco_col->size()<<std::endl;
     for(int i=0; i<reco_col->size();i++)
     {
-        std::map<int, edm4hep::ConstMCParticle> mc_map;
+        std::map<int, edm4hep::MCParticle> mc_map;
         std::map<int, float > id_edep_map;
         float tot_en = 0 ;
         auto pReco = reco_col->at(i);
         for(int j=0; j < pReco.clusters_size(); j++)
         {
-            edm4hep::ConstCluster cluster = pReco.getClusters(j);
+            edm4hep::Cluster cluster = pReco.getClusters(j);
             for(int k=0; k < cluster.hits_size(); k++)
             {
-                edm4hep::ConstCalorimeterHit hit = cluster.getHits(k);
+                edm4hep::CalorimeterHit hit = cluster.getHits(k);
                 for(auto iter = m_CollectionMaps->collectionMap_CaloRel.begin(); iter != m_CollectionMaps->collectionMap_CaloRel.end(); iter++)
                 {
                     for(auto it = iter->second.begin(); it != iter->second.end(); it ++)
@@ -667,7 +666,7 @@ StatusCode PandoraMatrixAlg::CreateMCRecoParticleAssociation()
         }
         for(auto it = mc_map.begin(); it != mc_map.end(); it ++)
         {      
-            edm4hep::MCRecoParticleAssociation association = pMCRecoParticleAssociationCollection->create();
+            auto association = pMCRecoParticleAssociationCollection->create();
             association.setRec(pReco);
             association.setSim(it->second);
             if(tot_en==0) 

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/PfoCreator.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/PfoCreator.cpp
@@ -52,8 +52,8 @@ pandora::StatusCode PfoCreator::CreateParticleFlowObjects(CollectionMaps& collec
     for (pandora::PfoList::const_iterator pIter = pPandoraPfoList->begin(), pIterEnd = pPandoraPfoList->end(); pIter != pIterEnd; ++pIter)
     {
         const pandora::ParticleFlowObject *const pPandoraPfo(*pIter);
-        edm4hep::ReconstructedParticle pReconstructedParticle0 = pReconstructedParticleCollection->create();
-        edm4hep::ReconstructedParticle* pReconstructedParticle = &pReconstructedParticle0;
+        auto pReconstructedParticle0 = pReconstructedParticleCollection->create();
+        edm4hep::MutableReconstructedParticle* pReconstructedParticle = &pReconstructedParticle0;
 
         const bool hasTrack(!pPandoraPfo->GetTrackList().empty());
         const pandora::ClusterList &clusterList(pPandoraPfo->GetClusterList());
@@ -68,8 +68,8 @@ pandora::StatusCode PfoCreator::CreateParticleFlowObjects(CollectionMaps& collec
             pandoraCaloHitList.insert(pandoraCaloHitList.end(), pPandoraCluster->GetIsolatedCaloHitList().begin(), pPandoraCluster->GetIsolatedCaloHitList().end());
 
             pandora::FloatVector hitE, hitX, hitY, hitZ;
-            edm4hep::Cluster p_Cluster0 = pClusterCollection->create();
-            edm4hep::Cluster* p_Cluster = &p_Cluster0;
+            auto p_Cluster0 = pClusterCollection->create();
+            edm4hep::MutableCluster* p_Cluster = &p_Cluster0;
             this->SetClusterSubDetectorEnergies(subDetectorNames, p_Cluster, pandoraCaloHitList, hitE, hitX, hitY, hitZ);
 
             float clusterCorrectEnergy(0.f);
@@ -85,7 +85,7 @@ pandora::StatusCode PfoCreator::CreateParticleFlowObjects(CollectionMaps& collec
                 clustersTotalEnergy += clusterCorrectEnergy;
             }
 
-            edm4hep::ConstCluster p_ClusterCon = *p_Cluster;
+            edm4hep::Cluster p_ClusterCon = *p_Cluster;
             pReconstructedParticle->addToClusters(p_ClusterCon);
         }
 
@@ -110,8 +110,8 @@ pandora::StatusCode PfoCreator::CreateParticleFlowObjects(CollectionMaps& collec
         this->AddTracksToRecoParticle(pPandoraPfo, pReconstructedParticle);
         this->SetRecoParticlePropertiesFromPFO(pPandoraPfo, pReconstructedParticle);
 
-        edm4hep::Vertex pStartVertex0 = pStartVertexCollection->create();
-        edm4hep::Vertex* pStartVertex = &pStartVertex0;
+        auto pStartVertex0 = pStartVertexCollection->create();
+        edm4hep::MutableVertex* pStartVertex = &pStartVertex0;
         pStartVertex->setAlgorithmType(0);
         const float ref_value[3] = {referencePoint.GetX(),referencePoint.GetY(),referencePoint.GetZ()};
         pStartVertex->setPosition(edm4hep::Vector3f(ref_value));
@@ -135,7 +135,7 @@ void PfoCreator::InitialiseSubDetectorNames(pandora::StringVector &subDetectorNa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PfoCreator::SetClusterSubDetectorEnergies(const pandora::StringVector &subDetectorNames, edm4hep::Cluster *const p_Cluster,
+void PfoCreator::SetClusterSubDetectorEnergies(const pandora::StringVector &subDetectorNames, edm4hep::MutableCluster *const p_Cluster,
     const pandora::CaloHitList &pandoraCaloHitList, pandora::FloatVector &hitE, pandora::FloatVector &hitX, pandora::FloatVector &hitY,
     pandora::FloatVector &hitZ) const
 {
@@ -173,7 +173,7 @@ void PfoCreator::SetClusterSubDetectorEnergies(const pandora::StringVector &subD
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void PfoCreator::SetClusterEnergyAndError(const pandora::ParticleFlowObject *const pPandoraPfo, const pandora::Cluster *const pPandoraCluster, 
-    edm4hep::Cluster *const p_Cluster, float &clusterCorrectEnergy) const
+    edm4hep::MutableCluster *const p_Cluster, float &clusterCorrectEnergy) const
 {
     const bool isEmShower((pandora::PHOTON == pPandoraPfo->GetParticleId()) || (pandora::E_MINUS == std::abs(pPandoraPfo->GetParticleId())));
     clusterCorrectEnergy = (isEmShower ? pPandoraCluster->GetCorrectedElectromagneticEnergy(*m_pPandora) : pPandoraCluster->GetCorrectedHadronicEnergy(*m_pPandora));
@@ -192,7 +192,7 @@ void PfoCreator::SetClusterEnergyAndError(const pandora::ParticleFlowObject *con
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void PfoCreator::SetClusterPositionAndError(const unsigned int nHitsInCluster, pandora::FloatVector &hitE, pandora::FloatVector &hitX, 
-    pandora::FloatVector &hitY, pandora::FloatVector &hitZ, edm4hep::Cluster *const p_Cluster, pandora::CartesianVector &clusterPositionVec) const
+    pandora::FloatVector &hitY, pandora::FloatVector &hitZ, edm4hep::MutableCluster *const p_Cluster, pandora::CartesianVector &clusterPositionVec) const
 {
     ClusterShapes *const pClusterShapes(new ClusterShapes(nHitsInCluster, hitE.data(), hitX.data(), hitY.data(), hitZ.data()));
 
@@ -371,7 +371,7 @@ bool PfoCreator::AreAnyOtherSiblingsInList(const pandora::Track *const pPandoraT
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PfoCreator::SetRecoParticleReferencePoint(const pandora::CartesianVector &referencePoint, edm4hep::ReconstructedParticle *const pReconstructedParticle) const
+void PfoCreator::SetRecoParticleReferencePoint(const pandora::CartesianVector &referencePoint, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const
 {
     const float referencePointArray[3] = {referencePoint.GetX(), referencePoint.GetY(), referencePoint.GetZ()};
     pReconstructedParticle->setReferencePoint(referencePointArray);
@@ -379,7 +379,7 @@ void PfoCreator::SetRecoParticleReferencePoint(const pandora::CartesianVector &r
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PfoCreator::AddTracksToRecoParticle(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::ReconstructedParticle *const pReconstructedParticle) const
+void PfoCreator::AddTracksToRecoParticle(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const
 {
     const pandora::TrackList &trackList(pPandoraPfo->GetTrackList());
 
@@ -395,7 +395,7 @@ void PfoCreator::AddTracksToRecoParticle(const pandora::ParticleFlowObject *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PfoCreator::SetRecoParticlePropertiesFromPFO(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::ReconstructedParticle *const pReconstructedParticle) const
+void PfoCreator::SetRecoParticlePropertiesFromPFO(const pandora::ParticleFlowObject *const pPandoraPfo, edm4hep::MutableReconstructedParticle *const pReconstructedParticle) const
 {
     const float momentum[3] = {pPandoraPfo->GetMomentum().GetX(), pPandoraPfo->GetMomentum().GetY(), pPandoraPfo->GetMomentum().GetZ()};
     pReconstructedParticle->setMomentum(momentum);

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/TrackCreator.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/TrackCreator.cpp
@@ -396,11 +396,11 @@ pandora::StatusCode TrackCreator::ExtractV0s(const CollectionMaps& collectionMap
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackCreator::IsConflictingRelationship(const edm4hep::ConstReconstructedParticle &Particle) const
+bool TrackCreator::IsConflictingRelationship(const edm4hep::ReconstructedParticle &Particle) const
 {
     for (unsigned int iTrack = 0, nTracks = Particle.tracks_size(); iTrack < nTracks; ++iTrack)
     {
-        edm4hep::ConstTrack pTrack = Particle.getTracks(iTrack) ;
+        edm4hep::Track pTrack = Particle.getTracks(iTrack) ;
         unsigned int pTrack_id = pTrack.id() ;
 
         if (this->IsDaughter(pTrack_id) || this->IsParent(pTrack_id) || this->IsV0(pTrack_id))
@@ -410,7 +410,7 @@ bool TrackCreator::IsConflictingRelationship(const edm4hep::ConstReconstructedPa
     return false;
 }
 
-edm4hep::ConstTrack* TrackCreator::GetTrackAddress(const CollectionMaps& collectionMaps, const edm4hep::ConstTrack& pTrack )
+edm4hep::Track* TrackCreator::GetTrackAddress(const CollectionMaps& collectionMaps, const edm4hep::Track& pTrack )
 {
     for (StringVector::const_iterator iter = m_settings.m_trackCollections.begin(), iterEnd = m_settings.m_trackCollections.end(); iter != iterEnd; ++iter)
     {
@@ -521,7 +521,7 @@ pandora::StatusCode TrackCreator::CreateTracks(const CollectionMaps& collectionM
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackCreator::GetTrackStates(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
+void TrackCreator::GetTrackStates(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
 {
     edm4hep::TrackState pTrackState = pTrack->getTrackStates(1); // ref  /cvmfs/cepcsw.ihep.ac.cn/prototype/LCIO/include/EVENT/TrackState.h 
 
@@ -551,7 +551,7 @@ void TrackCreator::GetTrackStates(edm4hep::ConstTrack *const pTrack, PandoraApi:
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float TrackCreator::CalculateTrackTimeAtCalorimeter(edm4hep::ConstTrack *const pTrack) const
+float TrackCreator::CalculateTrackTimeAtCalorimeter(edm4hep::Track *const pTrack) const
 {
     const pandora::Helix helix(pTrack->getTrackStates(0).phi, pTrack->getTrackStates(0).D0, pTrack->getTrackStates(0).Z0, pTrack->getTrackStates(0).omega, pTrack->getTrackStates(0).tanLambda, m_bField);
     const pandora::CartesianVector &referencePoint(helix.GetReferencePoint());
@@ -624,7 +624,7 @@ void TrackCreator::CopyTrackState(const edm4hep::TrackState & pTrackState, pando
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackCreator::TrackReachesECAL(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
+void TrackCreator::TrackReachesECAL(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
 {
     
     // Calculate hit position information
@@ -639,7 +639,7 @@ void TrackCreator::TrackReachesECAL(edm4hep::ConstTrack *const pTrack, PandoraAp
     for (unsigned int i = 0; i < nTrackHits; ++i)
     {
         
-        const edm4hep::ConstTrackerHit Hit ( pTrack->getTrackerHits(i) );
+        const edm4hep::TrackerHit Hit ( pTrack->getTrackerHits(i) );
         const edm4hep::Vector3d pos = Hit.getPosition();
         
         float x = float(pos[0]);
@@ -707,7 +707,7 @@ void TrackCreator::TrackReachesECAL(edm4hep::ConstTrack *const pTrack, PandoraAp
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackCreator::DefineTrackPfoUsage(edm4hep::ConstTrack *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
+void TrackCreator::DefineTrackPfoUsage(edm4hep::Track *const pTrack, PandoraApi::Track::Parameters &trackParameters) const
 {
     bool canFormPfo(false);
     bool canFormClusterlessPfo(false);
@@ -791,7 +791,7 @@ void TrackCreator::DefineTrackPfoUsage(edm4hep::ConstTrack *const pTrack, Pandor
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackCreator::PassesQualityCuts(edm4hep::ConstTrack *const pTrack, const PandoraApi::Track::Parameters &trackParameters) const
+bool TrackCreator::PassesQualityCuts(edm4hep::Track *const pTrack, const PandoraApi::Track::Parameters &trackParameters) const
 {
     // First simple sanity checks
     if (trackParameters.m_trackStateAtCalorimeter.Get().GetPosition().GetMagnitude() < m_settings.m_minTrackECalDistanceFromIp)
@@ -868,14 +868,14 @@ bool TrackCreator::PassesQualityCuts(edm4hep::ConstTrack *const pTrack, const Pa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-int TrackCreator::GetNTpcHits(edm4hep::ConstTrack *const pTrack) const
+int TrackCreator::GetNTpcHits(edm4hep::Track *const pTrack) const
 {
     return pTrack->getSubDetectorHitNumbers(2 * lcio::ILDDetID::TPC - 1);// still use LCIO code now
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-int TrackCreator::GetNFtdHits(edm4hep::ConstTrack *const pTrack) const
+int TrackCreator::GetNFtdHits(edm4hep::Track *const pTrack) const
 {
     return pTrack->getSubDetectorHitNumbers( 2 * lcio::ILDDetID::FTD - 1 );
 }

--- a/Reconstruction/RecGenfitAlg/src/GenfitTrack.h
+++ b/Reconstruction/RecGenfitAlg/src/GenfitTrack.h
@@ -41,10 +41,11 @@ namespace edm4hep{
     class MCParticle;
     class SimTrackerHitCollection;
     class ReconstructedParticle;
+    class MutableReconstructedParticle;
     class MCRecoTrackerAssociationCollection;
     class Track;
-    class ConstTrack;
-    class ConstTrackerHit;
+    class Track;
+    class TrackerHit;
     class Vector3d;
     class Vector3f;
 }
@@ -92,14 +93,14 @@ class GenfitTrack {
     ///Create genfit track from MCParticle
     bool createGenfitTrackFromMCParticle(int pidTyep,const edm4hep::MCParticle&
             mcParticle, double eventStartTime=0.);
-    bool createGenfitTrackFromEDM4HepTrack(int pidType, edm4hep::ConstTrack track,
+    bool createGenfitTrackFromEDM4HepTrack(int pidType, edm4hep::Track track,
             double eventStartTime);
 
     //  /// Prepare a hit list, return number of hits on track
     //  int PrepareHits();//TODO
 
     /// Add a space point measurement, return number of hits on track
-    bool addSpacePointTrakerHit(edm4hep::ConstTrackerHit hit, int hitID);
+    bool addSpacePointTrakerHit(edm4hep::TrackerHit hit, int hitID);
 
     /// Add a space point measurement, return number of hits on track
     virtual bool addSpacePointMeasurement(const TVectorD&, double,
@@ -111,15 +112,15 @@ class GenfitTrack {
             const TVector3& endPoint2, int lrAmbig, int detID, int hitID);
 
     /// Add a WireMeasurement with DC digi
-    virtual bool addWireMeasurementOnTrack(edm4hep::ConstTrack track, double sigma);
+    virtual bool addWireMeasurementOnTrack(edm4hep::Track track, double sigma);
 
     ///Add space point from truth to track
-    int addSimTrackerHits( edm4hep::ConstTrack track,
+    int addSimTrackerHits( edm4hep::Track track,
         const edm4hep::MCRecoTrackerAssociationCollection* assoHits,
         float sigma,bool smear=false);// float nSigmaSelection
 
     ///Store track to ReconstructedParticle
-    bool storeTrack(edm4hep::ReconstructedParticle& dcRecParticle,int pidType,
+    bool storeTrack(edm4hep::MutableReconstructedParticle& dcRecParticle,int pidType,
             int ndfCut=1e9, double chi2Cut=1.e9);
 
     ///A tool to convert track to the first layer of DC

--- a/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
@@ -4,7 +4,7 @@
 #include "DataHelper/Navigation.h"
 
 #include "edm4hep/TrackerHit.h"
-#include "edm4hep/TrackerHitConst.h"
+#include "edm4hep/TrackerHit.h"
 #include "edm4hep/Track.h"
 
 #include "UTIL/ILDConf.h"
@@ -266,7 +266,7 @@ StatusCode ForwardTrackingAlg::execute(){
       if(pixelCollectionID==hitFTDCollections[iCol]->getID()){
 	if ( UTIL::BitSet32( trackerHit.getType() )[ UTIL::ILDTrkHitTypeBit::ONE_DIMENSIONAL ] ) continue;
       }
-      edm4hep::ConstTrackerHit hit = trackerHit;
+      edm4hep::TrackerHit hit = trackerHit;
       debug() << "hit " << trackerHit.id() << " " << KiTrackMarlin::getCellID0Info( trackerHit.getCellID() ) 
 	      << " " << KiTrackMarlin::getPositionInfo( hit )<< endmsg;
          
@@ -637,7 +637,7 @@ StatusCode ForwardTrackingAlg::execute(){
       FTDTrack* myTrack = dynamic_cast< FTDTrack* >( tracks[i] );
          
       if( myTrack != NULL ){
-	edm4hep::Track trackImpl( *(myTrack->getLcioTrack()) );
+	edm4hep::MutableTrack trackImpl( *(myTrack->getLcioTrack()) );
             
 	try{
 	  finaliseTrack( &trackImpl );
@@ -906,7 +906,7 @@ bool ForwardTrackingAlg::setCriteria( unsigned round ){
   return newValuesGotUsed;
 }
 
-void ForwardTrackingAlg::finaliseTrack( edm4hep::Track* trackImpl ){
+void ForwardTrackingAlg::finaliseTrack( edm4hep::MutableTrack* trackImpl ){
      
   Fitter fitter( trackImpl , _trkSystem );
    
@@ -953,7 +953,7 @@ void ForwardTrackingAlg::finaliseTrack( edm4hep::Track* trackImpl ){
   
   unsigned int nHits = trackImpl->trackerHits_size();
   for( unsigned j=0; j<nHits; j++ ){
-    const edm4hep::ConstTrackerHit& hit = trackImpl->getTrackerHits(j);
+    const edm4hep::TrackerHit& hit = trackImpl->getTrackerHits(j);
     UTIL::BitField64 encoder( UTIL::ILDCellID0::encoder_string );
     encoder.setValue( hit.getCellID() );
     int subdet =  encoder[UTIL::ILDCellID0::subdet];

--- a/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.h
+++ b/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.h
@@ -200,7 +200,7 @@ class ForwardTrackingAlg : public GaudiAlgorithm {
    * Sets the subdetector hit numbers and the radius of the innermost hit.
    * Also sets chi2 and Ndf.
    */
-  void finaliseTrack( edm4hep::Track* track );
+  void finaliseTrack( edm4hep::MutableTrack* track );
   
   /* Sets the cut off values for all the criteria
    * 

--- a/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
@@ -438,7 +438,6 @@ int SiliconTrackingAlg::InitialiseFTD() {
     //for (int ielem=0; ielem<nelem; ++ielem) {
     for(auto hit : *hitFTDPixelCol){
       if ( UTIL::BitSet32( hit.getType() )[ UTIL::ILDTrkHitTypeBit::ONE_DIMENSIONAL ] ) continue;
-      //dm4hep::ConstTrackerHit hit = hitFTDPixelCol->at(ielem);
       TrackerHitExtended * hitExt = new TrackerHitExtended( hit );
       //gear::Vector3D U(1.0,hit->getU()[1],hit->getU()[0],gear::Vector3D::spherical);
       //gear::Vector3D V(1.0,hit->getV()[1],hit->getV()[0],gear::Vector3D::spherical);
@@ -549,7 +548,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
     
     //for (int ielem=0; ielem<nelem; ++ielem) {
     for(auto hit : *hitFTDSpacePointCol){
-    //edm4hep::ConstTrackerHit hit =  hitFTDSpacePointCol->at(ielem);
+    //edm4hep::TrackerHit hit =  hitFTDSpacePointCol->at(ielem);
       
       TrackerHitExtended * hitExt = new TrackerHitExtended(hit);
       
@@ -773,7 +772,7 @@ int SiliconTrackingAlg::InitialiseVTX() {
         //    iv)  TrackerHitZCylinder 
         //    v)   Must be standard TrackerHit
         
-	//const edm4hep::ConstTrackerHit trkhit = hitSITCol->at(ielem);
+	//const edm4hep::TrackerHit trkhit = hitSITCol->at(ielem);
         int layer = getLayerID(trkhit);
         
         // VXD and SIT are treated as one system so SIT layers start from _nLayersVTX
@@ -1515,7 +1514,7 @@ int SiliconTrackingAlg::BuildTrack(TrackerHitExtended * outerHit,
       float epar[15];
       
       for (int ih=0;ih<nHits;++ih) {
-	edm4hep::ConstTrackerHit trkHit = hvec[ih]->getTrackerHit();
+	edm4hep::TrackerHit trkHit = hvec[ih]->getTrackerHit();
         xh[ih] = trkHit.getPosition()[0];
         yh[ih] = trkHit.getPosition()[1];
         zh[ih] = float(trkHit.getPosition()[2]);
@@ -1526,7 +1525,7 @@ int SiliconTrackingAlg::BuildTrack(TrackerHitExtended * outerHit,
         if (ph[ih] < 0.) 
           ph[ih] = TWOPI + ph[ih]; 
       }      
-      edm4hep::ConstTrackerHit assignedTrkHit = assignedhit->getTrackerHit();
+      edm4hep::TrackerHit assignedTrkHit = assignedhit->getTrackerHit();
       xh[nHits] = assignedTrkHit.getPosition()[0];
       yh[nHits] = assignedTrkHit.getPosition()[1];
       zh[nHits] = float(assignedTrkHit.getPosition()[2]);
@@ -1669,7 +1668,7 @@ void SiliconTrackingAlg::CreateTrack(TrackExtended * trackAR ) {
       float epar[15];
       float refPoint[3] = {0.,0.,0.};
       for (int ih=0;ih<nHits;++ih) {
-	edm4hep::ConstTrackerHit trkHit = hitVec[ih]->getTrackerHit();
+	edm4hep::TrackerHit trkHit = hitVec[ih]->getTrackerHit();
         float rR = hitVec[ih]->getResolutionRPhi();
         float rZ = hitVec[ih]->getResolutionZ();
         if (int(hitVec[ih]->getTrackExtendedVec().size()) != 0)
@@ -1683,7 +1682,7 @@ void SiliconTrackingAlg::CreateTrack(TrackExtended * trackAR ) {
         ph[ih] = float(atan2(yh[ih],xh[ih]));
       }      
       for (int ih=0;ih<nHitsOld;++ih) {
-	edm4hep::ConstTrackerHit trkHit = hitVecOld[ih]->getTrackerHit();
+	edm4hep::TrackerHit trkHit = hitVecOld[ih]->getTrackerHit();
         xh[ih+nHits] = trkHit.getPosition()[0];
         yh[ih+nHits] = trkHit.getPosition()[1];
         zh[ih+nHits] = float(trkHit.getPosition()[2]);
@@ -1878,7 +1877,7 @@ void SiliconTrackingAlg::AttachRemainingVTXHitsFast() {
           TrackerHitExtended * hitExt = hitVec[iH];
           TrackExtendedVec& trackVec = hitExt->getTrackExtendedVec();
           if (trackVec.size()==0) {
-	    edm4hep::ConstTrackerHit hit = hitExt->getTrackerHit();
+	    edm4hep::TrackerHit hit = hitExt->getTrackerHit();
             double pos[3];
             double radius = 0;
             for (int i=0; i<3; ++i) {
@@ -1942,8 +1941,8 @@ void SiliconTrackingAlg::AttachRemainingVTXHitsFast() {
                 for (int IHIT=0;IHIT<NHITS;++IHIT) {
                   
                   // Here we are trying to find if a hits are too close i.e. closer than _minDistToDelta
-		  edm4hep::ConstTrackerHit trkhit1 = hit->getTrackerHit();
-		  edm4hep::ConstTrackerHit trkhit2 = hitVector[IHIT]->getTrackerHit();                  
+		  edm4hep::TrackerHit trkhit1 = hit->getTrackerHit();
+		  edm4hep::TrackerHit trkhit2 = hitVector[IHIT]->getTrackerHit();                  
                   
                   if ( trkhit1.getCellID() == trkhit2.getCellID() ){ // i.e. they are in the same sensor
                     float distance = 0.;
@@ -2052,8 +2051,8 @@ void SiliconTrackingAlg::AttachRemainingVTXHitsSlow() {
           for (int IHIT=0;IHIT<NHITS;++IHIT) {
             
             // Here we are trying to find if a hits are too close i.e. closer than _minDistToDelta
-	    edm4hep::ConstTrackerHit trkhit1 = hit->getTrackerHit();
-	    edm4hep::ConstTrackerHit trkhit2 = hitVector[IHIT]->getTrackerHit();                  
+	    edm4hep::TrackerHit trkhit1 = hit->getTrackerHit();
+	    edm4hep::TrackerHit trkhit2 = hitVector[IHIT]->getTrackerHit();                  
 	    
             if ( trkhit1.getCellID() == trkhit2.getCellID() ){ // i.e. they are in the same sensor
               
@@ -2404,7 +2403,7 @@ int SiliconTrackingAlg::BuildTrackFTD(TrackExtended * trackAR, int * nLR, int iS
         int nH = int(hitVec.size());
         for (int iH=0; iH<nH; ++iH) {
           TrackerHitExtended * hit = hitVec[iH];
-	  edm4hep::ConstTrackerHit trkHit = hit->getTrackerHit();
+	  edm4hep::TrackerHit trkHit = hit->getTrackerHit();
           float pos[3];
           for (int i=0;i<3;++i)
             pos[i] = float(trkHit.getPosition()[i]);
@@ -2447,7 +2446,7 @@ int SiliconTrackingAlg::AttachHitToTrack(TrackExtended * trackAR, TrackerHitExte
   float epar[15];
   
   for (int i=0; i<nHits; ++i) {
-    edm4hep::ConstTrackerHit trkHit = hitVec[i]->getTrackerHit();
+    edm4hep::TrackerHit trkHit = hitVec[i]->getTrackerHit();
     xh[i] = double(trkHit.getPosition()[0]);
     yh[i] = double(trkHit.getPosition()[1]);
     zh[i] = float(trkHit.getPosition()[2]);
@@ -2459,7 +2458,7 @@ int SiliconTrackingAlg::AttachHitToTrack(TrackExtended * trackAR, TrackerHitExte
     wzh[i] = 1.0/(rZ*rZ);
   }
   
-  edm4hep::ConstTrackerHit trkHit = hit->getTrackerHit();
+  edm4hep::TrackerHit trkHit = hit->getTrackerHit();
   xh[nHits] = double(trkHit.getPosition()[0]);
   yh[nHits] = double(trkHit.getPosition()[1]);
   zh[nHits] = float(trkHit.getPosition()[2]);
@@ -2589,7 +2588,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
         lh[ihit] = 1; // only hits which have lh=1 will be used for the fit
         
         // get the pointer to the lcio trackerhit for this hit
-	edm4hep::ConstTrackerHit trkHit = hitVec[ihit]->getTrackerHit();
+	edm4hep::TrackerHit trkHit = hitVec[ihit]->getTrackerHit();
         
         int det = getDetectorID(trkHit);
         
@@ -2603,7 +2602,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
           for (int lhit=0;lhit<ihit;++lhit) {
             
             // get the pointer to the lcio trackerhit for the previously checked hit
-	    edm4hep::ConstTrackerHit trkHitS = hitVec[lhit]->getTrackerHit();
+	    edm4hep::TrackerHit trkHitS = hitVec[lhit]->getTrackerHit();
             
             
             //          int layerS = getLayerID(trkHitS);
@@ -2665,14 +2664,14 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       
       delete helix;
       
-      std::vector<ConstTrackerHit> trkHits;
-      std::vector<ConstTrackerHit> trkHits_used_inFit;
+      std::vector<TrackerHit> trkHits;
+      std::vector<TrackerHit> trkHits_used_inFit;
       
       int nFit = 0;
       for (int i=0; i<nHits; ++i) {
         // check if the hit has been rejected as being on the same layer and further from the helix lh==0
         if (lh[i] == 1) {
-	  edm4hep::ConstTrackerHit trkHit = hitVec[i]->getTrackerHit();
+	  edm4hep::TrackerHit trkHit = hitVec[i]->getTrackerHit();
 	  debug() << "TrackerHit " << i << " id = " << trkHit.id() << endmsg;
           nFit++;
           if(trkHit.isAvailable()) { 
@@ -2695,7 +2694,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       //TrackImpl* Track = new TrackImpl ;
       //auto track = trk_col->create();
       //fucd
-      edm4hep::Track track;// = new edm4hep::Track;
+      edm4hep::MutableTrack track;// = new edm4hep::Track;
       // setup initial dummy covariance matrix
       //std::vector<float> covMatrix;
       //covMatrix.resize(15);
@@ -2712,11 +2711,11 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       covMatrix[14] = ( _initialTrackError_tanL  ); //sigma_tanl^2
       
       
-      std::vector< std::pair<float, edm4hep::ConstTrackerHit> > r2_values;
+      std::vector< std::pair<float, edm4hep::TrackerHit> > r2_values;
       r2_values.reserve(trkHits.size());
       
-      for (std::vector<edm4hep::ConstTrackerHit>::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
-        edm4hep::ConstTrackerHit h = *it;
+      for (std::vector<edm4hep::TrackerHit>::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
+        edm4hep::TrackerHit h = *it;
         float r2 = h.getPosition()[0]*h.getPosition()[0]+h.getPosition()[1]*h.getPosition()[1];
         r2_values.push_back(std::make_pair(r2, *it));
       }
@@ -2726,7 +2725,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       trkHits.clear();
       trkHits.reserve(r2_values.size());
 
-      for (std::vector< std::pair<float, edm4hep::ConstTrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
+      for (std::vector< std::pair<float, edm4hep::TrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
         trkHits.push_back(it->second);
       }
       //std::cout << "fucd------------------3 " << _trksystem << std::endl;
@@ -2785,16 +2784,16 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
 #endif
       */
       
-      std::vector<std::pair<edm4hep::ConstTrackerHit , double> > hits_in_fit ;  
-      std::vector<std::pair<edm4hep::ConstTrackerHit , double> > outliers ;
-      std::vector<edm4hep::ConstTrackerHit> all_hits;    
+      std::vector<std::pair<edm4hep::TrackerHit , double> > hits_in_fit ;  
+      std::vector<std::pair<edm4hep::TrackerHit , double> > outliers ;
+      std::vector<edm4hep::TrackerHit> all_hits;    
       all_hits.reserve(300);
       
       marlinTrk->getHitsInFit(hits_in_fit);
       
       for ( unsigned ihit = 0; ihit < hits_in_fit.size(); ++ihit) {
 	debug() << "Hit id =" << hits_in_fit[ihit].first.id() << endmsg;
-	edm4hep::ConstTrackerHit trk = hits_in_fit[ihit].first;
+	edm4hep::TrackerHit trk = hits_in_fit[ihit].first;
         all_hits.push_back(trk);//hits_in_fit[ihit].first);
       }
       

--- a/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.h
+++ b/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.h
@@ -402,11 +402,11 @@ class SiliconTrackingAlg : public GaudiAlgorithm {
   //  int _createMap;
   
   UTIL::BitField64* _encoder;
-  int getDetectorID(edm4hep::ConstTrackerHit hit) { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::subdet]; }
-  int getSideID(edm4hep::ConstTrackerHit hit)     { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::side]; };
-  int getLayerID(edm4hep::ConstTrackerHit hit)    { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::layer]; };
-  int getModuleID(edm4hep::ConstTrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::module]; };
-  int getSensorID(edm4hep::ConstTrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::sensor]; };
+  int getDetectorID(edm4hep::TrackerHit hit) { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::subdet]; }
+  int getSideID(edm4hep::TrackerHit hit)     { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::side]; };
+  int getLayerID(edm4hep::TrackerHit hit)    { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::layer]; };
+  int getModuleID(edm4hep::TrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::module]; };
+  int getSensorID(edm4hep::TrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::sensor]; };
   
   StatusCode setupGearGeom() ;
   

--- a/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.cpp
@@ -148,8 +148,8 @@ StatusCode SpacePointBuilderAlg::execute(){
 	  for( unsigned j=0; j<hitsBack.size(); j++ ){
 	    auto hitBack = hitsBack[j];
 
-	    std::vector<edm4hep::ConstSimTrackerHit> simHitsFront;
-	    std::vector<edm4hep::ConstSimTrackerHit> simHitsBack;
+	    std::vector<edm4hep::SimTrackerHit> simHitsFront;
+	    std::vector<edm4hep::SimTrackerHit> simHitsBack;
 	    for(auto hitAss : *hitAssCol){
 	      if(hitAss.getRec().id()==hitFront.id()) simHitsFront.push_back(hitAss.getSim());
 	      if(hitAss.getRec().id()==hitBack.id()) simHitsBack.push_back(hitAss.getSim());
@@ -157,13 +157,13 @@ StatusCode SpacePointBuilderAlg::execute(){
 	    debug() << "attempt to create space point from:" << endmsg;
             debug() << "   front hit: " << hitFront.id() << " no. of simhit = " << simHitsFront.size() ;
             if( simHitsFront.size()!=0 ) { 
-	      edm4hep::ConstSimTrackerHit& simhit = simHitsFront[0];
+	      edm4hep::SimTrackerHit& simhit = simHitsFront[0];
               debug() << "   first simhit = " << simhit.id() << " mcp = " << simhit.getMCParticle().id() << " (" << simhit.getPosition() << ") " ; 
             }
             debug() << endmsg;
             debug() << "  rear hit: " << hitBack.id() << " no. of simhit = " << simHitsBack.size() ;
             if( simHitsBack.size()!=0 ) { 
-	      edm4hep::ConstSimTrackerHit& simhit = simHitsBack[0];
+	      edm4hep::SimTrackerHit& simhit = simHitsBack[0];
               debug() << "   first simhit = " << simhit.id() << " mcp = "<< simhit.getMCParticle().id() << " (" << simhit.getPosition() << ") " ; 
             }
 	    debug() << endmsg;
@@ -198,7 +198,7 @@ StatusCode SpacePointBuilderAlg::execute(){
             // add tolerence 
             strip_length_mm = strip_length_mm * (1.0 + _striplength_tolerance);
 	    try{
-	      edm4hep::TrackerHit spacePoint = createSpacePoint( hitFront, hitBack, strip_length_mm);
+	      edm4hep::MutableTrackerHit spacePoint = createSpacePoint( hitFront, hitBack, strip_length_mm);
 
 	      //UTIL::CellIDEncoder<TrackerHitImpl> cellid_encoder( UTIL::ILDCellID0::encoder_string , spCol );
               //cellid_encoder.setValue( cellID0 ); //give the new hit, the CellID0 of the front hit
@@ -219,15 +219,15 @@ StatusCode SpacePointBuilderAlg::execute(){
               ///////////////////////////////
               // make the relations
               if( simHitsFront.size() == 1 ){
-		edm4hep::ConstSimTrackerHit& simHit = simHitsFront[0];
-		edm4hep::MCRecoTrackerAssociation spAss = relCol->create();
+		edm4hep::SimTrackerHit& simHit = simHitsFront[0];
+		auto spAss = relCol->create();
 		spAss.setRec(spacePoint);
 		spAss.setSim(simHit);
 		spAss.setWeight( 0.5 );
               }
               if( simHitsBack.size() == 1 ){
-		edm4hep::ConstSimTrackerHit& simHit = simHitsBack[0];
-		edm4hep::MCRecoTrackerAssociation spAss = relCol->create();
+		edm4hep::SimTrackerHit& simHit = simHitsBack[0];
+		auto spAss = relCol->create();
                 spAss.setRec(spacePoint);
 		spAss.setSim(simHit);
                 spAss.setWeight( 0.5 );
@@ -268,7 +268,7 @@ StatusCode SpacePointBuilderAlg::finalize(){
   return GaudiAlgorithm::finalize();
 }
 
-edm4hep::TrackerHit SpacePointBuilderAlg::createSpacePoint( edm4hep::ConstTrackerHit a , edm4hep::ConstTrackerHit b, double stripLength ){
+edm4hep::MutableTrackerHit SpacePointBuilderAlg::createSpacePoint( edm4hep::TrackerHit a , edm4hep::TrackerHit b, double stripLength ){
   
   const edm4hep::Vector3d& pa = a.getPosition();
   double xa = pa[0];
@@ -406,7 +406,7 @@ edm4hep::TrackerHit SpacePointBuilderAlg::createSpacePoint( edm4hep::ConstTracke
   }
   
   //Create the new TrackerHit
-  edm4hep::TrackerHit spacePoint;// = new edm4hep::TrackerHit();
+  edm4hep::MutableTrackerHit spacePoint;// = new edm4hep::TrackerHit();
   
   edm4hep::Vector3d pos(point.x(), point.y(), point.z());
   spacePoint.setPosition(pos) ;

--- a/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.h
+++ b/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.h
@@ -144,7 +144,7 @@ class SpacePointBuilderAlg : public GaudiAlgorithm {
   
   
   /** @return a spacepoint (in the form of a TrackerHitImpl* ) created from two TrackerHitPlane* which stand for si-strips */
-  edm4hep::TrackerHit createSpacePoint( edm4hep::ConstTrackerHit a , edm4hep::ConstTrackerHit b, double stripLength );
+  edm4hep::MutableTrackerHit createSpacePoint( edm4hep::TrackerHit a , edm4hep::TrackerHit b, double stripLength );
   
 //   TrackerHitImpl* createSpacePointOld( TrackerHitPlane* a , TrackerHitPlane* b );
   

--- a/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
@@ -96,7 +96,7 @@ StatusCode TrackSubsetAlg::finalize(){
 }
 
 StatusCode TrackSubsetAlg::execute(){ 
-  std::vector<edm4hep::ConstTrack> tracks;
+  std::vector<edm4hep::Track> tracks;
 
   auto trkCol = _outColHdl.createAndPut();
   /**********************************************************************************************/
@@ -151,13 +151,13 @@ StatusCode TrackSubsetAlg::execute(){
   
   debug() << "The tracks and their qualities (and their hits ): " << endmsg;
 
-  std::vector<edm4hep::ConstTrack*> tracks_p;
+  std::vector<edm4hep::Track*> tracks_p;
   for( unsigned i=0; i < tracks.size(); i++ ){
     auto* track = &tracks[i];
     tracks_p.push_back(track);
     double qi = trackQI( track );
     debug() << "Track " << track->id() << " address " << track << "\t" << qi << "( ";
-    std::vector<edm4hep::ConstTrackerHit> hits;
+    std::vector<edm4hep::TrackerHit> hits;
     std::copy(track->trackerHits_begin(), track->trackerHits_end(), std::back_inserter(hits));
     
     std::sort( hits.begin(), hits.end(), KiTrackMarlin::compare_TrackerHit_z );
@@ -174,7 +174,7 @@ StatusCode TrackSubsetAlg::execute(){
   
   TrackCompatibility comp;
   
-  SubsetHopfieldNN<edm4hep::ConstTrack*> subset;
+  SubsetHopfieldNN<edm4hep::Track*> subset;
   //SubsetSimple<edm4hep::Track* > subset;
   subset.add( tracks_p );
   subset.setOmega( _omega );
@@ -201,12 +201,12 @@ StatusCode TrackSubsetAlg::execute(){
   //auto trkCol = _outColHdl.createAndPut();
 
   for( unsigned i=0; i < accepted.size(); i++ ){
-    edm4hep::Track trackImpl;
+    edm4hep::MutableTrack trackImpl;
     
     auto track = accepted[i];
     
-    std::vector<edm4hep::ConstTrackerHit> trackerHitsObj;
-    std::vector<edm4hep::ConstTrackerHit> trackerHits;
+    std::vector<edm4hep::TrackerHit> trackerHitsObj;
+    std::vector<edm4hep::TrackerHit> trackerHits;
     std::copy(track->trackerHits_begin(), track->trackerHits_end(), std::back_inserter(trackerHitsObj));
 
     for(unsigned i=0; i<trackerHitsObj.size(); i++){
@@ -225,11 +225,11 @@ StatusCode TrackSubsetAlg::execute(){
     covMatrix[9]  = ( _initialTrackError_z0    ); //sigma_z0^2
     covMatrix[14] = ( _initialTrackError_tanL  ); //sigma_tanl^2
     
-    std::vector< std::pair<float, edm4hep::ConstTrackerHit> > r2_values;
+    std::vector< std::pair<float, edm4hep::TrackerHit> > r2_values;
     r2_values.reserve(trackerHits.size());
     
-    for (std::vector<edm4hep::ConstTrackerHit>::iterator it=trackerHits.begin(); it!=trackerHits.end(); ++it) {
-      edm4hep::ConstTrackerHit h = *it;
+    for (std::vector<edm4hep::TrackerHit>::iterator it=trackerHits.begin(); it!=trackerHits.end(); ++it) {
+      edm4hep::TrackerHit h = *it;
       float r2 = h.getPosition()[0]*h.getPosition()[0]+h.getPosition()[1]*h.getPosition()[1];
       r2_values.push_back(std::make_pair(r2, *it));
     }
@@ -239,7 +239,7 @@ StatusCode TrackSubsetAlg::execute(){
     trackerHits.clear();
     trackerHits.reserve(r2_values.size());
     
-    for (std::vector< std::pair<float, edm4hep::ConstTrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
+    for (std::vector< std::pair<float, edm4hep::TrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
       trackerHits.push_back(it->second);
     }
 
@@ -264,9 +264,9 @@ StatusCode TrackSubsetAlg::execute(){
     
     // Add hit numbers 
     
-    std::vector<std::pair<edm4hep::ConstTrackerHit , double> > hits_in_fit ;
-    std::vector<std::pair<edm4hep::ConstTrackerHit , double> > outliers ;
-    std::vector<edm4hep::ConstTrackerHit> all_hits;
+    std::vector<std::pair<edm4hep::TrackerHit , double> > hits_in_fit ;
+    std::vector<std::pair<edm4hep::TrackerHit , double> > outliers ;
+    std::vector<edm4hep::TrackerHit> all_hits;
     all_hits.reserve(300);
     
     marlinTrk->getHitsInFit(hits_in_fit);

--- a/Reconstruction/SiliconTracking/src/TrackSubsetAlg.h
+++ b/Reconstruction/SiliconTracking/src/TrackSubsetAlg.h
@@ -84,7 +84,7 @@ class TrackSubsetAlg : public GaudiAlgorithm {
 /** A functor to return whether two tracks are compatible: The criterion is if the share a TrackerHit or more */
 class TrackCompatibility{
  public:
-  inline bool operator()( edm4hep::ConstTrack* trackA, edm4hep::ConstTrack* trackB ){
+  inline bool operator()( edm4hep::Track* trackA, edm4hep::Track* trackB ){
     unsigned nHitsA = trackA->trackerHits_size();
     unsigned nHitsB = trackB->trackerHits_size();
     for( unsigned i=0; i < nHitsA; i++){
@@ -104,7 +104,7 @@ class TrackQI{
   /** @param trkSystem a pointer to an IMarlinTrkSystem, needed for fitting of tracks */
   TrackQI( MarlinTrk::IMarlinTrkSystem* trkSystem ): _trkSystem(trkSystem){}
   
-  inline double operator()( edm4hep::ConstTrack* track ){
+  inline double operator()( edm4hep::Track* track ){
     return ROOT::Math::chisquared_cdf_c( track->getChi2() , track->getNdf() );   
   }
   

--- a/Reconstruction/Tracking/include/Tracking/TrackingHelper.h
+++ b/Reconstruction/Tracking/include/Tracking/TrackingHelper.h
@@ -9,7 +9,7 @@
 #include "lcio.h"
 #include <array>
 
-inline bool hasTrackStateAt(edm4hep::ConstTrack track, int location) {
+inline bool hasTrackStateAt(edm4hep::Track track, int location) {
     for (auto it = track.trackStates_begin(); it != track.trackStates_end(); it++) {
         if (it->location == location) {
             return true;
@@ -18,7 +18,7 @@ inline bool hasTrackStateAt(edm4hep::ConstTrack track, int location) {
     return false;
 }
 
-inline edm4hep::TrackState getTrackStateAt(edm4hep::ConstTrack track, int location) {
+inline edm4hep::TrackState getTrackStateAt(edm4hep::Track track, int location) {
     for (auto it = track.trackStates_begin(); it != track.trackStates_end(); it++) {
         if (it->location == location) {
 	  return *it;
@@ -27,28 +27,28 @@ inline edm4hep::TrackState getTrackStateAt(edm4hep::ConstTrack track, int locati
     return edm4hep::TrackState();
 }
 
-inline std::array<float,15> getCovMatrix(const edm4hep::ConstTrack &track) {
+inline std::array<float,15> getCovMatrix(const edm4hep::Track &track) {
   if(track.trackStates_size()>0) return track.getTrackStates(0).covMatrix;
   std::array<float,15> dummy{};
   return dummy;
 }
-inline float getTanLambda(const edm4hep::ConstTrack &track) {
+inline float getTanLambda(const edm4hep::Track &track) {
   if(track.trackStates_size()>0) return track.getTrackStates(0).tanLambda;
   return 0;
 }
-inline float getOmega(const edm4hep::ConstTrack &track) {
+inline float getOmega(const edm4hep::Track &track) {
   if(track.trackStates_size()>0) return track.getTrackStates(0).omega;
   return 0;
 }
-inline float getD0(const edm4hep::ConstTrack &track) {
+inline float getD0(const edm4hep::Track &track) {
   if(track.trackStates_size()>0) return track.getTrackStates(0).D0;
   return 0;
 }
-inline float getZ0(const edm4hep::ConstTrack &track) {
+inline float getZ0(const edm4hep::Track &track) {
   if(track.trackStates_size()>0) return track.getTrackStates(0).Z0;
   return 0;
 }
-inline float getPhi(const edm4hep::ConstTrack &track) {
+inline float getPhi(const edm4hep::Track &track) {
   if(track.trackStates_size()>0) return track.getTrackStates(0).phi;
   return 0;
 }
@@ -62,12 +62,5 @@ inline int getLayer(const edm4hep::TrackerHit hit) {
     return layer;
 }
 
-inline int getLayer(const edm4hep::ConstTrackerHit hit) {
-    UTIL::BitField64* _encoder = new UTIL::BitField64(lcio::ILDCellID0::encoder_string);
-    _encoder->setValue(hit.getCellID());
-    int layer = (*_encoder)[lcio::ILDCellID0::layer];
-    delete _encoder;
-    return layer;
-}
 
 #endif

--- a/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.h
+++ b/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.h
@@ -8,7 +8,7 @@
 
 #include "GaudiAlg/GaudiAlgorithm.h"
 #include "edm4hep/Track.h"
-#include "edm4hep/TrackerHitConst.h"
+#include "edm4hep/TrackerHit.h"
 #include "edm4hep/TrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include <string>
@@ -104,7 +104,7 @@ class ClupatraAlg : public GaudiAlgorithm {
 
   /** helper method to compute a few track segment parameters (start and end points, z spread,...)
    */
-  void computeTrackInfo(edm4hep::ConstTrack lTrk) ;
+  void computeTrackInfo(edm4hep::Track lTrk) ;
 
 
   StatusCode pickUpSiTrackerHits(edm4hep::TrackCollection* trackCol) ;

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
@@ -38,9 +38,9 @@ namespace clupatra_new{
 		return (  std::abs( TrackInfo_of_edm4hepTrack(l)->zAvg )   <   std::abs( TrackInfo_of_edm4hepTrack(r)->zAvg )  ) ;
 	}
 
-	void ComputeTrackerInfo::operator()( edm4hep::Track o )
+	void ComputeTrackerInfo::operator()( edm4hep::MutableTrack o )
 	{
-		edm4hep::Track lTrk  = o ;
+		edm4hep::MutableTrack lTrk  = o ;
 
 		// compute z-extend of this track segment
 		// const edm4hep::TrackerHitVec& hv = lTrk->getTrackerHits() ;
@@ -287,7 +287,7 @@ namespace clupatra_new{
 		UTIL::BitField64 encoder( UTIL::ILDCellID0::encoder_string ) ;
 		encoder[UTIL::ILDCellID0::subdet] = UTIL::ILDDetID::TPC ;
 
-		edm4hep::ConstTrackerHit firstHit; // =  0 ;
+		edm4hep::TrackerHit firstHit; // =  0 ;
                 //firstHit.unlink();
 
 		IMarlinTrack* bwTrk = 0 ;
@@ -430,7 +430,7 @@ namespace clupatra_new{
 
 						double deltaChi = 0. ;
 
-						edm4hep::ConstTrackerHit ht = bestHit->first->edm4hepHit;
+						edm4hep::TrackerHit ht = bestHit->first->edm4hepHit;
 						int addHit =  theTrk->addAndFit(ht , deltaChi, dChi2Max )  ;
 
 
@@ -557,7 +557,7 @@ namespace clupatra_new{
 				if( ch2Min  < chi2Cut ) {
 
 					double deltaChi = 0. ;
-					edm4hep::ConstTrackerHit bh = bestHit->first->edm4hepHit;
+					edm4hep::TrackerHit bh = bestHit->first->edm4hepHit;
 					int addHit = trk->addAndFit( bh, deltaChi, dChi2Max ) ;
 
 
@@ -1242,7 +1242,7 @@ start:
 		if( reverse_order ){
 		  //std::cout << "It is true order" << std::endl;
 		  for( CluTrack::reverse_iterator it=clu->rbegin() ; it != clu->rend() ; ++it){
-		    edm4hep::ConstTrackerHit ph = (*it)->first->edm4hepHit;
+		    edm4hep::TrackerHit ph = (*it)->first->edm4hepHit;
 		    trk->addHit(ph) ;
 		    ++nHit ;
 		    //std::cout  <<  "   hit  added  " <<  (*it)->first->edm4hepHit   << std::endl ;
@@ -1253,7 +1253,7 @@ start:
 		} else {
 		  //std::cout << "It is reverse order" << std::endl;
 		  for( CluTrack::iterator it=clu->begin() ; it != clu->end() ; ++it){
-		    edm4hep::ConstTrackerHit ph = (*it)->first->edm4hepHit;
+		    edm4hep::TrackerHit ph = (*it)->first->edm4hepHit;
 		    trk->addHit(ph) ;
 		    ++nHit ;
 		    //std::cout <<  "   hit  added  "<<  (*it)->first->edm4hepHit   << std::endl ;
@@ -1274,7 +1274,7 @@ start:
 		}
 
 
-                std::vector<std::pair<edm4hep::ConstTrackerHit, double> > hitsInFit ;
+                std::vector<std::pair<edm4hep::TrackerHit, double> > hitsInFit ;
                 trk->getHitsInFit( hitsInFit ) ;
 		//----- if the fit did not fail but has a small number of hits used,
 		//      we try again one more time with a larger max-chi2-increment
@@ -1299,11 +1299,11 @@ start:
 
 	//---------------------------------------------------------------------------------------------------------------------------
 
-	edm4hep::Track PLCIOTrackConverter::operator() (CluTrack* c) {
+	edm4hep::MutableTrack PLCIOTrackConverter::operator() (CluTrack* c) {
 	  
 		static lcio::BitField64 encoder( lcio::ILDCellID0::encoder_string ) ;
 
-		edm4hep::Track trk;
+		edm4hep::MutableTrack trk;
 
 		trk.setType( lcio::ILDDetID::TPC ) ;
 
@@ -1333,12 +1333,12 @@ start:
 		   trk->subdetectorHitNumbers()[ 2*lcio::ILDDetID::TPC - 1 ] =  nHit ;
 		   */
 
-		RuntimeMap<edm4hep::ConstTrackerHit, int> DChi2_of_hit;
+		RuntimeMap<edm4hep::TrackerHit, int> DChi2_of_hit;
 
 		if( mtrk != 0 && ! c->empty() ){
 
 
-			std::vector<std::pair<edm4hep::ConstTrackerHit, double> > hitsInFit ;
+			std::vector<std::pair<edm4hep::TrackerHit, double> > hitsInFit ;
 			mtrk->getHitsInFit( hitsInFit ) ;
                         // for (auto hit : hitsInFit) std::cout << hit.second << std::endl;
 			// FIXME Mingrui
@@ -1382,8 +1382,8 @@ start:
 				// lcio::TrackerHit* fHit =  ( reverse_order ?  hb->first->lcioHit  :  hf->first->lcioHit ) ;
 				// lcio::TrackerHit* lHit =  ( reverse_order ?  hf->first->lcioHit  :  hb->first->lcioHit ) ;
 
-				edm4hep::ConstTrackerHit fHit = (hitsInFit.back().first);
-				edm4hep::ConstTrackerHit lHit = (hitsInFit.front().first);
+				edm4hep::TrackerHit fHit = (hitsInFit.back().first);
+				edm4hep::TrackerHit lHit = (hitsInFit.front().first);
 
 				//order of hits in fit is reversed wrt time  (we fit inwards)
 
@@ -1404,7 +1404,7 @@ start:
 #if use_fit_at_last_hit
 				code = mtrk->getTrackState( lHit, tsLH, chi2, ndf ) ;
 #else     // get the track state at the last hit by propagating from the last(first) constrained fit position (a la MarlinTrkUtils)
-				edm4hep::ConstTrackerHit last_constrained_hit(0);
+				edm4hep::TrackerHit last_constrained_hit(0);
 				code = mtrk->getTrackerHitAtPositiveNDF( last_constrained_hit );
 				//code = mtrk->smooth() ;
 				if( code != MarlinTrk::IMarlinTrack::success ){

--- a/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp
+++ b/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp
@@ -5,9 +5,8 @@
 
 #include <GearSvc/IGearSvc.h>
 
-#include <edm4hep/TrackerHitConst.h>
 #include <edm4hep/TrackerHit.h>
-#include <edm4hep/TrackConst.h>
+#include <edm4hep/TrackerHit.h>
 #include <edm4hep/Track.h>
 
 #include <iostream>
@@ -54,13 +53,13 @@
 #include <vector>
 #include <bitset>
 
-typedef std::vector<edm4hep::ConstTrackerHit> ConstTrackerHitVec;
+typedef std::vector<edm4hep::TrackerHit> TrackerHitVec;
 
 using namespace edm4hep ;
 using namespace MarlinTrk ;
 
 /** debug printout helper method */
-std::string toString( int iTrk, edm4hep::ConstTrack tpcTrack, float bField=3.5 ) {
+std::string toString( int iTrk, edm4hep::Track tpcTrack, float bField=3.5 ) {
   
   int   nHits    = int( tpcTrack.trackerHits_size() );
   float d0TPC    = getD0(tpcTrack);
@@ -254,7 +253,7 @@ void FullLDCTrackingAlg::AddTrackColToEvt(TrackExtendedVec & trkVec, edm4hep::Tr
     TrackExtended * trkCand = trkVec[iTRK];
     TrackerHitExtendedVec& hitVec = trkCand->getTrackerHitExtendedVec();
     
-    std::vector<edm4hep::ConstTrackerHit> trkHits;
+    std::vector<edm4hep::TrackerHit> trkHits;
     
     //debug() << " Trying to add track " << trkCand << "(" << iTRK << ")" << " to final lcio collection " << endmsg;
         
@@ -269,7 +268,7 @@ void FullLDCTrackingAlg::AddTrackColToEvt(TrackExtendedVec & trkVec, edm4hep::Tr
         continue;
       }
 
-      edm4hep::ConstTrackerHit trkHit = hitVec[ihit]->getTrackerHit();
+      edm4hep::TrackerHit trkHit = hitVec[ihit]->getTrackerHit();
       
       if(trkHit.isAvailable()) {
         trkHits.push_back(trkHit);
@@ -286,7 +285,7 @@ void FullLDCTrackingAlg::AddTrackColToEvt(TrackExtendedVec & trkVec, edm4hep::Tr
       continue ;
     }
     
-    edm4hep::Track track;// = new edm4hep::Track;
+    edm4hep::MutableTrack track;// = new edm4hep::Track;
     
     // setup initial dummy covariance matrix
     std::array<float,15> covMatrix;
@@ -354,11 +353,11 @@ void FullLDCTrackingAlg::AddTrackColToEvt(TrackExtendedVec & trkVec, edm4hep::Tr
     ts_initial.covMatrix = covMatrix;
         
     // sort hits in R
-    std::vector< std::pair<float, edm4hep::ConstTrackerHit> > r2_values;
+    std::vector< std::pair<float, edm4hep::TrackerHit> > r2_values;
     r2_values.reserve(trkHits.size());
     
-    for (std::vector<edm4hep::ConstTrackerHit>::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
-      edm4hep::ConstTrackerHit h = *it;
+    for (std::vector<edm4hep::TrackerHit>::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
+      edm4hep::TrackerHit h = *it;
       float r2 = h.getPosition()[0]*h.getPosition()[0]+h.getPosition()[1]*h.getPosition()[1];
       r2_values.push_back(std::make_pair(r2, *it));
     }
@@ -368,7 +367,7 @@ void FullLDCTrackingAlg::AddTrackColToEvt(TrackExtendedVec & trkVec, edm4hep::Tr
     trkHits.clear();
     trkHits.reserve(r2_values.size());
     
-    for (std::vector< std::pair<float, edm4hep::ConstTrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
+    for (std::vector< std::pair<float, edm4hep::TrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
       trkHits.push_back(it->second);
     }
 
@@ -408,9 +407,9 @@ void FullLDCTrackingAlg::AddTrackColToEvt(TrackExtendedVec & trkVec, edm4hep::Tr
 #endif
     
     
-    std::vector<std::pair<edm4hep::ConstTrackerHit , double> > hits_in_fit ;
-    std::vector<std::pair<edm4hep::ConstTrackerHit , double> > outliers ;
-    std::vector<edm4hep::ConstTrackerHit> all_hits;
+    std::vector<std::pair<edm4hep::TrackerHit , double> > hits_in_fit ;
+    std::vector<std::pair<edm4hep::TrackerHit , double> > outliers ;
+    std::vector<edm4hep::TrackerHit> all_hits;
     all_hits.reserve(hits_in_fit.size());
     
     marlinTrk->getHitsInFit(hits_in_fit);
@@ -471,7 +470,7 @@ void FullLDCTrackingAlg::AddTrackColToEvt(TrackExtendedVec & trkVec, edm4hep::Tr
 	    track.addToTracks(subTrack->getTrack().getTracks(iSeg));
 	  }
           //const TrackVec segments = subTrack->getTrack().getTracks();
-	  //std::vector<edm4hep::ConstTrack> segments;
+	  //std::vector<edm4hep::Track> segments;
 	  //std::copy(subTrack->getTrack().tracks_begin(), subTrack->getTrack().tracks_end(), std::back_inserter(segments));
           //if ( segments.empty() == false ) {
             
@@ -581,7 +580,7 @@ void FullLDCTrackingAlg::prepareVectors() {
   _trkImplVec.clear();
   _candidateCombinedTracks.clear();
   
-  std::map <edm4hep::ConstTrackerHit,TrackerHitExtended*> mapTrackerHits;
+  std::map <edm4hep::TrackerHit,TrackerHitExtended*> mapTrackerHits;
 
   // Reading TPC hits
   const edm4hep::TrackerHitCollection* hitTPCCol = nullptr;
@@ -594,7 +593,7 @@ void FullLDCTrackingAlg::prepareVectors() {
   if(hitTPCCol){
     int nelem = hitTPCCol->size();
     debug() << "Number of TPC hits = " << nelem << endmsg;
-    for (edm4hep::ConstTrackerHit hit : *hitTPCCol) {
+    for (edm4hep::TrackerHit hit : *hitTPCCol) {
       TrackerHitExtended * hitExt = new TrackerHitExtended(hit);
       //info() << "TPC hit " << hit.id() << " " << hitExt << endmsg;
       // Covariance Matrix in LCIO is defined in XYZ convert to R-Phi-Z
@@ -639,7 +638,7 @@ void FullLDCTrackingAlg::prepareVectors() {
   if(hitFTDPixelCol){
     int nelem = hitFTDPixelCol->size();
     debug() << "Number of FTD Pixel Hits = " << nelem << endmsg;
-    for(edm4hep::ConstTrackerHit hit : *hitFTDPixelCol){
+    for(edm4hep::TrackerHit hit : *hitFTDPixelCol){
       if ( UTIL::BitSet32( hit.getType() )[ UTIL::ILDTrkHitTypeBit::ONE_DIMENSIONAL ] ) continue;
 
       TrackerHitExtended * hitExt = new TrackerHitExtended( hit );
@@ -716,7 +715,7 @@ void FullLDCTrackingAlg::prepareVectors() {
     Navigation::Instance()->AddTrackerHitCollection(rawFTDCol);
     int nelem = hitFTDSpacePointCol->size();
     debug() << "Number of FTD SpacePoints = " << nelem << endmsg;
-    for(edm4hep::ConstTrackerHit hit : *hitFTDSpacePointCol){
+    for(edm4hep::TrackerHit hit : *hitFTDSpacePointCol){
       TrackerHitExtended * hitExt = new TrackerHitExtended( hit );
       
       // SJA:FIXME: fudge for now by a factor of two and ignore covariance
@@ -797,7 +796,7 @@ void FullLDCTrackingAlg::prepareVectors() {
     double drphi(NAN);
     double dz(NAN);
     
-    for(edm4hep::ConstTrackerHit trkhit : *hitSITCol){
+    for(edm4hep::TrackerHit trkhit : *hitSITCol){
       
       // hit could be of the following type
       // 1) TrackerHit, either ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT or just standard TrackerHit
@@ -931,7 +930,7 @@ void FullLDCTrackingAlg::prepareVectors() {
     double drphi(NAN);
     double dz(NAN);
 
-    for(edm4hep::ConstTrackerHit trkhit : *hitSETCol){
+    for(edm4hep::TrackerHit trkhit : *hitSETCol){
       // hit could be of the following type
       // 1) TrackerHit, either ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT or just standard TrackerHit
       // 2) TrackerHitPlane, either 1D or 2D
@@ -1050,7 +1049,7 @@ void FullLDCTrackingAlg::prepareVectors() {
   if(hitVTXCol){
     int nelem = hitVTXCol->size();
     debug() << "Number of VTX hits = " << nelem << endmsg;
-    for(edm4hep::ConstTrackerHit trkhit : *hitVTXCol){
+    for(edm4hep::TrackerHit trkhit : *hitVTXCol){
       // FIXME tracker hit plane type of the hit
       TrackerHitExtended* hitExt = new TrackerHitExtended(trkhit);
       
@@ -1092,7 +1091,7 @@ void FullLDCTrackingAlg::prepareVectors() {
     debug() << "Number of TPC Tracks = " << nelem << endmsg;
     debug() << " Trk    ID        p          D0         Z0       Px       Py       Pz   ntpc ndf  Chi2/ndf nlinkedTracks" << endmsg;
     int iTrk = -1;
-    for(edm4hep::ConstTrack tpcTrack : *tpcTrackCol){
+    for(edm4hep::Track tpcTrack : *tpcTrackCol){
       iTrk++;
       //ConstTrackerHitVec hitVec(tpcTrack.trackerHits_begin(), tpcTrack.trackerHits_end());
       int nHits = tpcTrack.trackerHits_size();//int(hitVec.size());
@@ -1126,7 +1125,7 @@ void FullLDCTrackingAlg::prepareVectors() {
       trackExt->setNDF(tpcTrack.getNdf());
       trackExt->setChi2(tpcTrack.getChi2());
       for (int iHit=0;iHit<nHits;++iHit) {
-	edm4hep::ConstTrackerHit hit = tpcTrack.getTrackerHits(iHit);//hitVec[iHit];
+	edm4hep::TrackerHit hit = tpcTrack.getTrackerHits(iHit);//hitVec[iHit];
 	if(!hit.isAvailable()) error() << "Tracker hit not available" << endmsg;
 	//info() << "hit " << hit.id() << " " << hit.getCellID() << " " << hit.getPosition()[0] << " " << hit.getPosition()[1] << " " << hit.getPosition()[2] << endmsg;
 	auto it = mapTrackerHits.find(hit);
@@ -1154,7 +1153,7 @@ void FullLDCTrackingAlg::prepareVectors() {
     debug() << "Number of Si Tracks = " << nelem << endmsg;
     debug() << " Trk    ID        p          D0         Z0       Px       Py       Pz   ntpc ndf  Chi2/ndf nlinkedTracks" << endmsg;
     int iTrk = -1;
-    for(edm4hep::ConstTrack siTrack : *siTrackCol){
+    for(edm4hep::Track siTrack : *siTrackCol){
       iTrk++;
       double prob = ( siTrack.getNdf() > 0 ? gsl_cdf_chisq_Q(  siTrack.getChi2() ,  (double) siTrack.getNdf() )  : 0. ) ;
       if( prob < _minChi2ProbForSiliconTracks ) {
@@ -1191,7 +1190,7 @@ void FullLDCTrackingAlg::prepareVectors() {
       char strg[200];
       HelixClass helixSi;
       for (int iHit=0;iHit<nHits;++iHit) {
-	edm4hep::ConstTrackerHit hit = siTrack.getTrackerHits(iHit);//hitVec[iHit];
+	edm4hep::TrackerHit hit = siTrack.getTrackerHits(iHit);//hitVec[iHit];
         TrackerHitExtended * hitExt = mapTrackerHits[hit];
         hitExt->setTrackExtended( trackExt );
         
@@ -1497,11 +1496,11 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
   //std::cout << "FullLDCTrackingAlg::CombineTracks nSiHits = " << nSiHits << endmsg;
   //std::cout << "FullLDCTrackingAlg::CombineTracks nTPCHits = " << nTPCHits << endmsg;
   
-  ConstTrackerHitVec trkHits;
+  TrackerHitVec trkHits;
   trkHits.reserve(nHits);
   
   for (int ih=0;ih<nSiHits;++ih) {
-    edm4hep::ConstTrackerHit trkHit = siHitVec[ih]->getTrackerHit();
+    edm4hep::TrackerHit trkHit = siHitVec[ih]->getTrackerHit();
     if(trkHit.isAvailable()) {
       trkHits.push_back(trkHit);
     }
@@ -1511,7 +1510,7 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
   }
   
   for (int ih=0;ih<nTPCHits;++ih) {
-    edm4hep::ConstTrackerHit trkHit = tpcHitVec[ih]->getTrackerHit();
+    edm4hep::TrackerHit trkHit = tpcHitVec[ih]->getTrackerHit();
     if(trkHit.isAvailable()) {
       trkHits.push_back(trkHit);
     }
@@ -1531,11 +1530,11 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
   
   debug() << "FullLDCTrackingAlg::CombineTracks: Sorting Hits " << trkHits.size() << endmsg;
   
-  std::vector< std::pair<float, edm4hep::ConstTrackerHit> > r2_values;
+  std::vector< std::pair<float, edm4hep::TrackerHit> > r2_values;
   r2_values.reserve(trkHits.size());
   
-  for (ConstTrackerHitVec::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
-    edm4hep::ConstTrackerHit h = *it;
+  for (TrackerHitVec::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
+    edm4hep::TrackerHit h = *it;
     float r2 = h.getPosition()[0]*h.getPosition()[0]+h.getPosition()[1]*h.getPosition()[1];
     r2_values.push_back(std::make_pair(r2, *it));
   }
@@ -1545,7 +1544,7 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
   trkHits.clear();
   trkHits.reserve(r2_values.size());
   
-  for (std::vector< std::pair<float, edm4hep::ConstTrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
+  for (std::vector< std::pair<float, edm4hep::TrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
     trkHits.push_back(it->second);
   }
   
@@ -1617,7 +1616,7 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
     
   debug() << "FullLDCTrackingAlg::CombineTracks: Check for outliers " << endmsg;
   
-  std::vector<std::pair<edm4hep::ConstTrackerHit, double> > outliers ;
+  std::vector<std::pair<edm4hep::TrackerHit, double> > outliers ;
   marlin_trk.getOutliers(outliers);
   
   float outlier_pct = outliers.size()/float(trkHits.size()) ;
@@ -1639,10 +1638,10 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
     bool hit_is_outlier = false;
     
     // we need to make sure that in the case of a composite hit we reject this as well
-    ConstTrackerHitVec hits;
+    TrackerHitVec hits;
     
     // all hits, both the 2D tracker hit, as well as any raw hits which belong to it
-    ConstTrackerHit hit = siHitVec[i]->getTrackerHit();
+    TrackerHit hit = siHitVec[i]->getTrackerHit();
     hits.push_back(hit);
     
     // add the raw hits ...
@@ -1652,7 +1651,7 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
 	try{
 	  int type = hit.getType();
 	  if(UTIL::BitSet32(type)[UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT]){
-	    edm4hep::ConstTrackerHit rawHit = Navigation::Instance()->GetTrackerHit(hit.getRawHits(ihit));
+	    edm4hep::TrackerHit rawHit = Navigation::Instance()->GetTrackerHit(hit.getRawHits(ihit));
 	    hits.push_back(rawHit);
 	  }
 	  else debug() << "not space point, id=" << hit.id() << endmsg;
@@ -1885,7 +1884,7 @@ void FullLDCTrackingAlg::SelectCombinedTracks() {
         // get min and max z for the first sub track
         for (int iF=0;iF<nFirst;++iF) {
           TrackerHitExtended * trkHitExt = firstVec[iF];
-	  edm4hep::ConstTrackerHit trkHit = trkHitExt->getTrackerHit();
+	  edm4hep::TrackerHit trkHit = trkHitExt->getTrackerHit();
           float zpos = float(trkHit.getPosition()[2]);
           if (zpos>edges[1])
             edges[1] = zpos;
@@ -1896,7 +1895,7 @@ void FullLDCTrackingAlg::SelectCombinedTracks() {
         // get min and max z for the second sub track
         for (int iS=0;iS<nSecond;++iS) {
           TrackerHitExtended * trkHitExt = secondVec[iS];
-	  edm4hep::ConstTrackerHit trkHit = trkHitExt->getTrackerHit();
+	  edm4hep::TrackerHit trkHit = trkHitExt->getTrackerHit();
           float zpos = float(trkHit.getPosition()[2]);
           if (zpos>edges[1])
             edges[1] = zpos;
@@ -2044,7 +2043,7 @@ void FullLDCTrackingAlg::AddNotCombinedTracks() {
             TrackerHitExtended * hitExt = siHitVec[iH];
             OutputTrack->addTrackerHitExtended(hitExt);
             hitExt->setUsedInFit(true);
-	    edm4hep::ConstTrackerHit hit = hitExt->getTrackerHit();
+	    edm4hep::TrackerHit hit = hitExt->getTrackerHit();
             float zpos = float(hit.getPosition()[2]);
             if (zpos<edges[0])
               edges[0] = zpos;
@@ -2055,7 +2054,7 @@ void FullLDCTrackingAlg::AddNotCombinedTracks() {
             TrackerHitExtended * hitExt = tpcHitVec[iH];
             OutputTrack->addTrackerHitExtended(hitExt);
             hitExt->setUsedInFit(true);
-	    edm4hep::ConstTrackerHit hit = hitExt->getTrackerHit();
+	    edm4hep::TrackerHit hit = hitExt->getTrackerHit();
             float zpos = float(hit.getPosition()[2]);
             if (zpos<edges[0])
               edges[0] = zpos;
@@ -2169,7 +2168,7 @@ void FullLDCTrackingAlg::AddNotCombinedTracks() {
 
         for (int iCur=0;iCur<nCur;++iCur) {
           TrackerHitExtended * curTrkHitExt = currentVec[iCur];
-	  edm4hep::ConstTrackerHit curTrkHit = curTrkHitExt->getTrackerHit();
+	  edm4hep::TrackerHit curTrkHit = curTrkHitExt->getTrackerHit();
           float zpos = float(curTrkHit.getPosition()[2]);
           if (zpos < zmin)
             zmin = zpos;
@@ -2213,7 +2212,7 @@ void FullLDCTrackingAlg::AddNotCombinedTracks() {
               for (int iHitInGrp=0;iHitInGrp<nHitsInGrp;iHitInGrp++) {
 
                 TrackerHitExtended * xTrkExt = hitInGroupVec[iHitInGrp];
-		edm4hep::ConstTrackerHit xTrk = xTrkExt->getTrackerHit();
+		edm4hep::TrackerHit xTrk = xTrkExt->getTrackerHit();
 
                 float xZ = float(xTrk.getPosition()[2]);
                 if (xZ>zmin&&xZ<zmax) {
@@ -2459,7 +2458,7 @@ void FullLDCTrackingAlg::AddNotCombinedTracks() {
             TrackExtended * segment = segVec[iTrk];
 
             // get the lcio track which is behind this segemnt
-	    edm4hep::ConstTrack track = segment->getTrack();
+	    edm4hep::Track track = segment->getTrack();
             //ConstTrackerHitVec hitVec(track.trackerHits_begin(), track.trackerHits_end());
 
             debug() << "Group of orphaned TPC tracks: trying track " << track.id() << endmsg;
@@ -2530,7 +2529,7 @@ void FullLDCTrackingAlg::AddNotCombinedTracks() {
   else { // adding all TPC segments to the list of tracks (track splitting is allowed)
     for (int i=0;i<nTPCTrk;++i) {
       TrackExtended * trkExt = _allTPCTracks[i];
-      edm4hep::ConstTrack track = trkExt->getTrack();
+      edm4hep::Track track = trkExt->getTrack();
       GroupTracks * group = trkExt->getGroupTracks();
 
       if (group == NULL) {
@@ -2555,7 +2554,7 @@ void FullLDCTrackingAlg::AddNotCombinedTracks() {
   
   for (int i=0;i<nSiTrk;++i) { // adding left-over Si segments to the list of tracks
     TrackExtended * trkExt = _allSiTracks[i];
-    edm4hep::ConstTrack track = trkExt->getTrack();
+    edm4hep::Track track = trkExt->getTrack();
     GroupTracks * group = trkExt->getGroupTracks();
 
     if (group == NULL) {
@@ -3006,8 +3005,8 @@ float FullLDCTrackingAlg::CompareTrk(TrackExtended * first, TrackExtended * seco
         
         int nTrkGrpFirst = 0;
         int nTrkGrpSecond = 0;
-        ConstTrackerHitVec hitvecFirst;
-        ConstTrackerHitVec hitvecSecond;
+        TrackerHitVec hitvecFirst;
+        TrackerHitVec hitvecSecond;
         GroupTracks * groupFirst = first->getGroupTracks();
         GroupTracks * groupSecond = second->getGroupTracks();
 
@@ -3204,7 +3203,7 @@ void FullLDCTrackingAlg::AddNotAssignedHits() {
   //    
   //    for (int iSET=0;iSET<nSETHits;++iSET) {
   //      TrackerHitExtended * trkHit = _allSETHits[iSET];
-  //      edm4hep::ConstTrackerHit hit = trkHit->getTrackerHit();
+  //      edm4hep::TrackerHit hit = trkHit->getTrackerHit();
   //      int layer = getLayerID(trkHit);
   //      if (layer>=0&&layer<nLayersSET) 
   //        SETHits[layer].push_back(trkHit);
@@ -3227,7 +3226,7 @@ void FullLDCTrackingAlg::AddNotAssignedHits() {
   //    
   //    for (int iETD=0;iETD<nETDHits;++iETD) {
   //      TrackerHitExtended * trkHit = _allETDHits[iETD];
-  //      edm4hep::ConstTrackerHit hit = trkHit->getTrackerHit();
+  //      edm4hep::TrackerHit hit = trkHit->getTrackerHit();
   //      int layer = getLayerID(trkHit);
   //      if (layer>=0 && layer < nLayersETD) 
   //        ETDHits[layer].push_back(trkHit);
@@ -3261,7 +3260,7 @@ void FullLDCTrackingAlg::AddNotAssignedHits() {
  
      for (int iSET=0;iSET<nSETHits;++iSET) {
        TrackerHitExtended * trkHitExt = _allSETHits[iSET];
-       edm4hep::ConstTrackerHit trkHit = trkHitExt->getTrackerHit();
+       edm4hep::TrackerHit trkHit = trkHitExt->getTrackerHit();
        int layer = getLayerID(trkHit);
        if (layer>=0 && (unsigned)layer < _nLayersSET)
          SETHits[layer].push_back(trkHitExt);
@@ -3293,7 +3292,7 @@ void FullLDCTrackingAlg::AddNotAssignedHits() {
       
       // check if this hit has not already been assigned to a track
       if (trkExt == NULL) {
-	edm4hep::ConstTrackerHit trkHit = trkHitExt->getTrackerHit();
+	edm4hep::TrackerHit trkHit = trkHitExt->getTrackerHit();
         
         int layer = getLayerID(trkHit);
         
@@ -3332,7 +3331,7 @@ void FullLDCTrackingAlg::AddNotAssignedHits() {
       
       // check if this hit has not already been assigned to a track
       if (trkExt == NULL) {
-	edm4hep::ConstTrackerHit trkHit = trkHitExt->getTrackerHit();
+	edm4hep::TrackerHit trkHit = trkHitExt->getTrackerHit();
                 
         // get the layer number
         int layer = getLayerID(trkHit);
@@ -3383,7 +3382,7 @@ void FullLDCTrackingAlg::AddNotAssignedHits() {
       
       // check if this hit has not already been assigned to a track
       if (trkExt == NULL) {
-	edm4hep::ConstTrackerHit trkHit = trkHitExt->getTrackerHit();
+	edm4hep::TrackerHit trkHit = trkHitExt->getTrackerHit();
         
         int layer = getLayerID(trkHit);
         
@@ -3470,7 +3469,7 @@ void FullLDCTrackingAlg::AssignOuterHitsToTracks(TrackerHitExtendedVec hitVec, f
     float pos[3];
     
     TrackerHitExtended * trkHitExt = hitVec[iH];
-    edm4hep::ConstTrackerHit hit = trkHitExt->getTrackerHit();
+    edm4hep::TrackerHit hit = trkHitExt->getTrackerHit();
     
     for (int ip=0;ip<3;++ip) {
       pos[ip] = float(hit.getPosition()[ip]);
@@ -3563,13 +3562,13 @@ void FullLDCTrackingAlg::AssignOuterHitsToTracks(TrackerHitExtendedVec hitVec, f
           
           // add the previously used hits from the track to the vectors
           
-          ConstTrackerHitVec trkHits;
+          TrackerHitVec trkHits;
           
           for (int iHit=0;iHit<nTotH;++iHit) {
             
             TrackerHitExtended * hitInTrack = hitsInTrack[iHit];
             if (hitInTrack->getUsedInFit()) {
-	      edm4hep::ConstTrackerHit hit = hitInTrack->getTrackerHit();
+	      edm4hep::TrackerHit hit = hitInTrack->getTrackerHit();
               iHitInFit++;
               if(hit.isAvailable()) {
                 trkHits.push_back(hit);
@@ -3581,7 +3580,7 @@ void FullLDCTrackingAlg::AssignOuterHitsToTracks(TrackerHitExtendedVec hitVec, f
           }
           
           // add the hit to be attached to the vectors
-	  edm4hep::ConstTrackerHit remainHit = trkHitExt->getTrackerHit();
+	  edm4hep::TrackerHit remainHit = trkHitExt->getTrackerHit();
           iHitInFit++;
           trkHits.push_back(remainHit);
           
@@ -3593,11 +3592,11 @@ void FullLDCTrackingAlg::AssignOuterHitsToTracks(TrackerHitExtendedVec hitVec, f
           if( trkHits.size() < 3 ) return ;
           
           // sort the hits in R
-          std::vector< std::pair<float, edm4hep::ConstTrackerHit> > r2_values;
+          std::vector< std::pair<float, edm4hep::TrackerHit> > r2_values;
           r2_values.reserve(trkHits.size());
           
-          for (ConstTrackerHitVec::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
-	    edm4hep::ConstTrackerHit h = *it;
+          for (TrackerHitVec::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
+	    edm4hep::TrackerHit h = *it;
             float r2 = h.getPosition()[0]*h.getPosition()[0]+h.getPosition()[1]*h.getPosition()[1];
             r2_values.push_back(std::make_pair(r2, *it));
           }
@@ -3607,7 +3606,7 @@ void FullLDCTrackingAlg::AssignOuterHitsToTracks(TrackerHitExtendedVec hitVec, f
           trkHits.clear();
           trkHits.reserve(r2_values.size());
           
-          for (std::vector< std::pair<float, edm4hep::ConstTrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
+          for (std::vector< std::pair<float, edm4hep::TrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
             trkHits.push_back(it->second);
           }
                     
@@ -3652,7 +3651,7 @@ void FullLDCTrackingAlg::AssignOuterHitsToTracks(TrackerHitExtendedVec hitVec, f
             continue ;
 	  }
          
-          std::vector<std::pair<edm4hep::ConstTrackerHit , double> > outliers ;
+          std::vector<std::pair<edm4hep::TrackerHit , double> > outliers ;
           marlin_trk->getOutliers(outliers);
           
           float outlier_pct = outliers.size()/float(trkHits.size()) ;
@@ -3749,7 +3748,7 @@ HelixClass * FullLDCTrackingAlg::GetExtrapolationHelix( TrackExtended * track) {
   
   for (unsigned itrk=0; itrk<trk_vec.size(); ++itrk) {
 
-    edm4hep::ConstTrack trk_lcio = trk_vec[itrk]->getTrack();
+    edm4hep::Track trk_lcio = trk_vec[itrk]->getTrack();
     
     if (trk_lcio.isAvailable()) {
   
@@ -3844,7 +3843,7 @@ void FullLDCTrackingAlg::AssignTPCHitsToTracks(TrackerHitExtendedVec hitVec,
   for (int iH=0;iH<nHits;++iH) { // loop over leftover TPC hits
     tracksToAttach[iH]=NULL;
     //Get all TrackerHit positions, so we only have to get them once
-    edm4hep::ConstTrackerHit temphit = hitVec[iH]->getTrackerHit();
+    edm4hep::TrackerHit temphit = hitVec[iH]->getTrackerHit();
     const edm4hep::Vector3d temppos = temphit.getPosition();
     HitPositions[iH].push_back(float(temppos[0]));
     HitPositions[iH].push_back(float(temppos[1]));
@@ -3992,7 +3991,7 @@ void FullLDCTrackingAlg::AssignSiHitsToTracks(TrackerHitExtendedVec hitVec,
     
     float pos[3];
     TrackerHitExtended * trkHitExt = hitVec[iH];
-    edm4hep::ConstTrackerHit hit = trkHitExt->getTrackerHit();
+    edm4hep::TrackerHit hit = trkHitExt->getTrackerHit();
     
     for (int ip=0;ip<3;++ip) {
       pos[ip] = float(hit.getPosition()[ip]);
@@ -4069,13 +4068,13 @@ void FullLDCTrackingAlg::AssignSiHitsToTracks(TrackerHitExtendedVec hitVec,
         
         // add the previously used hits from the track to the vectors 
         
-        ConstTrackerHitVec trkHits;
+        TrackerHitVec trkHits;
         
         for (int iHit=0;iHit<nTotH;++iHit) {
           
           TrackerHitExtended * hitInTrack = hitsInTrack[iHit];
           if (hitInTrack->getUsedInFit()) {
-	    edm4hep::ConstTrackerHit hit = hitInTrack->getTrackerHit();
+	    edm4hep::TrackerHit hit = hitInTrack->getTrackerHit();
             iHitInFit++;
             if(hit.isAvailable()) {
               trkHits.push_back(hit);
@@ -4087,7 +4086,7 @@ void FullLDCTrackingAlg::AssignSiHitsToTracks(TrackerHitExtendedVec hitVec,
         }
         
         // add the hit to be attached to the vectors 
-	edm4hep::ConstTrackerHit remainHit = trkHitExt->getTrackerHit();
+	edm4hep::TrackerHit remainHit = trkHitExt->getTrackerHit();
         iHitInFit++;
         trkHits.push_back(remainHit);
         
@@ -4098,11 +4097,11 @@ void FullLDCTrackingAlg::AssignSiHitsToTracks(TrackerHitExtendedVec hitVec,
         if( trkHits.size() < 3 ) return ;
         
         // sort the hits in R
-        std::vector< std::pair<float, edm4hep::ConstTrackerHit> > r2_values;
+        std::vector< std::pair<float, edm4hep::TrackerHit> > r2_values;
         r2_values.reserve(trkHits.size());
         
-        for (ConstTrackerHitVec::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
-	  edm4hep::ConstTrackerHit h = *it;
+        for (TrackerHitVec::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
+	  edm4hep::TrackerHit h = *it;
           float r2 = h.getPosition()[0]*h.getPosition()[0]+h.getPosition()[1]*h.getPosition()[1];
           r2_values.push_back(std::make_pair(r2, *it));
         }
@@ -4112,7 +4111,7 @@ void FullLDCTrackingAlg::AssignSiHitsToTracks(TrackerHitExtendedVec hitVec,
         trkHits.clear();
         trkHits.reserve(r2_values.size());
         
-        for (std::vector< std::pair<float, edm4hep::ConstTrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
+        for (std::vector< std::pair<float, edm4hep::TrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
           trkHits.push_back(it->second);
         }
 
@@ -4158,7 +4157,7 @@ void FullLDCTrackingAlg::AssignSiHitsToTracks(TrackerHitExtendedVec hitVec,
           continue ;
 	}
         
-        std::vector<std::pair<edm4hep::ConstTrackerHit , double> > outliers ;
+        std::vector<std::pair<edm4hep::TrackerHit , double> > outliers ;
         marlin_trk->getOutliers(outliers);
         
         float outlier_pct = outliers.size()/float(trkHits.size());
@@ -4656,8 +4655,8 @@ int FullLDCTrackingAlg::SegmentRadialOverlap(TrackExtended* first, TrackExtended
   
   int nTrkGrpFirst = 0;
   int nTrkGrpSecond = 0;
-  ConstTrackerHitVec hitvecFirst;
-  ConstTrackerHitVec hitvecSecond;
+  TrackerHitVec hitvecFirst;
+  TrackerHitVec hitvecSecond;
   GroupTracks * groupFirst = first->getGroupTracks();
   GroupTracks * groupSecond = second->getGroupTracks();
   

--- a/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.h
+++ b/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.h
@@ -404,11 +404,11 @@ protected:
   std::set<TrackExtended*> _candidateCombinedTracks;
   
   UTIL::BitField64* _encoder;
-  int getDetectorID(edm4hep::ConstTrackerHit hit) { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::subdet]; }
-  int getSideID(edm4hep::ConstTrackerHit hit)     { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::side]; };
-  int getLayerID(edm4hep::ConstTrackerHit hit)    { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::layer]; };
-  int getModuleID(edm4hep::ConstTrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::module]; };
-  int getSensorID(edm4hep::ConstTrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::sensor]; };
+  int getDetectorID(edm4hep::TrackerHit hit) { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::subdet]; }
+  int getSideID(edm4hep::TrackerHit hit)     { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::side]; };
+  int getLayerID(edm4hep::TrackerHit hit)    { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::layer]; };
+  int getModuleID(edm4hep::TrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::module]; };
+  int getSensorID(edm4hep::TrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::sensor]; };
 
   
   void setupGearGeom() ;

--- a/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.cpp
+++ b/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.cpp
@@ -121,7 +121,7 @@ StatusCode TruthTrackerAlg::execute()
     if(nullptr!=siTrackCol) {
         ///New SDT track
         for(auto siTrack:*siTrackCol){
-            edm4hep::Track sdtTrack=sdtTrackCol->create();
+            auto sdtTrack=sdtTrackCol->create();
             edm4hep::TrackState sdtTrackState;
             edm4hep::TrackState siTrackStat=siTrack.getTrackStates(0);//FIXME?
             sdtTrackState.location=siTrackStat.location;
@@ -199,7 +199,7 @@ StatusCode TruthTrackerAlg::execute()
         helix.Initialize_VP(pos,mom,mcParticle.getCharge(),B[2]/dd4hep::tesla);
 
         ///new Track
-        edm4hep::Track dcTrack=dcTrackCol->create();
+        auto dcTrack=dcTrackCol->create();
         edm4hep::TrackState trackState;
         trackState.D0=helix.getD0();
         trackState.phi=helix.getPhi0();
@@ -227,7 +227,7 @@ StatusCode TruthTrackerAlg::execute()
         }
         dcTrack.setRadiusOfInnermostHit(radiusOfInnermostHit);//TODO
 
-        edm4hep::ReconstructedParticle dcRecParticle;
+        edm4hep::MutableReconstructedParticle dcRecParticle;
         if(m_writeRecParticle){
             dcRecParticle=dcRecParticleCol->create();
             ///new ReconstructedParticle

--- a/Service/TrackSystemSvc/include/TrackSystemSvc/IMarlinTrack.h
+++ b/Service/TrackSystemSvc/include/TrackSystemSvc/IMarlinTrack.h
@@ -6,7 +6,7 @@
 //#include "lcio.h"
 
 #include "edm4hep/TrackerHit.h"
-#include "edm4hep/TrackerHitConst.h"
+#include "edm4hep/TrackerHit.h"
 #include "edm4hep/TrackState.h"
 
 //#include "gearimpl/Vector3D.h"
@@ -55,7 +55,7 @@ namespace MarlinTrk{
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */
-    virtual int addHit(edm4hep::ConstTrackerHit& hit) = 0 ;
+    virtual int addHit(edm4hep::TrackerHit& hit) = 0 ;
     
     /** initialise the fit using the hits added up to this point -
      *  the fit direction has to be specified using IMarlinTrack::backward or IMarlinTrack::forward. 
@@ -82,12 +82,12 @@ namespace MarlinTrk{
     /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from adding the hit via reference. 
      *  the given hit will not be added if chi2increment > maxChi2Increment. 
      */
-    virtual int addAndFit( edm4hep::ConstTrackerHit& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) = 0 ;
+    virtual int addAndFit( edm4hep::TrackerHit& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) = 0 ;
 
     
     /** obtain the chi2 increment which would result in adding the hit to the fit. This method will not alter the current fit, and the hit will not be stored in the list of hits or outliers
      */
-    virtual int testChi2Increment( edm4hep::ConstTrackerHit& hit, double& chi2increment ) = 0 ;
+    virtual int testChi2Increment( edm4hep::TrackerHit& hit, double& chi2increment ) = 0 ;
 
     
     /** smooth all track states 
@@ -97,7 +97,7 @@ namespace MarlinTrk{
     
     /** smooth track states from the last filtered hit back to the measurement site associated with the given hit 
      */
-    virtual int smooth( edm4hep::ConstTrackerHit& hit ) = 0 ;
+    virtual int smooth( edm4hep::TrackerHit& hit ) = 0 ;
     
     
     
@@ -110,21 +110,21 @@ namespace MarlinTrk{
     
     /** get track state at measurement associated with the given hit, returning TrackState, chi2 and ndf via reference 
      */
-    virtual int getTrackState( edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
+    virtual int getTrackState( edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
     
     /** get the list of hits included in the fit, together with the chi2 contributions of the hits. 
      *  Pointers to the hits together with their chi2 contribution will be filled into a vector of 
      *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
      *  the second.
      */
-    virtual int getHitsInFit( std::vector<std::pair<edm4hep::ConstTrackerHit, double> >& hits ) = 0 ;
+    virtual int getHitsInFit( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) = 0 ;
 
     /** get the list of hits which have been rejected by from the fit due to the a chi2 increment greater than threshold,
      *  Pointers to the hits together with their chi2 contribution will be filled into a vector of 
      *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
      *  the second.
      */
-    virtual int getOutliers( std::vector<std::pair<edm4hep::ConstTrackerHit, double> >& hits ) = 0 ;
+    virtual int getOutliers( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) = 0 ;
     
     /** get the current number of degrees of freedom for the fit.
      */
@@ -132,7 +132,7 @@ namespace MarlinTrk{
     
     /** get TrackeHit at which fit became constrained, i.e. ndf >= 0
      */
-    virtual int getTrackerHitAtPositiveNDF( edm4hep::ConstTrackerHit& trkhit ) = 0 ;
+    virtual int getTrackerHitAtPositiveNDF( edm4hep::TrackerHit& trkhit ) = 0 ;
     
     // PROPAGATORS 
     
@@ -144,7 +144,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point,
      *  returning TrackState, chi2 and ndf via reference   
      */
-    virtual int propagate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
+    virtual int propagate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
     
     
     /** propagate fit to numbered sensitive layer, returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference 
@@ -154,7 +154,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference 
      */
-    virtual int propagateToLayer(int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0;
+    virtual int propagateToLayer(int layerID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0;
     
     /** propagate the fit to sensitive detector element, returning TrackState, chi2 and ndf via reference
      */
@@ -163,7 +163,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
      */
-    virtual int propagateToDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
+    virtual int propagateToDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
     
     
     
@@ -176,7 +176,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point, 
      *  returning TrackState, chi2 and ndf via reference   
      */
-    virtual int extrapolate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
+    virtual int extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
     
     /** extrapolate the fit to numbered sensitive layer, returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference
      */
@@ -185,7 +185,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference 
      */
-    virtual int extrapolateToLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0  ;
+    virtual int extrapolateToLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0  ;
     
     /** extrapolate the fit to sensitive detector element, returning TrackState, chi2 and ndf via reference
      */
@@ -194,7 +194,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
      */
-    virtual int extrapolateToDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
+    virtual int extrapolateToDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
     
     
     // INTERSECTORS
@@ -207,7 +207,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer,
      *  returning intersection point in global coordinates and integer ID of the intersected sensitive detector element via reference 
      */
-    virtual int intersectionWithLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest ) = 0  ;
+    virtual int intersectionWithLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest ) = 0  ;
     
     
     /** extrapolate the fit to numbered sensitive detector element, returning intersection point in global coordinates via reference 
@@ -217,7 +217,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element,
      *  returning intersection point in global coordinates via reference 
      */
-    virtual int intersectionWithDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::Vector3d& point, int mode=modeClosest ) = 0  ;
+    virtual int intersectionWithDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::Vector3d& point, int mode=modeClosest ) = 0  ;
     
     
   protected:

--- a/Service/TrackSystemSvc/include/TrackSystemSvc/MarlinTrkUtils.h
+++ b/Service/TrackSystemSvc/include/TrackSystemSvc/MarlinTrkUtils.h
@@ -4,7 +4,8 @@
 #include <vector>
 #include <array>
 #include <cfloat>
-#include <edm4hep/TrackerHitConst.h>
+#include <edm4hep/TrackerHit.h>
+#include <edm4hep/Track.h>
 
 #include <LCIOSTLTypes.h>
 
@@ -39,8 +40,8 @@ namespace MarlinTrk{
    *  it @IP, @First_Hit, @Last_Hit and @CaloFace */
   int createFinalisedLCIOTrack(
       IMarlinTrack* marlinTrk,
-      std::vector<edm4hep::ConstTrackerHit>& hit_list,
-      edm4hep::Track* track,
+      std::vector<edm4hep::TrackerHit>& hit_list,
+      edm4hep::MutableTrack* track,
       bool fit_backwards,
       edm4hep::TrackState* pre_fit,
       float bfield_z,
@@ -51,18 +52,18 @@ namespace MarlinTrk{
    *  it @IP, @First_Hit, @Last_Hit and @CaloFace */
   int createFinalisedLCIOTrack(
       IMarlinTrack* marlinTrk,
-      std::vector<edm4hep::ConstTrackerHit>& hit_list,
-      edm4hep::Track* track,
+      std::vector<edm4hep::TrackerHit>& hit_list,
+      edm4hep::MutableTrack* track,
       bool fit_backwards,
       const std::array<float,15>& initial_cov_for_prefit,
       float bfield_z,
       double maxChi2Increment=DBL_MAX);
   
   /** Provides the values of a track state from the first, middle and last hits in the hit_list. */
-  int createPrefit( std::vector<edm4hep::ConstTrackerHit>& hit_list, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards );
+  int createPrefit( std::vector<edm4hep::TrackerHit>& hit_list, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards );
 
   /** Takes a list of hits and uses the IMarlinTrack inferface to fit them using a supplied prefit containing a covariance matrix for the initialisation. */  
-  int createFit( std::vector<edm4hep::ConstTrackerHit>& hit_list, IMarlinTrack* marlinTrk, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards, double maxChi2Increment=DBL_MAX );
+  int createFit( std::vector<edm4hep::TrackerHit>& hit_list, IMarlinTrack* marlinTrk, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards, double maxChi2Increment=DBL_MAX );
 
   /** Takes a fitted MarlinTrack, TrackImpl to record the fit and the hits which have been added to the fit.
    *  The TrackImpl will have the 4 trackstates added to it @IP, @First_Hit, @Last_Hit and @CaloFace.
@@ -71,16 +72,16 @@ namespace MarlinTrk{
    *  that they can be recorded in the LCIO TrackImpl */
   int finaliseLCIOTrack(
       IMarlinTrack* marlinTrk,
-      edm4hep::Track* track,
-      std::vector<edm4hep::ConstTrackerHit>& hit_list,
+      edm4hep::MutableTrack* track,
+      std::vector<edm4hep::TrackerHit>& hit_list,
       edm4hep::TrackState* atLastHit=0,
       edm4hep::TrackState* atCaloFace=0);
   
   /** Set the subdetector hit numbers for the TrackImpl */
-  void addHitNumbersToTrack(edm4hep::Track* track, std::vector<edm4hep::ConstTrackerHit>& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder);
+  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<edm4hep::TrackerHit>& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder);
 
   /** Set the subdetector hit numbers for the TrackImpl */
-  void addHitNumbersToTrack(edm4hep::Track* track, std::vector<std::pair<edm4hep::ConstTrackerHit , double> >& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder);
+  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<std::pair<edm4hep::TrackerHit , double> >& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder);
   
 }
 

--- a/Service/TrackSystemSvc/src/MarlinKalTest.cc
+++ b/Service/TrackSystemSvc/src/MarlinKalTest.cc
@@ -415,7 +415,7 @@ namespace MarlinTrk{
     return ml_retval;
   }
   
-  const ILDVMeasLayer* MarlinKalTest::findMeasLayer( edm4hep::ConstTrackerHit trkhit) const {
+  const ILDVMeasLayer* MarlinKalTest::findMeasLayer( edm4hep::TrackerHit trkhit) const {
     
     const TVector3 hit_pos( trkhit.getPosition()[0], trkhit.getPosition()[1], trkhit.getPosition()[2]) ;
     

--- a/Service/TrackSystemSvc/src/MarlinKalTest.h
+++ b/Service/TrackSystemSvc/src/MarlinKalTest.h
@@ -2,7 +2,7 @@
 #define MarlinKalTest_h
 
 #include "TrackSystemSvc/IMarlinTrkSystem.h"
-#include "edm4hep/TrackerHitConst.h"
+#include "edm4hep/TrackerHit.h"
 
 #include "gear/GearMgr.h"
 
@@ -80,7 +80,7 @@ namespace MarlinTrk{
     bool is_initialised ;
     
     //** find the measurment layer for a given hit 
-    const ILDVMeasLayer* findMeasLayer(edm4hep::ConstTrackerHit trkhit) const ; 
+    const ILDVMeasLayer* findMeasLayer(edm4hep::TrackerHit trkhit) const ; 
     //** find the measurment layer for a given det element ID and point in space 
     const ILDVMeasLayer* findMeasLayer(int detElementID, const TVector3& point) const ;
     

--- a/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
+++ b/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
@@ -76,7 +76,7 @@ namespace MarlinTrk {
   
   
   MarlinKalTestTrack::MarlinKalTestTrack(MarlinKalTest* ktest) 
-    : _ktest(ktest), _trackHitAtPositiveNDF(edm4hep::ConstTrackerHit(0)) {
+    : _ktest(ktest), _trackHitAtPositiveNDF(edm4hep::TrackerHit(0)) {
     
     _kaltrack = new TKalTrack() ;
     _kaltrack->SetOwner() ;
@@ -109,13 +109,13 @@ namespace MarlinTrk {
   
   
   
-  int MarlinKalTestTrack::addHit( edm4hep::ConstTrackerHit& trkhit) {
+  int MarlinKalTestTrack::addHit( edm4hep::TrackerHit& trkhit) {
     
     return this->addHit( trkhit, _ktest->findMeasLayer( trkhit )) ;
     
   } 
   
-  int MarlinKalTestTrack::addHit( edm4hep::ConstTrackerHit& trkhit, const ILDVMeasLayer* ml) {
+  int MarlinKalTestTrack::addHit( edm4hep::TrackerHit& trkhit, const ILDVMeasLayer* ml) {
     //std::cout << "MarlinKalTestTrack::addHit: trkhit = "  << trkhit.id() << " addr: " << trkhit << " ml = " << ml << std::endl ;
     if( trkhit.isAvailable() && ml ) {
       //if(ml){
@@ -128,7 +128,7 @@ namespace MarlinTrk {
     return bad_intputs ;
   }
   
-  int MarlinKalTestTrack::addHit( edm4hep::ConstTrackerHit& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) {
+  int MarlinKalTestTrack::addHit( edm4hep::TrackerHit& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) {
     //std::cout << "MarlinKalTestTrack::addHit: trkhit = "  << trkhit.id() << " ILDVTrackHit: " << kalhit << " ml = " << ml << std::endl ;
     if( kalhit && ml ) {
       //if(ml){
@@ -659,7 +659,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::addAndFit( edm4hep::ConstTrackerHit& trkhit, double& chi2increment, double maxChi2Increment) {
+  int MarlinKalTestTrack::addAndFit( edm4hep::TrackerHit& trkhit, double& chi2increment, double maxChi2Increment) {
     
     if( ! trkhit.isAvailable() ) {
       std::cout << "Error: MarlinKalTestTrack::addAndFit(edm4hep::TrackerHit trkhit, double& chi2increment, double maxChi2Increment): trkhit == 0" << std::endl;
@@ -736,7 +736,7 @@ namespace MarlinTrk {
   
   
   
-  int MarlinKalTestTrack::testChi2Increment( edm4hep::ConstTrackerHit& trkhit, double& chi2increment ) {
+  int MarlinKalTestTrack::testChi2Increment( edm4hep::TrackerHit& trkhit, double& chi2increment ) {
     
     //if( ! trkhit ) {
     //  streamlog_out( ERROR) << "MarlinKalTestTrack::addAndFit(edm4hep::TrackerHit trkhit, double& chi2increment, double maxChi2Increment): trkhit == 0" << std::endl;
@@ -810,7 +810,7 @@ namespace MarlinTrk {
       int error_code = this->addAndFit( kalhit, chi2increment, site, maxChi2Increment );
       
       
-      edm4hep::ConstTrackerHit trkhit = kalhit->getLCIOTrackerHit();
+      edm4hep::TrackerHit trkhit = kalhit->getLCIOTrackerHit();
       
       if( error_code == 0 ){ // add trkhit to map associating trkhits and sites
         _hit_used_for_sites[trkhit] = site;
@@ -900,7 +900,7 @@ namespace MarlinTrk {
   
   /** smooth track states from the last filtered hit back to the measurement site associated with the given hit 
    */
-  int MarlinKalTestTrack::smooth( edm4hep::ConstTrackerHit& trkhit ) {
+  int MarlinKalTestTrack::smooth( edm4hep::TrackerHit& trkhit ) {
     
     //streamlog_out( DEBUG2 )  << "MarlinKalTestTrack::smooth( edm4hep::TrackerHit " << trkhit << "  ) " << std::endl ;
 
@@ -908,7 +908,7 @@ namespace MarlinTrk {
       return bad_intputs ;
     }
         
-    std::map<edm4hep::ConstTrackerHit, TKalTrackSite*>::const_iterator it;
+    std::map<edm4hep::TrackerHit, TKalTrackSite*>::const_iterator it;
         
     TKalTrackSite* site = 0 ;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -941,9 +941,9 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::getTrackState( edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
+  int MarlinKalTestTrack::getTrackState( edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
     
-    //streamlog_out( DEBUG2 )  << "MarlinKalTestTrack::getTrackState(edm4hep::ConstTrackerHit trkhit, edm4hep::TrackState& ts ) using hit: " << trkhit << " with cellID0 = " << trkhit.getCellID() << std::endl ;
+    //streamlog_out( DEBUG2 )  << "MarlinKalTestTrack::getTrackState(edm4hep::TrackerHit trkhit, edm4hep::TrackState& ts ) using hit: " << trkhit << " with cellID0 = " << trkhit.getCellID() << std::endl ;
     
     TKalTrackSite* site = 0 ;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -958,7 +958,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::getHitsInFit( std::vector<std::pair<edm4hep::ConstTrackerHit, double> >& hits ) {
+  int MarlinKalTestTrack::getHitsInFit( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) {
     //std::cout << "debug: _hit_chi2_values address= " << &_hit_chi2_values << " " << &(*(_hit_chi2_values.begin())) << " want to copy to hits address=" << &hits << std::endl; 
     std::copy( _hit_chi2_values.begin() , _hit_chi2_values.end() , std::back_inserter(  hits  )  ) ;
     //hits.resize(_hit_chi2_values.size());
@@ -980,7 +980,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::getOutliers( std::vector<std::pair<edm4hep::ConstTrackerHit, double> >& hits ) {
+  int MarlinKalTestTrack::getOutliers( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) {
 
     std::copy( _outlier_chi2_values.begin() , _outlier_chi2_values.end() , std::back_inserter(  hits  )  ) ;
    
@@ -1011,7 +1011,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::getTrackerHitAtPositiveNDF( edm4hep::ConstTrackerHit& trkhit ) {
+  int MarlinKalTestTrack::getTrackerHitAtPositiveNDF( edm4hep::TrackerHit& trkhit ) {
     if(_trackHitAtPositiveNDF.isAvailable()){
       trkhit = _trackHitAtPositiveNDF;
       return success;    
@@ -1031,7 +1031,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
+  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
     
     TKalTrackSite* site = 0 ;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1083,7 +1083,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::extrapolateToLayer( int layerID, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
+  int MarlinKalTestTrack::extrapolateToLayer( int layerID, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1120,7 +1120,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
+  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1161,7 +1161,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::propagate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ){
+  int MarlinKalTestTrack::propagate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ){
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1271,7 +1271,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::propagateToLayer( int layerID, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
+  int MarlinKalTestTrack::propagateToLayer( int layerID, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1309,7 +1309,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::propagateToDetElement( int detElementID, edm4hep::ConstTrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
+  int MarlinKalTestTrack::propagateToDetElement( int detElementID, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1347,7 +1347,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::intersectionWithDetElement( int detElementID,  edm4hep::ConstTrackerHit& trkhit, edm4hep::Vector3d& point, int mode ) {
+  int MarlinKalTestTrack::intersectionWithDetElement( int detElementID,  edm4hep::TrackerHit& trkhit, edm4hep::Vector3d& point, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1414,7 +1414,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::intersectionWithLayer( int layerID,  edm4hep::ConstTrackerHit& trkhit, edm4hep::Vector3d& point, int& detElementID, int mode ) {
+  int MarlinKalTestTrack::intersectionWithLayer( int layerID,  edm4hep::TrackerHit& trkhit, edm4hep::Vector3d& point, int& detElementID, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1662,9 +1662,9 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::getSiteFromLCIOHit( edm4hep::ConstTrackerHit& trkhit, TKalTrackSite*& site ) const {
+  int MarlinKalTestTrack::getSiteFromLCIOHit( edm4hep::TrackerHit& trkhit, TKalTrackSite*& site ) const {
     
-    std::map<edm4hep::ConstTrackerHit,TKalTrackSite*>::const_iterator it;
+    std::map<edm4hep::TrackerHit,TKalTrackSite*>::const_iterator it;
     
     it = _hit_used_for_sites.find(trkhit) ;  
     

--- a/Service/TrackSystemSvc/src/MarlinKalTestTrack.h
+++ b/Service/TrackSystemSvc/src/MarlinKalTestTrack.h
@@ -49,17 +49,17 @@ namespace MarlinTrk{
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */
-    int addHit(edm4hep::ConstTrackerHit& hit) ;
+    int addHit(edm4hep::TrackerHit& hit) ;
     
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */    
-    int addHit(edm4hep::ConstTrackerHit& trkhit, const ILDVMeasLayer* ml) ;
+    int addHit(edm4hep::TrackerHit& trkhit, const ILDVMeasLayer* ml) ;
     
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */    
-    int addHit( edm4hep::ConstTrackerHit& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) ;
+    int addHit( edm4hep::TrackerHit& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) ;
     
     /** initialise the fit using the hits added up to this point -
      *  the fit direction has to be specified using IMarlinTrack::backward or IMarlinTrack::forward. 
@@ -90,13 +90,13 @@ namespace MarlinTrk{
     
     /** smooth track states from the last filtered hit back to the measurement site associated with the given hit 
      */
-    int smooth( edm4hep::ConstTrackerHit& hit )  ;
+    int smooth( edm4hep::TrackerHit& hit )  ;
     
     
     /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from adding the hit via reference. 
      *  the given hit will not be added if chi2increment > maxChi2Increment. 
      */
-    int addAndFit( edm4hep::ConstTrackerHit& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) ;
+    int addAndFit( edm4hep::TrackerHit& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) ;
     
     /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from adding the hit via reference. 
      *  the given hit will not be added if chi2increment > maxChi2Increment. 
@@ -106,7 +106,7 @@ namespace MarlinTrk{
     
     /** obtain the chi2 increment which would result in adding the hit to the fit. This method will not alter the current fit, and the hit will not be stored in the list of hits or outliers
      */
-    int testChi2Increment( edm4hep::ConstTrackerHit& hit, double& chi2increment ) ;
+    int testChi2Increment( edm4hep::TrackerHit& hit, double& chi2increment ) ;
     
     
     // Track State Accessesors
@@ -118,7 +118,7 @@ namespace MarlinTrk{
     
     /** get track state at measurement associated with the given hit, returning TrackState, chi2 and ndf via reference 
      */
-    int getTrackState( edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
+    int getTrackState( edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
     
     
     /** get the list of hits included in the fit, together with the chi2 contributions of the hits. 
@@ -126,14 +126,14 @@ namespace MarlinTrk{
      *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
      *  the second.
      */
-    int getHitsInFit( std::vector<std::pair<edm4hep::ConstTrackerHit, double> >& hits ) ;
+    int getHitsInFit( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) ;
     
     /** get the list of hits which have been rejected by from the fit due to the a chi2 increment greater than threshold,
      *  Pointers to the hits together with their chi2 contribution will be filled into a vector of 
      *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
      *  the second.
      */
-    int getOutliers( std::vector<std::pair<edm4hep::ConstTrackerHit, double> >& hits ) ;
+    int getOutliers( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) ;
     
     
     /** get the current number of degrees of freedom for the fit.
@@ -142,7 +142,7 @@ namespace MarlinTrk{
     
     /** get TrackeHit at which fit became constrained, i.e. ndf >= 0
      */
-    int getTrackerHitAtPositiveNDF( edm4hep::ConstTrackerHit& trkhit ) ;
+    int getTrackerHitAtPositiveNDF( edm4hep::TrackerHit& trkhit ) ;
     
     // PROPAGATORS 
   
@@ -154,7 +154,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point,
      *  returning TrackState, chi2 and ndf via reference   
      */
-    int propagate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
+    int propagate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
     
     
     /** propagate the fit at the provided measurement site, to the point of closest approach to the given point,
@@ -170,7 +170,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
      */
-    int propagateToLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
+    int propagateToLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
     
     /** propagate the fit at the measurement site, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -184,7 +184,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
      */
-    int propagateToDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
+    int propagateToDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
   
     /** propagate the fit at the measurement site, to sensitive detector element, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -202,7 +202,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point, 
      *    returning TrackState, chi2 and ndf via reference   
      */
-    int extrapolate( const edm4hep::Vector3d& point, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
+    int extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
     
     /** extrapolate the fit at the measurement site, to the point of closest approach to the given point, 
      *    returning TrackState, chi2 and ndf via reference   
@@ -216,7 +216,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
      */
-    int extrapolateToLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
+    int extrapolateToLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
     
     /** extrapolate the fit at the measurement site, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -230,7 +230,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
    */
-    int extrapolateToDetElement( int detEementID, edm4hep::ConstTrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
+    int extrapolateToDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
     
     /** extrapolate the fit at the measurement site, to sensitive detector element, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -250,7 +250,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer,
      *  returning intersection point in global coordinates and integer ID of the intersected sensitive detector element via reference 
      */
-    int intersectionWithLayer( int layerID, edm4hep::ConstTrackerHit& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest )  ;
+    int intersectionWithLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest )  ;
     
     /** extrapolate the fit at the measurement site, to numbered sensitive layer,
      *  returning intersection point in global coordinates and integer ID of the intersected sensitive detector element via reference 
@@ -265,7 +265,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element,
      *  returning intersection point in global coordinates via reference 
      */ 
-    int intersectionWithDetElement( int detElementID, edm4hep::ConstTrackerHit& hit, edm4hep::Vector3d& point, int mode=modeClosest )  ;
+    int intersectionWithDetElement( int detElementID, edm4hep::TrackerHit& hit, edm4hep::Vector3d& point, int mode=modeClosest )  ;
     
     /** extrapolate the fit at the measurement site, to sensitive detector element,
      *  returning intersection point in global coordinates via reference 
@@ -297,7 +297,7 @@ namespace MarlinTrk{
     
     /** get the measurement site associated with the given lcio TrackerHit trkhit
      */
-    int getSiteFromLCIOHit( edm4hep::ConstTrackerHit& trkhit, TKalTrackSite*& site ) const ;
+    int getSiteFromLCIOHit( edm4hep::TrackerHit& trkhit, TKalTrackSite*& site ) const ;
     
     
     
@@ -314,13 +314,13 @@ namespace MarlinTrk{
     
     TKalTrack* _kaltrack;
     
-    std::vector<edm4hep::ConstTrackerHit> _lcioHits ; 
+    std::vector<edm4hep::TrackerHit> _lcioHits ; 
     
     TObjArray* _kalhits;
     
     MarlinKalTest* _ktest;
   
-    edm4hep::ConstTrackerHit _trackHitAtPositiveNDF;
+    edm4hep::TrackerHit _trackHitAtPositiveNDF;
     int _hitIndexAtPositiveNDF;
     
     /** used to store whether initial track state has been supplied or created 
@@ -338,23 +338,23 @@ namespace MarlinTrk{
     
     /** map to store relation between lcio hits and measurement sites
      */
-    std::map<edm4hep::ConstTrackerHit, TKalTrackSite*> _hit_used_for_sites ;
+    std::map<edm4hep::TrackerHit, TKalTrackSite*> _hit_used_for_sites ;
   
     /** map to store relation between lcio hits kaltest hits
      */
-    std::map<edm4hep::ConstTrackerHit, ILDVTrackHit*> _lcio_hits_to_kaltest_hits ;
+    std::map<edm4hep::TrackerHit, ILDVTrackHit*> _lcio_hits_to_kaltest_hits ;
     
     /** vector to store lcio hits rejected for measurement sites
      */
-    std::vector<edm4hep::ConstTrackerHit> _hit_not_used_for_sites ;
+    std::vector<edm4hep::TrackerHit> _hit_not_used_for_sites ;
     
     /** vector to store the chi-sqaure increment for measurement sites
      */
-    std::vector< std::pair<edm4hep::ConstTrackerHit, double> > _hit_chi2_values ;
+    std::vector< std::pair<edm4hep::TrackerHit, double> > _hit_chi2_values ;
     
     /** vector to store the chi-sqaure increment for measurement sites
      */
-    std::vector< std::pair<edm4hep::ConstTrackerHit, double> > _outlier_chi2_values ;
+    std::vector< std::pair<edm4hep::TrackerHit, double> > _outlier_chi2_values ;
     
   } ;
 }

--- a/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
+++ b/Simulation/DetSimAna/src/Edm4hepWriterAnaElemTool.cpp
@@ -421,7 +421,7 @@ Edm4hepWriterAnaElemTool::PostUserTrackingAction(const G4Track* track) {
                     // create secondaries in MC particles
                     // todo: convert the const collection to non-const
                     // auto mcCol = const_cast<edm4hep::MCParticleCollection*>(m_mcParCol.get());
-                    edm4hep::MCParticle mcp = mcCol->create();
+                    auto mcp = mcCol->create();
                     mcp.setPDG(secparticle->GetPDGEncoding());
                     mcp.setGeneratorStatus(0); // not created by Generator
                     mcp.setCreatedInSimulation(1);

--- a/Utilities/DataHelper/include/DataHelper/Navigation.h
+++ b/Utilities/DataHelper/include/DataHelper/Navigation.h
@@ -17,9 +17,9 @@ class Navigation{
   void AddTrackerHitCollection(const edm4hep::TrackerHitCollection* col){m_hitColVec.push_back(col);};
   void AddTrackerAssociationCollection(const edm4hep::MCRecoTrackerAssociationCollection* col){m_assColVec.push_back(col);};
 
-  edm4hep::ConstTrackerHit GetTrackerHit(const edm4hep::ObjectID& id, bool delete_by_caller=true);
-  std::vector<edm4hep::ConstSimTrackerHit> GetRelatedTrackerHit(const edm4hep::ObjectID& id);
-  std::vector<edm4hep::ConstSimTrackerHit> GetRelatedTrackerHit(const edm4hep::TrackerHit& hit);
+  edm4hep::TrackerHit GetTrackerHit(const edm4hep::ObjectID& id, bool delete_by_caller=true);
+  std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::ObjectID& id);
+  std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::TrackerHit& hit);
   
   //static Navigation* m_fNavigation;
  private:
@@ -27,6 +27,6 @@ class Navigation{
   //DataHandle<edm4hep::MCRecoTrackerAssociationCollection> _inHitAssColHdl{"FTDStripTrackerHitsAssociation", Gaudi::DataHandle::Reader, this};
   std::vector<const edm4hep::TrackerHitCollection*> m_hitColVec;
   std::vector<const edm4hep::MCRecoTrackerAssociationCollection*> m_assColVec;
-  std::map<int, edm4hep::ConstTrackerHit> m_trkHits;
+  std::map<int, edm4hep::TrackerHit> m_trkHits;
 };
 #endif 

--- a/Utilities/DataHelper/include/DataHelper/TrackExtended.h
+++ b/Utilities/DataHelper/include/DataHelper/TrackExtended.h
@@ -4,7 +4,6 @@
 //#include "lcio.h"
 //#include "EVENT/LCIO.h"
 #include "edm4hep/Track.h"
-#include "edm4hep/TrackConst.h"
 #include <vector>
 //#include "ClusterExtended.h"
 //#include "TrackerHitExtended.h"
@@ -33,10 +32,10 @@ class TrackExtended {
 
     TrackExtended( );
     TrackExtended( TrackerHitExtended * trackerhit );
-    TrackExtended( edm4hep::ConstTrack track );
+    TrackExtended( edm4hep::Track track );
     ~TrackExtended();
     
-    edm4hep::ConstTrack getTrack();
+    edm4hep::Track getTrack();
     const float * getSeedDirection();
     const float * getSeedPosition();
     ClusterExtendedVec & getClusterVec();
@@ -96,7 +95,7 @@ class TrackExtended {
     ClusterExtended *_superCluster;
     ClusterExtendedVec _clusterVec;
     GroupTracks * _group;
-    edm4hep::ConstTrack _track;
+    edm4hep::Track _track;
     float _seedDirection[3];
     float _seedPosition[3];
     TrackerHitExtendedVec _trackerHitVector;    

--- a/Utilities/DataHelper/include/DataHelper/TrackerHitExtended.h
+++ b/Utilities/DataHelper/include/DataHelper/TrackerHitExtended.h
@@ -24,14 +24,14 @@ class TrackerHitExtended {
   
  public:
   
-  TrackerHitExtended(const edm4hep::ConstTrackerHit trackerhit);
+  TrackerHitExtended(const edm4hep::TrackerHit trackerhit);
   ~TrackerHitExtended();
   void setTrackExtended(TrackExtended * trackAR);
     void addTrackExtended(TrackExtended * trackAR);
     void setTrackerHitTo(TrackerHitExtended * hitTo);
     void setTrackerHitFrom(TrackerHitExtended * hitFrom);
     void setGenericDistance(float genericDistance);
-    //void setTrackerHit(edm4hep::ConstTrackerHit hit);
+    //void setTrackerHit(edm4hep::TrackerHit hit);
     void setYresTo(float yresTo);
     void setYresFrom(float yresFrom);
     void setDirVec(float * dirVec);
@@ -42,7 +42,7 @@ class TrackerHitExtended {
     void setDet(int idet);
     void setUsedInFit(bool usedInFit);
 
-    edm4hep::ConstTrackerHit getTrackerHit();
+    edm4hep::TrackerHit getTrackerHit();
     TrackExtended * getTrackExtended();
     TrackExtendedVec & getTrackExtendedVec();
     TrackerHitExtended * getTrackerHitFrom();
@@ -59,7 +59,7 @@ class TrackerHitExtended {
 
  private:
 
-    edm4hep::ConstTrackerHit _trackerHit;
+    edm4hep::TrackerHit _trackerHit;
     TrackExtended * _trackAR;
     TrackerHitExtended * _hitTo;
     TrackerHitExtended * _hitFrom;

--- a/Utilities/DataHelper/src/Navigation.cpp
+++ b/Utilities/DataHelper/src/Navigation.cpp
@@ -19,13 +19,13 @@ Navigation::~Navigation(){
 void Navigation::Initialize(){
   m_hitColVec.clear();
   m_assColVec.clear();
-  for(std::map<int, edm4hep::ConstTrackerHit>::iterator it=m_trkHits.begin();it!=m_trkHits.end();it++){
+  for(std::map<int, edm4hep::TrackerHit>::iterator it=m_trkHits.begin();it!=m_trkHits.end();it++){
     // delete it->second;
   }
   m_trkHits.clear();
 }
 
-edm4hep::ConstTrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_id, bool delete_by_caller){
+edm4hep::TrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_id, bool delete_by_caller){
   int id = obj_id.collectionID * 10000000 + obj_id.index;
   if(!delete_by_caller){
     if(m_trkHits.find(id)!=m_trkHits.end()) return m_trkHits[id];
@@ -47,7 +47,7 @@ edm4hep::ConstTrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_
       edm4hep::ObjectID this_id = hit.getObjectID();
       if(this_id.collectionID!=obj_id.collectionID)break;
       else if(this_id.index==obj_id.index){
-	edm4hep::ConstTrackerHit hit_copy = edm4hep::ConstTrackerHit(hit);
+	edm4hep::TrackerHit hit_copy = edm4hep::TrackerHit(hit);
 	if(!delete_by_caller) m_trkHits[id] = hit_copy;
 	return hit_copy;//&(m_trkHits[id]);
       }
@@ -57,8 +57,8 @@ edm4hep::ConstTrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_
   throw std::runtime_error("Not found TrackerHit");
 }
 
-std::vector<edm4hep::ConstSimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::ObjectID& id){
-  std::vector<edm4hep::ConstSimTrackerHit> hits;
+std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::ObjectID& id){
+  std::vector<edm4hep::SimTrackerHit> hits;
   for(int i=0;i<m_assColVec.size();i++){
     for(auto ass : *m_assColVec[i]){
       edm4hep::ObjectID this_id = ass.getRec().getObjectID();
@@ -69,8 +69,8 @@ std::vector<edm4hep::ConstSimTrackerHit> Navigation::GetRelatedTrackerHit(const 
   return hits;
 }
 
-std::vector<edm4hep::ConstSimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::TrackerHit& hit){
-  std::vector<edm4hep::ConstSimTrackerHit> hits;
+std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::TrackerHit& hit){
+  std::vector<edm4hep::SimTrackerHit> hits;
   for(int i=0;i<m_assColVec.size();i++){
     for(auto ass : *m_assColVec[i]){
       if(ass.getRec().getObjectID().collectionID != hit.getObjectID().collectionID) break;

--- a/Utilities/DataHelper/src/TrackExtended.cc
+++ b/Utilities/DataHelper/src/TrackExtended.cc
@@ -11,7 +11,7 @@ TrackExtended::TrackExtended( ) {
     _group = NULL;
 }
 
-TrackExtended::TrackExtended(ConstTrack track) {
+TrackExtended::TrackExtended(Track track) {
     _track = track;
     _superCluster = NULL;
     _trackerHitVector.clear();
@@ -32,7 +32,7 @@ TrackExtended::TrackExtended( TrackerHitExtended * trackerhit) {
 
 TrackExtended::~TrackExtended() {}
 
-ConstTrack TrackExtended::getTrack() {
+Track TrackExtended::getTrack() {
   if(!_track.isAvailable()){
     std::cout << "Error: track not available" << _track.isAvailable() << " id= " << _track.id() << std::endl;
     throw std::runtime_error("Error: track not available");

--- a/Utilities/DataHelper/src/TrackerHitExtended.cc
+++ b/Utilities/DataHelper/src/TrackerHitExtended.cc
@@ -1,7 +1,7 @@
 #include "DataHelper/TrackExtended.h"
 #include "DataHelper/TrackerHitExtended.h"
 
-TrackerHitExtended::TrackerHitExtended(const edm4hep::ConstTrackerHit trackerhit):
+TrackerHitExtended::TrackerHitExtended(const edm4hep::TrackerHit trackerhit):
   _trackerHit(trackerhit){
   _trackAR = NULL;
   _trackVecAR.clear();
@@ -41,7 +41,7 @@ void TrackerHitExtended::setGenericDistance(float genericDistance) {
     _genericDistance = genericDistance; 
 }
 
-//void TrackerHitExtended::setTrackerHit(edm4hep::ConstTrackerHit hit) {
+//void TrackerHitExtended::setTrackerHit(edm4hep::TrackerHit hit) {
 //    _trackerHit = hit;
 //}
 
@@ -67,7 +67,7 @@ void TrackerHitExtended::setDet(int idet) {
     _idet = idet;
 }
 
-edm4hep::ConstTrackerHit TrackerHitExtended::getTrackerHit() {
+edm4hep::TrackerHit TrackerHitExtended::getTrackerHit() {
     return _trackerHit;
 }
 

--- a/Utilities/KalDet/include/kaldet/ILDConeMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDConeMeasLayer.h
@@ -60,7 +60,7 @@ public:
    Bool_t IsOnSurface(const TVector3 &xx) const;
 
    /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
-   virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+   virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
       
       /* streamlog_out( ERROR ) << "Don't use this, it's not implemented!"; */
       return NULL;

--- a/Utilities/KalDet/include/kaldet/ILDCylinderHit.h
+++ b/Utilities/KalDet/include/kaldet/ILDCylinderHit.h
@@ -17,7 +17,7 @@ public:
   
   /** Constructor Taking R and Rphi coordinates and associated measurement layer, with bfield */
   ILDCylinderHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-                 Double_t bfield, edm4hep::ConstTrackerHit trkhit ) 
+                 Double_t bfield, edm4hep::TrackerHit trkhit ) 
   : ILDVTrackHit(ms, x, dx, bfield, 2, trkhit)
   { /* no op */ } 
     

--- a/Utilities/KalDet/include/kaldet/ILDCylinderMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDCylinderMeasLayer.h
@@ -71,7 +71,7 @@ public:
                                 TKalMatrix &H)    const;
   
   /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
   /** Get the intersection and the CellID, needed for multilayers */
   virtual int getIntersectionAndCellID(const TVTrack  &hel,

--- a/Utilities/KalDet/include/kaldet/ILDDiscMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDDiscMeasLayer.h
@@ -70,7 +70,7 @@ public:
     
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
   /** Check if global point is on surface  */
   inline virtual Bool_t   IsOnSurface (const TVector3 &xx) const;

--- a/Utilities/KalDet/include/kaldet/ILDParallelPlanarStripMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDParallelPlanarStripMeasLayer.h
@@ -50,7 +50,7 @@ public:
   
   void CalcDhDa(const TVTrackHit &vht, const TVector3   &xxv, const TKalMatrix &dxphiada, TKalMatrix &H)  const;
     
-  ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const;
+  ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const;
   
 private:
   

--- a/Utilities/KalDet/include/kaldet/ILDPlanarHit.h
+++ b/Utilities/KalDet/include/kaldet/ILDPlanarHit.h
@@ -21,7 +21,7 @@ public:
                Double_t           *x,
                Double_t           *dx,
                Double_t           bfield,
-               edm4hep::ConstTrackerHit trkhit) 
+               edm4hep::TrackerHit trkhit) 
   : ILDVTrackHit(ms, x, dx, bfield, ILDPlanarHit_DIM,trkhit)
   { /* no op */ } 
   

--- a/Utilities/KalDet/include/kaldet/ILDPlanarMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDPlanarMeasLayer.h
@@ -63,7 +63,7 @@ public:
                                 const TKalMatrix &dxphiada,
                                 TKalMatrix &H)  const;
   
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
   virtual Bool_t   IsOnSurface (const TVector3 &xx) const;
   

--- a/Utilities/KalDet/include/kaldet/ILDPlanarStripHit.h
+++ b/Utilities/KalDet/include/kaldet/ILDPlanarStripHit.h
@@ -22,7 +22,7 @@ public:
                Double_t       *x,
                Double_t       *dx,
                Double_t        bfield,
-               edm4hep::ConstTrackerHit trkhit) 
+               edm4hep::TrackerHit trkhit) 
   : ILDVTrackHit(ms, x, dx, bfield, ILDPlanarStripHit_DIM,trkhit)
   { /* no op */ } 
   

--- a/Utilities/KalDet/include/kaldet/ILDPolygonBarrelMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDPolygonBarrelMeasLayer.h
@@ -70,7 +70,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
 
   /** overloaded version of CalcXingPointWith using closed solution*/
   virtual Int_t    CalcXingPointWith(const TVTrack  &hel,

--- a/Utilities/KalDet/include/kaldet/ILDRotatedTrapMeaslayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDRotatedTrapMeaslayer.h
@@ -57,7 +57,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
   /** Check if global point is on surface  */
   inline virtual Bool_t   IsOnSurface (const TVector3 &xx) const;

--- a/Utilities/KalDet/include/kaldet/ILDSegmentedDiscMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDSegmentedDiscMeasLayer.h
@@ -77,7 +77,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
 
   /** overloaded version of CalcXingPointWith using closed solution*/
   virtual Int_t    CalcXingPointWith(const TVTrack  &hel,

--- a/Utilities/KalDet/include/kaldet/ILDSegmentedDiscStripMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDSegmentedDiscStripMeasLayer.h
@@ -67,7 +67,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
 private:
   

--- a/Utilities/KalDet/include/kaldet/ILDVMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDVMeasLayer.h
@@ -13,7 +13,7 @@
 #include "kaltest/TAttDrawable.h"
 #include "kaltest/KalTrackDim.h"
 #include "TString.h"
-#include "edm4hep/TrackerHitConst.h"
+#include "edm4hep/TrackerHit.h"
 
 #include <vector>
 
@@ -44,7 +44,7 @@ public:
   inline Double_t GetBz() const { return _Bz; }
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const = 0 ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const = 0 ;
   
   /** Check whether the measurement layer represents a series of detector elements */
   bool isMultilayer() const { return _isMultiLayer; } 

--- a/Utilities/KalDet/include/kaldet/ILDVTrackHit.h
+++ b/Utilities/KalDet/include/kaldet/ILDVTrackHit.h
@@ -19,15 +19,15 @@ public:
   
    /** Constructor Taking coordinates and associated measurement layer, with bfield and number of measurement dimentions*/
   ILDVTrackHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-               Double_t bfield , Int_t dim, edm4hep::ConstTrackerHit trkhit) 
+               Double_t bfield , Int_t dim, edm4hep::TrackerHit trkhit) 
   : TVTrackHit(ms, x, dx, bfield, dim), _trkhit(trkhit)
   { /* no op */ }
   
-  edm4hep::ConstTrackerHit getLCIOTrackerHit() const { return _trkhit; }
+  edm4hep::TrackerHit getLCIOTrackerHit() const { return _trkhit; }
   
 private:
   
-  edm4hep::ConstTrackerHit _trkhit;
+  edm4hep::TrackerHit _trkhit;
   
 };
 #endif

--- a/Utilities/KalDet/src/ild/common/ILDConeMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDConeMeasLayer.h
@@ -60,7 +60,7 @@ public:
    Bool_t IsOnSurface(const TVector3 &xx) const;
 
    /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
-   virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+   virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
       
       /* streamlog_out( ERROR ) << "Don't use this, it's not implemented!"; */
       return NULL;

--- a/Utilities/KalDet/src/ild/common/ILDCylinderHit.h
+++ b/Utilities/KalDet/src/ild/common/ILDCylinderHit.h
@@ -17,7 +17,7 @@ public:
   
   /** Constructor Taking R and Rphi coordinates and associated measurement layer, with bfield */
   ILDCylinderHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-                 Double_t bfield, edm4hep::ConstTrackerHit trkhit ) 
+                 Double_t bfield, edm4hep::TrackerHit trkhit ) 
   : ILDVTrackHit(ms, x, dx, bfield, 2, trkhit)
   { /* no op */ } 
     

--- a/Utilities/KalDet/src/ild/common/ILDCylinderMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDCylinderMeasLayer.cc
@@ -110,7 +110,7 @@ void ILDCylinderMeasLayer::CalcDhDa(const TVTrackHit &vht, // tracker hit not us
 
 /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
 
-ILDVTrackHit* ILDCylinderMeasLayer::ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+ILDVTrackHit* ILDCylinderMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
   if ( ! trkhit.isAvailable() ) {
     // streamlog_out(ERROR) << "ILDCylinderMeasLayer::ConvertLCIOTrkHit trkhit pointer is NULL" << std::endl;
     return NULL;

--- a/Utilities/KalDet/src/ild/common/ILDCylinderMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDCylinderMeasLayer.h
@@ -71,7 +71,7 @@ public:
                                 TKalMatrix &H)    const;
   
   /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
   /** Get the intersection and the CellID, needed for multilayers */
   virtual int getIntersectionAndCellID(const TVTrack  &hel,

--- a/Utilities/KalDet/src/ild/common/ILDDiscMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDDiscMeasLayer.cc
@@ -207,13 +207,13 @@ Bool_t ILDDiscMeasLayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDDiscMeasLayer::ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+ILDVTrackHit* ILDDiscMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
   
   //edm4hep::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   //edm4hep::TrackerHitPlane* plane_hit = trkhit;
   if((trkhit.getType()&8)!=8) return NULL;
   
-  //edm4hep::ConstTrackerHit plane_hit = trkhit;
+  //edm4hep::TrackerHit plane_hit = trkhit;
   //if( plane_hit == NULL )  return NULL; // SJA:FIXME: should be replaced with an exception  
   
   //gear::Vector3D U(1.0,plane_hit.getU()[1],plane_hit.getU()[0],gear::Vector3D::spherical);

--- a/Utilities/KalDet/src/ild/common/ILDDiscMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDDiscMeasLayer.h
@@ -70,7 +70,7 @@ public:
     
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
   /** Check if global point is on surface  */
   inline virtual Bool_t   IsOnSurface (const TVector3 &xx) const;

--- a/Utilities/KalDet/src/ild/common/ILDParallelPlanarStripMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDParallelPlanarStripMeasLayer.cc
@@ -162,7 +162,7 @@ void ILDParallelPlanarStripMeasLayer::CalcDhDa(const TVTrackHit &vht,
   
 }
 
-ILDVTrackHit* ILDParallelPlanarStripMeasLayer::ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+ILDVTrackHit* ILDParallelPlanarStripMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
   
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8) {

--- a/Utilities/KalDet/src/ild/common/ILDParallelPlanarStripMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDParallelPlanarStripMeasLayer.h
@@ -50,7 +50,7 @@ public:
   
   void CalcDhDa(const TVTrackHit &vht, const TVector3   &xxv, const TKalMatrix &dxphiada, TKalMatrix &H)  const;
     
-  ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const;
+  ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const;
   
 private:
   

--- a/Utilities/KalDet/src/ild/common/ILDPlanarHit.h
+++ b/Utilities/KalDet/src/ild/common/ILDPlanarHit.h
@@ -21,7 +21,7 @@ public:
                Double_t           *x,
                Double_t           *dx,
                Double_t           bfield,
-               edm4hep::ConstTrackerHit trkhit) 
+               edm4hep::TrackerHit trkhit) 
   : ILDVTrackHit(ms, x, dx, bfield, ILDPlanarHit_DIM,trkhit)
   { /* no op */ } 
   

--- a/Utilities/KalDet/src/ild/common/ILDPlanarMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDPlanarMeasLayer.cc
@@ -244,7 +244,7 @@ Bool_t ILDPlanarMeasLayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDPlanarMeasLayer::ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+ILDVTrackHit* ILDPlanarMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
   //std::cout << "ILDPlanarMeasLayer::ConvertLCIOTrkHit " << trkhit << " type=" << trkhit.getType() << std::endl;
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8){

--- a/Utilities/KalDet/src/ild/common/ILDPlanarMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDPlanarMeasLayer.h
@@ -63,7 +63,7 @@ public:
                                 const TKalMatrix &dxphiada,
                                 TKalMatrix &H)  const;
   
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
   virtual Bool_t   IsOnSurface (const TVector3 &xx) const;
   

--- a/Utilities/KalDet/src/ild/common/ILDPlanarStripHit.h
+++ b/Utilities/KalDet/src/ild/common/ILDPlanarStripHit.h
@@ -22,7 +22,7 @@ public:
                Double_t       *x,
                Double_t       *dx,
                Double_t        bfield,
-               edm4hep::ConstTrackerHit trkhit) 
+               edm4hep::TrackerHit trkhit) 
   : ILDVTrackHit(ms, x, dx, bfield, ILDPlanarStripHit_DIM,trkhit)
   { /* no op */ } 
   

--- a/Utilities/KalDet/src/ild/common/ILDPolygonBarrelMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDPolygonBarrelMeasLayer.cc
@@ -136,7 +136,7 @@ Bool_t ILDPolygonBarrelMeasLayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDPolygonBarrelMeasLayer::ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+ILDVTrackHit* ILDPolygonBarrelMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
   
   // streamlog_out(ERROR) << "ILDPolygonBarrelMeasLayer::ConvertLCIOTrkHit Not implemented: exit(1) called from " << __FILE__ << "   line " << __LINE__ << std::endl; 
   exit(1);

--- a/Utilities/KalDet/src/ild/common/ILDPolygonBarrelMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDPolygonBarrelMeasLayer.h
@@ -70,7 +70,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
 
   /** overloaded version of CalcXingPointWith using closed solution*/
   virtual Int_t    CalcXingPointWith(const TVTrack  &hel,

--- a/Utilities/KalDet/src/ild/common/ILDRotatedTrapMeaslayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDRotatedTrapMeaslayer.cc
@@ -155,7 +155,7 @@ Bool_t ILDRotatedTrapMeaslayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDRotatedTrapMeaslayer::ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+ILDVTrackHit* ILDRotatedTrapMeaslayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
   
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8) return NULL;

--- a/Utilities/KalDet/src/ild/common/ILDRotatedTrapMeaslayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDRotatedTrapMeaslayer.h
@@ -57,7 +57,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
   /** Check if global point is on surface  */
   inline virtual Bool_t   IsOnSurface (const TVector3 &xx) const;

--- a/Utilities/KalDet/src/ild/common/ILDSegmentedDiscMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDSegmentedDiscMeasLayer.cc
@@ -193,7 +193,7 @@ TVector3 ILDSegmentedDiscMeasLayer::HitToXv(const TVTrackHit &vht) const
 //  double z = this->GetXc().Z() ;
 
   UTIL::BitField64 encoder( lcio::ILDCellID0::encoder_string ) ;
-  edm4hep::ConstTrackerHit hit = mv.getLCIOTrackerHit();
+  edm4hep::TrackerHit hit = mv.getLCIOTrackerHit();
   encoder.setValue(hit.getCellID());
   int segmentIndex = encoder[lcio::ILDCellID0::module] / 2 ;
   
@@ -495,7 +495,7 @@ Bool_t ILDSegmentedDiscMeasLayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDSegmentedDiscMeasLayer::ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+ILDVTrackHit* ILDSegmentedDiscMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8) {
   //if( plane_hit == NULL )  { 

--- a/Utilities/KalDet/src/ild/common/ILDSegmentedDiscMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDSegmentedDiscMeasLayer.h
@@ -77,7 +77,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
 
   /** overloaded version of CalcXingPointWith using closed solution*/
   virtual Int_t    CalcXingPointWith(const TVTrack  &hel,

--- a/Utilities/KalDet/src/ild/common/ILDSegmentedDiscStripMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDSegmentedDiscStripMeasLayer.cc
@@ -115,7 +115,7 @@ TVector3 ILDSegmentedDiscStripMeasLayer::HitToXv(const TVTrackHit &vht) const
   const ILDPlanarStripHit &mv = dynamic_cast<const ILDPlanarStripHit &>(vht);
   
   UTIL::BitField64 encoder( lcio::ILDCellID0::encoder_string ) ;
-  edm4hep::ConstTrackerHit hit = mv.getLCIOTrackerHit();
+  edm4hep::TrackerHit hit = mv.getLCIOTrackerHit();
   encoder.setValue(hit.getCellID());
   int segmentIndex = encoder[lcio::ILDCellID0::module] / 2 ;
   
@@ -242,7 +242,7 @@ void ILDSegmentedDiscStripMeasLayer::CalcDhDa(const TVTrackHit &vht,
 
 
 
-ILDVTrackHit* ILDSegmentedDiscStripMeasLayer::ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const {
+ILDVTrackHit* ILDSegmentedDiscStripMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
   
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8){

--- a/Utilities/KalDet/src/ild/common/ILDSegmentedDiscStripMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDSegmentedDiscStripMeasLayer.h
@@ -67,7 +67,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
   
 private:
   

--- a/Utilities/KalDet/src/ild/common/ILDVMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDVMeasLayer.h
@@ -13,7 +13,7 @@
 #include "kaltest/TAttDrawable.h"
 #include "kaltest/KalTrackDim.h"
 #include "TString.h"
-#include "edm4hep/TrackerHitConst.h"
+#include "edm4hep/TrackerHit.h"
 
 #include <vector>
 
@@ -44,7 +44,7 @@ public:
   inline Double_t GetBz() const { return _Bz; }
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::ConstTrackerHit trkhit) const = 0 ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const = 0 ;
   
   /** Check whether the measurement layer represents a series of detector elements */
   bool isMultilayer() const { return _isMultiLayer; } 

--- a/Utilities/KalDet/src/ild/common/ILDVTrackHit.h
+++ b/Utilities/KalDet/src/ild/common/ILDVTrackHit.h
@@ -19,15 +19,15 @@ public:
   
    /** Constructor Taking coordinates and associated measurement layer, with bfield and number of measurement dimentions*/
   ILDVTrackHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-               Double_t bfield , Int_t dim, edm4hep::ConstTrackerHit trkhit) 
+               Double_t bfield , Int_t dim, edm4hep::TrackerHit trkhit) 
   : TVTrackHit(ms, x, dx, bfield, dim), _trkhit(trkhit)
   { /* no op */ }
   
-  edm4hep::ConstTrackerHit getLCIOTrackerHit() const { return _trkhit; }
+  edm4hep::TrackerHit getLCIOTrackerHit() const { return _trkhit; }
   
 private:
   
-  edm4hep::ConstTrackerHit _trkhit;
+  edm4hep::TrackerHit _trkhit;
   
 };
 #endif

--- a/Utilities/KiTrack/include/ILDImpl/FTDHit01.h
+++ b/Utilities/KiTrack/include/ILDImpl/FTDHit01.h
@@ -14,7 +14,7 @@ namespace KiTrackMarlin{
   class FTDHit01 : public IFTDHit{
   public:
       
-    FTDHit01( edm4hep::ConstTrackerHit trackerHit , const SectorSystemFTD* const sectorSystemFTD );
+    FTDHit01( edm4hep::TrackerHit trackerHit , const SectorSystemFTD* const sectorSystemFTD );
   };
 }
 #endif

--- a/Utilities/KiTrack/include/ILDImpl/FTDTrack.h
+++ b/Utilities/KiTrack/include/ILDImpl/FTDTrack.h
@@ -5,6 +5,7 @@
 //#include "MarlinTrk/IMarlinTrkSystem.h"
 //#include "MarlinTrk/IMarlinTrack.h"
 #include "edm4hep/Track.h"
+#include "edm4hep/MutableTrack.h"
 #include "TrackSystemSvc/IMarlinTrkSystem.h"
 
 #include <vector>
@@ -33,7 +34,7 @@ namespace KiTrackMarlin{
         
     /** @return a track in the lcio format
      */
-    edm4hep::Track* getLcioTrack(){ return ( _lcioTrack );}
+    edm4hep::MutableTrack* getLcioTrack(){ return ( _lcioTrack );}
         
     void addHit( IFTDHit* hit );
     
@@ -58,7 +59,7 @@ namespace KiTrackMarlin{
      */
     std::vector< IFTDHit* > _hits;
       
-    edm4hep::Track*  _lcioTrack;
+    edm4hep::MutableTrack*  _lcioTrack;
     
     // for fitting
     MarlinTrk::IMarlinTrkSystem* _trkSystem;

--- a/Utilities/KiTrack/include/ILDImpl/IFTDHit.h
+++ b/Utilities/KiTrack/include/ILDImpl/IFTDHit.h
@@ -16,7 +16,7 @@ namespace KiTrackMarlin{
   class IFTDHit : public IHit{
   public:
         
-    edm4hep::ConstTrackerHit* getTrackerHit() { return &_trackerHit; };
+    edm4hep::TrackerHit* getTrackerHit() { return &_trackerHit; };
             
     int getSide() { return _side; }
     unsigned getModule() { return _module; }
@@ -31,7 +31,7 @@ namespace KiTrackMarlin{
     
   protected:
     
-    edm4hep::ConstTrackerHit _trackerHit;
+    edm4hep::TrackerHit _trackerHit;
             
     int _side;
     unsigned _layer;

--- a/Utilities/KiTrack/include/Tools/FTDHelixFitter.h
+++ b/Utilities/KiTrack/include/Tools/FTDHelixFitter.h
@@ -2,7 +2,8 @@
 #define FTDHelixFitter_h
 
 #include "edm4hep/Track.h"
-#include "edm4hep/TrackerHitConst.h"
+#include "edm4hep/MutableTrack.h"
+#include "edm4hep/TrackerHit.h"
 
 class FTDHelixFitterException : public std::exception {
  protected:
@@ -32,8 +33,8 @@ class FTDHelixFitterException : public std::exception {
 class FTDHelixFitter{
  public:
    
-  FTDHelixFitter( edm4hep::Track* track ) ;
-  FTDHelixFitter( std::vector<edm4hep::ConstTrackerHit> trackerHits ) ;
+  FTDHelixFitter( edm4hep::MutableTrack* track ) ;
+  FTDHelixFitter( std::vector<edm4hep::TrackerHit> trackerHits ) ;
    
    
    double getChi2(){ return _chi2; }
@@ -58,7 +59,7 @@ class FTDHelixFitter{
    float _d0;
    float _z0;
    
-   std::vector< edm4hep::ConstTrackerHit > _trackerHits;
+   std::vector< edm4hep::TrackerHit > _trackerHits;
      
 };
 

--- a/Utilities/KiTrack/include/Tools/Fitter.h
+++ b/Utilities/KiTrack/include/Tools/Fitter.h
@@ -4,6 +4,7 @@
 #include "TrackSystemSvc/IMarlinTrkSystem.h"
 #include "TrackSystemSvc/IMarlinTrack.h"
 #include "edm4hep/Track.h"
+#include "edm4hep/MutableTrack.h"
 //#include "lcio.h"
 
 #include "Math/ProbFunc.h"
@@ -69,9 +70,9 @@ class Fitter{
    
 public:
    
-  Fitter( edm4hep::Track* track , MarlinTrk::IMarlinTrkSystem* trkSystem );
-  Fitter( std::vector < edm4hep::ConstTrackerHit > trackerHits, MarlinTrk::IMarlinTrkSystem* trkSystem );
-  Fitter( edm4hep::Track* track , MarlinTrk::IMarlinTrkSystem* trkSystem, int VXDFlag );  
+  Fitter( edm4hep::MutableTrack* track , MarlinTrk::IMarlinTrkSystem* trkSystem );
+  Fitter( std::vector < edm4hep::TrackerHit > trackerHits, MarlinTrk::IMarlinTrkSystem* trkSystem );
+  Fitter( edm4hep::MutableTrack* track , MarlinTrk::IMarlinTrkSystem* trkSystem, int VXDFlag );  
 
    
    double getChi2Prob( int trackStateLocation ) ;
@@ -110,7 +111,7 @@ private:
    static float _bField;
    
    
-   std::vector< edm4hep::ConstTrackerHit > _trackerHits;
+   std::vector< edm4hep::TrackerHit > _trackerHits;
    
    /** here the created TrackStates (plus) are stored */
    std::vector< const TrackStatePlus* > _trackStatesPlus;

--- a/Utilities/KiTrack/include/Tools/KiTrackMarlinTools.h
+++ b/Utilities/KiTrack/include/Tools/KiTrackMarlinTools.h
@@ -62,8 +62,8 @@ void saveToRoot( std::string rootFileName, std::string treeName , std::vector < 
  * 
  * @return true if |a.z| < |b.z| , i.e. true if a is nearer to z=0 than b is
  */
-//bool compare_TrackerHit_z( edm4hep::ConstTrackerHit* a, edm4hep::ConstTrackerHit* b );
-bool compare_TrackerHit_z( edm4hep::ConstTrackerHit& a, edm4hep::ConstTrackerHit& b );
+//bool compare_TrackerHit_z( edm4hep::TrackerHit* a, edm4hep::TrackerHit* b );
+bool compare_TrackerHit_z( edm4hep::TrackerHit& a, edm4hep::TrackerHit& b );
 
 /** method that compares two TrackerHits.
  * 
@@ -71,7 +71,7 @@ bool compare_TrackerHit_z( edm4hep::ConstTrackerHit& a, edm4hep::ConstTrackerHit
  *
  * to be used at the VXD-SIT system
  */
-bool compare_TrackerHit_R( edm4hep::ConstTrackerHit& a, edm4hep::ConstTrackerHit& b );
+bool compare_TrackerHit_R( edm4hep::TrackerHit& a, edm4hep::TrackerHit& b );
 
 
 FTDHitSimple* createVirtualIPHit( int side , const SectorSystemFTD* sectorSystemFTD );
@@ -79,7 +79,7 @@ FTDHitSimple* createVirtualIPHit( int side , const SectorSystemFTD* sectorSystem
 VXDHitSimple* createVirtualIPHit( const SectorSystemVXD* sectorSystemVXD );
 
 
-std::string getPositionInfo( edm4hep::ConstTrackerHit hit );
+std::string getPositionInfo( edm4hep::TrackerHit hit );
 
 std::string getPositionInfo( IHit* hit );   
 

--- a/Utilities/KiTrack/src/ILDImpl/FTDHit01.cc
+++ b/Utilities/KiTrack/src/ILDImpl/FTDHit01.cc
@@ -6,7 +6,7 @@
 using namespace KiTrackMarlin;
 
 
-FTDHit01::FTDHit01( edm4hep::ConstTrackerHit trackerHit , const SectorSystemFTD* const sectorSystemFTD ){
+FTDHit01::FTDHit01( edm4hep::TrackerHit trackerHit , const SectorSystemFTD* const sectorSystemFTD ){
    
    
    _sectorSystemFTD = sectorSystemFTD;

--- a/Utilities/KiTrack/src/ILDImpl/FTDTrack.cc
+++ b/Utilities/KiTrack/src/ILDImpl/FTDTrack.cc
@@ -27,7 +27,7 @@ FTDTrack::FTDTrack( MarlinTrk::IMarlinTrkSystem* trkSystem ){
    _trkSystem = trkSystem;
    _chi2Prob = 0.;
  
-   _lcioTrack = new edm4hep::Track();
+   _lcioTrack = new edm4hep::MutableTrack();
    
    
 }
@@ -38,7 +38,7 @@ FTDTrack::FTDTrack( std::vector< IFTDHit* > hits , MarlinTrk::IMarlinTrkSystem* 
    _trkSystem = trkSystem;
    _chi2Prob = 0.;
    
-   _lcioTrack = new edm4hep::Track();
+   _lcioTrack = new edm4hep::MutableTrack();
    
    for( unsigned i=0; i < hits.size(); i++ ){
       
@@ -53,7 +53,7 @@ FTDTrack::FTDTrack( std::vector< IFTDHit* > hits , MarlinTrk::IMarlinTrkSystem* 
 FTDTrack::FTDTrack( const FTDTrack& f ){
 
    //make a new copied lcio track
-  _lcioTrack = new edm4hep::Track( *f._lcioTrack );
+  _lcioTrack = new edm4hep::MutableTrack( *f._lcioTrack );
    
    
    _hits = f._hits;
@@ -67,7 +67,7 @@ FTDTrack & FTDTrack::operator= (const FTDTrack & f){
    if (this == &f) return *this;   //protect against self assignment
    
    //make a new copied lcio track
-   _lcioTrack = new edm4hep::Track( *f._lcioTrack );
+   _lcioTrack = new edm4hep::MutableTrack( *f._lcioTrack );
    
    
    _hits = f._hits;

--- a/Utilities/KiTrack/src/ILDImpl/VXDTrack.cc
+++ b/Utilities/KiTrack/src/ILDImpl/VXDTrack.cc
@@ -30,7 +30,7 @@ VXDTrack::VXDTrack( MarlinTrk::IMarlinTrkSystem* trkSystem ){
    _trkSystem = trkSystem;
    _chi2Prob = 0.;
  
-   _lcioTrack = new edm4hep::Track();
+   _lcioTrack = new edm4hep::MutableTrack();
    
 }
 /*
@@ -58,7 +58,7 @@ VXDTrack::VXDTrack( std::vector< IMiniVector* > hits , MarlinTrk::IMarlinTrkSyst
    _trkSystem = trkSystem;
    _chi2Prob = 0.;
    
-   _lcioTrack = new edm4hep::Track();
+   _lcioTrack = new edm4hep::MutableTrack();
    
    for( unsigned i=0; i < hits.size(); i++ ){
       
@@ -75,7 +75,7 @@ VXDTrack::VXDTrack( std::vector< IMiniVector* > hits , MarlinTrk::IMarlinTrkSyst
 VXDTrack::VXDTrack( const VXDTrack& f ){
 
    //make a new copied lcio track
-  _lcioTrack = new edm4hep::Track( *f._lcioTrack );
+  _lcioTrack = new edm4hep::MutableTrack( *f._lcioTrack );
    
    
    _hits = f._hits;
@@ -89,7 +89,7 @@ VXDTrack & VXDTrack::operator= (const VXDTrack & f){
    if (this == &f) return *this;   //protect against self assignment
    
    //make a new copied lcio track
-   _lcioTrack = new edm4hep::Track( *f._lcioTrack );
+   _lcioTrack = new edm4hep::MutableTrack( *f._lcioTrack );
    
    
    _hits = f._hits;

--- a/Utilities/KiTrack/src/ILDImpl/VXDTrack.h
+++ b/Utilities/KiTrack/src/ILDImpl/VXDTrack.h
@@ -2,6 +2,7 @@
 #define VXDTrack_h
 
 #include "edm4hep/Track.h"
+#include "edm4hep/MutableTrack.h"
 #include "edm4hep/TrackerHit.h"
 #include "TrackSystemSvc/IMarlinTrkSystem.h"
 #include "TrackSystemSvc/IMarlinTrack.h"
@@ -41,7 +42,7 @@ namespace KiTrackMarlin{
           
     /** @return a track in the lcio format
      */
-    edm4hep::Track* getLcioTrack(){ return ( _lcioTrack );}
+    edm4hep::MutableTrack* getLcioTrack(){ return ( _lcioTrack );}
     
     //void addHit( IVXDHit* hit );
     void addHit( IMiniVector* MV );
@@ -76,7 +77,7 @@ namespace KiTrackMarlin{
     //std::vector< IVXDHit* > _hits;
     std::vector< IMiniVector* > _hits;     
       
-    edm4hep::Track* _lcioTrack;
+    edm4hep::MutableTrack* _lcioTrack;
       
     // for fitting
     MarlinTrk::IMarlinTrkSystem* _trkSystem;

--- a/Utilities/KiTrack/src/Tools/FTDHelixFitter.cc
+++ b/Utilities/KiTrack/src/Tools/FTDHelixFitter.cc
@@ -14,17 +14,17 @@
 #include "Tools/KiTrackMarlinTools.h"
 
 
-FTDHelixFitter::FTDHelixFitter( std::vector<edm4hep::ConstTrackerHit> trackerHits ){
+FTDHelixFitter::FTDHelixFitter( std::vector<edm4hep::TrackerHit> trackerHits ){
   _trackerHits = trackerHits;
   fit();
 }
 
-FTDHelixFitter::FTDHelixFitter( edm4hep::Track* track ){
+FTDHelixFitter::FTDHelixFitter( edm4hep::MutableTrack* track ){
   _trackerHits.clear();
   //int nHits = track->trackerHits_size();
   std::copy(track->trackerHits_begin(), track->trackerHits_end(), std::back_inserter(_trackerHits));
   //for(int i=0;i<nHits;i++){
-  //  edm4hep::ConstTrackerHit hit = &track->getTrackerHits(i);
+  //  edm4hep::TrackerHit hit = &track->getTrackerHits(i);
   //  _trackerHits.push_back(hit);
   //}
   fit();
@@ -57,7 +57,7 @@ void FTDHelixFitter::fit(){
   float epar[15];
   
   for( int i=0; i<nHits; i++ ){
-    edm4hep::ConstTrackerHit hit = _trackerHits[i];
+    edm4hep::TrackerHit hit = _trackerHits[i];
       
     xh[i] = hit.getPosition()[0];
     yh[i] = hit.getPosition()[1];

--- a/Utilities/KiTrack/src/Tools/Fitter.cc
+++ b/Utilities/KiTrack/src/Tools/Fitter.cc
@@ -13,7 +13,7 @@
 #include "DataHelper/Navigation.h"
 #include "Tools/KiTrackMarlinTools.h"
 
-typedef std::vector<edm4hep::ConstTrackerHit> TrackerHitVec;
+typedef std::vector<edm4hep::TrackerHit> TrackerHitVec;
 using namespace MarlinTrk;
 
 // by fucd: 3.5->3.0 default, will be read from GeomSvc
@@ -33,18 +33,18 @@ void Fitter::init_BField(){
 
 }
 
-bool compare_TrackerHit_z( edm4hep::ConstTrackerHit a, edm4hep::ConstTrackerHit b ){
+bool compare_TrackerHit_z( edm4hep::TrackerHit a, edm4hep::TrackerHit b ){
   return ( fabs(a.getPosition()[2]) < fabs( b.getPosition()[2]) ); //compare their z values
 }
 
-bool compare_TrackerHit_R( edm4hep::ConstTrackerHit a, edm4hep::ConstTrackerHit b ){
+bool compare_TrackerHit_R( edm4hep::TrackerHit a, edm4hep::TrackerHit b ){
   double Rad_a2 = (a.getPosition()[0]*a.getPosition()[0]) + (a.getPosition()[1]*a.getPosition()[1]) ;
   double Rad_b2 = (b.getPosition()[0]*b.getPosition()[0]) + (b.getPosition()[1]*b.getPosition()[1]) ;
   
   return ( Rad_a2 < Rad_b2 ); //compare their radii
 }
 
-Fitter::Fitter( edm4hep::Track* track , MarlinTrk::IMarlinTrkSystem* trkSystem ): _trkSystem( trkSystem ){
+Fitter::Fitter( edm4hep::MutableTrack* track , MarlinTrk::IMarlinTrkSystem* trkSystem ): _trkSystem( trkSystem ){
   _trackerHits.clear();
 
   std::copy(track->trackerHits_begin(), track->trackerHits_end(), std::back_inserter(_trackerHits));
@@ -53,14 +53,14 @@ Fitter::Fitter( edm4hep::Track* track , MarlinTrk::IMarlinTrkSystem* trkSystem )
   fit();
 }
 
-Fitter::Fitter( edm4hep::Track* track , MarlinTrk::IMarlinTrkSystem* trkSystem, int VXDFlag ): _trkSystem( trkSystem ){
+Fitter::Fitter( edm4hep::MutableTrack* track , MarlinTrk::IMarlinTrkSystem* trkSystem, int VXDFlag ): _trkSystem( trkSystem ){
   _trackerHits.clear();
   std::copy(track->trackerHits_begin(), track->trackerHits_end(), std::back_inserter(_trackerHits));
   //_trackerHits = track->getTrackerHits();
   fitVXD();
 }
 
-Fitter::Fitter( std::vector<edm4hep::ConstTrackerHit> trackerHits , MarlinTrk::IMarlinTrkSystem* trkSystem ): _trkSystem( trkSystem ){
+Fitter::Fitter( std::vector<edm4hep::TrackerHit> trackerHits , MarlinTrk::IMarlinTrkSystem* trkSystem ): _trkSystem( trkSystem ){
   _trackerHits = trackerHits;
   fit();
 }
@@ -84,21 +84,21 @@ void Fitter::fitVXD(){
      
   unsigned number_of_added_hits = 0;
   unsigned ndof_added = 0;
-  std::vector< edm4hep::ConstTrackerHit > added_hits;
-  std::vector< edm4hep::ConstTrackerHit > added_hits_2D;
+  std::vector< edm4hep::TrackerHit > added_hits;
+  std::vector< edm4hep::TrackerHit > added_hits_2D;
   
   for( it = _trackerHits.begin() ; it != _trackerHits.end() ; ++it ) {
-    edm4hep::ConstTrackerHit trkHit = Navigation::Instance()->GetTrackerHit((*it).getObjectID());
+    edm4hep::TrackerHit trkHit = Navigation::Instance()->GetTrackerHit((*it).getObjectID());
     bool isSuccessful = false; 
     
     if( UTIL::BitSet32( trkHit.getType() )[ UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT ]   ){ //it is a composite spacepoint
       //Split it up and hits to the MarlinTrk
-      std::vector< edm4hep::ConstTrackerHit > rawHits;
+      std::vector< edm4hep::TrackerHit > rawHits;
       //const LCObjectVec rawObjects = trkHit.getRawHits();
       //for( unsigned k=0; k<rawObjects.size(); k++ ) rawHits.push_back( dynamic_cast< ConstTrackerHit >( rawObjects[k] ) );
       int nRawHit = trkHit.rawHits_size();
       for( unsigned k=0; k< nRawHit; k++ ){
-	edm4hep::ConstTrackerHit rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
+	edm4hep::TrackerHit rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
 	rawHits.push_back(rawHit);
       }
       std::sort( rawHits.begin(), rawHits.end(), compare_TrackerHit_R );
@@ -223,7 +223,7 @@ void Fitter::fitVXD(){
   
   // fitting finished get hits in the fit for safety checks:
   
-  std::vector<std::pair<edm4hep::ConstTrackerHit, double> > hits_in_fit;
+  std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
   
   // remember the hits are ordered in the order in which they were fitted
   // here we are fitting inwards so the first is the last and vice verse
@@ -240,13 +240,13 @@ void Fitter::fitVXD(){
     throw FitterException( s.str() );
     
   }
-  edm4hep::ConstTrackerHit first_hit_in_fit = hits_in_fit.back().first;
+  edm4hep::TrackerHit first_hit_in_fit = hits_in_fit.back().first;
   if (! first_hit_in_fit.isAvailable()) {
     throw FitterException( std::string("Fitter::fit(): TrackerHit pointer to first hit == NULL ")  ) ;
   }
   
   
-  edm4hep::ConstTrackerHit last_hit_in_fit = hits_in_fit.front().first;
+  edm4hep::TrackerHit last_hit_in_fit = hits_in_fit.front().first;
   if (!last_hit_in_fit.isAvailable()) {
     throw FitterException( std::string("Fitter::fit(): TrackerHit pointer to last hit == NULL ")  ) ;
   }
@@ -275,20 +275,20 @@ void Fitter::fit(){
   
   unsigned number_of_added_hits = 0;
   unsigned ndof_added = 0;
-  std::vector<edm4hep::ConstTrackerHit> added_hits;
+  std::vector<edm4hep::TrackerHit> added_hits;
   
   for( it = _trackerHits.begin() ; it != _trackerHits.end() ; ++it ) {
-    edm4hep::ConstTrackerHit trkHit = Navigation::Instance()->GetTrackerHit((*it).getObjectID());
+    edm4hep::TrackerHit trkHit = Navigation::Instance()->GetTrackerHit((*it).getObjectID());
     bool isSuccessful = false; 
     //std::cout << "Hit " << trkHit->id() << " " << trkHit.getPosition() << std::endl;
     if( UTIL::BitSet32( trkHit.getType() )[ UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT ]   ){ //it is a composite spacepoint
       //Split it up and hits to the MarlinTrk
-      std::vector<edm4hep::ConstTrackerHit> rawHits;
+      std::vector<edm4hep::TrackerHit> rawHits;
       //const LCObjectVec rawObjects = trkHit.getRawHits();                    
       //for( unsigned k=0; k<rawObjects.size(); k++ ) rawHits.push_back( dynamic_cast< ConstTrackerHit >( rawObjects[k] ) );
       int nRawHit = trkHit.rawHits_size();
       for( unsigned k=0; k< nRawHit; k++ ){
-	edm4hep::ConstTrackerHit rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
+	edm4hep::TrackerHit rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
 	//std::cout << "Raw Hit " << rawHit->id() << " " << rawHit.getPosition() << std::endl;
 	rawHits.push_back(rawHit);
       }
@@ -396,7 +396,7 @@ void Fitter::fit(){
   
   // fitting finished get hits in the fit for safety checks:
   
-  std::vector<std::pair<edm4hep::ConstTrackerHit, double> > hits_in_fit;
+  std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
   
   // remember the hits are ordered in the order in which they were fitted
   // here we are fitting inwards so the first is the last and vice verse
@@ -410,12 +410,12 @@ void Fitter::fit(){
     
     throw FitterException( s.str() );
   }
-  edm4hep::ConstTrackerHit first_hit_in_fit = hits_in_fit.back().first;
+  edm4hep::TrackerHit first_hit_in_fit = hits_in_fit.back().first;
   if (!first_hit_in_fit.isAvailable()) {
     throw FitterException( std::string("Fitter::fit(): TrackerHit pointer to first hit == NULL ")  ) ;
   }
   
-  edm4hep::ConstTrackerHit last_hit_in_fit = hits_in_fit.front().first;
+  edm4hep::TrackerHit last_hit_in_fit = hits_in_fit.front().first;
   if (!last_hit_in_fit.isAvailable()) {
     throw FitterException( std::string("Fitter::fit(): TrackerHit pointer to last hit == NULL ")  ) ;
   }
@@ -478,13 +478,13 @@ const TrackStatePlus* Fitter::getTrackStatePlus( int trackStateLocation ){
      }
    }
    case 2/*lcio::TrackState::AtFirstHit*/:{
-     std::vector<std::pair<edm4hep::ConstTrackerHit, double> > hits_in_fit;
+     std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
          
      // remember the hits are ordered in the order in which they were fitted
      // here we are fitting inwards so the first is the last and vice verse
      _marlinTrk->getHitsInFit(hits_in_fit);
      
-     edm4hep::ConstTrackerHit first_hit_in_fit = hits_in_fit.back().first;
+     edm4hep::TrackerHit first_hit_in_fit = hits_in_fit.back().first;
           
      return_code = _marlinTrk->getTrackState(first_hit_in_fit, *trackState, chi2, ndf ) ;
      
@@ -506,10 +506,10 @@ const TrackStatePlus* Fitter::getTrackStatePlus( int trackStateLocation ){
      }
    }
    case 3/*lcio::TrackState::AtLastHit*/:{
-     std::vector<std::pair<edm4hep::ConstTrackerHit, double> > hits_in_fit;
+     std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
      _marlinTrk->getHitsInFit(hits_in_fit);
      
-     edm4hep::ConstTrackerHit last_hit_in_fit = hits_in_fit.front().first;
+     edm4hep::TrackerHit last_hit_in_fit = hits_in_fit.front().first;
           
      return_code = _marlinTrk->getTrackState(last_hit_in_fit, *trackState, chi2, ndf ) ;
          
@@ -531,10 +531,10 @@ const TrackStatePlus* Fitter::getTrackStatePlus( int trackStateLocation ){
      break;
    }
    case 4/*lcio::TrackState::AtCalorimeter*/:{
-     std::vector<std::pair<edm4hep::ConstTrackerHit, double> > hits_in_fit;
+     std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
      _marlinTrk->getHitsInFit(hits_in_fit);
      
-     edm4hep::ConstTrackerHit last_hit_in_fit = hits_in_fit.front().first;
+     edm4hep::TrackerHit last_hit_in_fit = hits_in_fit.front().first;
           
      UTIL::BitField64 encoder( UTIL::ILDCellID0::encoder_string ) ; 
      encoder.reset() ;  // reset to 0

--- a/Utilities/KiTrack/src/Tools/KiTrackMarlinTools.cc
+++ b/Utilities/KiTrack/src/Tools/KiTrackMarlinTools.cc
@@ -150,15 +150,15 @@ void KiTrackMarlin::saveToRoot( std::string rootFileName, std::string treeName ,
 }
 
 
-//bool KiTrackMarlin::compare_TrackerHit_z( edm4hep::ConstTrackerHit a, edm4hep::ConstTrackerHit b ){
+//bool KiTrackMarlin::compare_TrackerHit_z( edm4hep::TrackerHit a, edm4hep::TrackerHit b ){
 //  return ( fabs(a.getPosition()[2]) < fabs( b.getPosition()[2]) ); //compare their z values
 //}
 
-bool KiTrackMarlin::compare_TrackerHit_z( edm4hep::ConstTrackerHit& a, edm4hep::ConstTrackerHit& b ){
+bool KiTrackMarlin::compare_TrackerHit_z( edm4hep::TrackerHit& a, edm4hep::TrackerHit& b ){
   return ( fabs(a.getPosition()[2]) < fabs( b.getPosition()[2]) );
 }
 
-bool KiTrackMarlin::compare_TrackerHit_R( edm4hep::ConstTrackerHit& a, edm4hep::ConstTrackerHit& b ){
+bool KiTrackMarlin::compare_TrackerHit_R( edm4hep::TrackerHit& a, edm4hep::TrackerHit& b ){
   double Rad_a2 = (a.getPosition()[0]*a.getPosition()[0]) + (a.getPosition()[1]*a.getPosition()[1]) ;
   double Rad_b2 = (b.getPosition()[0]*b.getPosition()[0]) + (b.getPosition()[1]*b.getPosition()[1]) ;
   
@@ -197,7 +197,7 @@ VXDHitSimple* KiTrackMarlin::createVirtualIPHit( const SectorSystemVXD* sectorSy
 }
 
 
-std::string KiTrackMarlin::getPositionInfo( edm4hep::ConstTrackerHit hit ){
+std::string KiTrackMarlin::getPositionInfo( edm4hep::TrackerHit hit ){
    
    std::stringstream info;
    
@@ -245,10 +245,10 @@ std::string KiTrackMarlin::getTrackHitInfo( ITrack* track){
 
 std::string KiTrackMarlin::getTrackHitInfo( edm4hep::Track* track){
   std::stringstream info;
-  //std::vector< edm4hep::ConstTrackerHit > hits;
+  //std::vector< edm4hep::TrackerHit > hits;
   unsigned int nHits = track->trackerHits_size();
   for(unsigned i=0; i<nHits; i++){
-    edm4hep::ConstTrackerHit hit = track->getTrackerHits(i);
+    edm4hep::TrackerHit hit = track->getTrackerHits(i);
     info << getPositionInfo(hit);
   }
    

--- a/Utilities/KiTrack/src/Tools/VXDHelixFitter.h
+++ b/Utilities/KiTrack/src/Tools/VXDHelixFitter.h
@@ -47,7 +47,7 @@ class VXDHelixFitter{
 public:
    
   VXDHelixFitter( edm4hep::Track* track ) ;
-  VXDHelixFitter( std::vector < edm4hep::ConstTrackerHit > trackerHits ) ;
+  VXDHelixFitter( std::vector < edm4hep::TrackerHit > trackerHits ) ;
    
    
    double getChi2(){ return _chi2; }
@@ -74,7 +74,7 @@ private:
    float _d0;
    float _z0;
    
-   std::vector< edm4hep::ConstTrackerHit > _trackerHits;
+   std::vector< edm4hep::TrackerHit > _trackerHits;
   
    
 };


### PR DESCRIPTION
Replace some dedicated types with  and rename others (Cluster -> MutableCluster, ConstCluster -> Cluster) to adapt to the new naming scheme introduced in AIDASoft/podio#205.

This PR includes a lot of changes and even though they are simple, it will be good to test it again. I only checked that it compiles ok. The easiest way to test is probably to merge this and run some validation with the nightlies tomorrow.

In a few places a pointer is still used to set members of a edm4hep object, which is no longer necessary I think - I kept it as is for simplicity but it could be cleaned up.