### PR TITLE
Update ECAL Barrel geometry

### DIFF
--- a/Detector/DetCRD/compact/CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml
@@ -2,10 +2,13 @@
 <lccdd>
   <define>
     <constant name="ecalbarrel_inner_radius" value="Ecal_barrel_inner_radius"/>
-    <constant name="ecalbarrel_thickness"    value="Ecal_barrel_thickness"/>    <!--Must be n*10*mm! -->
-    <constant name="ecalbarrel_zlength"      value="Ecal_barrel_half_length*2"/>   <!--Must be n*10*mm! -->
-    <constant name="bar_x" value="1*cm"/>
-    <constant name="bar_y" value="1*cm"/>
+    <constant name="ecalbarrel_thickness"    value="Ecal_barrel_thickness"/>       <!--Must be n*10*mm! -->
+    <constant name="ecalbarrel_zlength"      value="Ecal_barrel_half_length*2"/>   <!--Must be n*10*mm n*Nblock_z! -->
+    <constant name="n_symm"                  value="Ecal_barrel_symmetry" />       <!--Only support 8 and 12 now -->
+    <constant name="Nblock_z"   value="11" />
+    <constant name="Nblock_phi" value="4" />
+    <constant name="bar_x"      value="1*cm"/>
+    <constant name="bar_y"      value="1*cm"/>
   </define>
 
   <regions>
@@ -21,7 +24,7 @@
   
   <readouts>
     <readout name="EcalBarrelCollection">
-      <!-- <segmentation type="NoSegmentation"/> -->
+      <!--segmentation type="NoSegmentation"/-->
 
       <!--segmentation type="CartesianGridXYZ"
                     grid_size_x="1*cm"

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
@@ -150,13 +150,13 @@
     <constant name="Ecal_barrel_inner_radius" value="1860*mm"/><!--1900->1860, since 1900-2180 is range for symmetry=12, but now fixed as 8 in constructor code-->
     <constant name="Ecal_barrel_thickness"    value="280*mm"/>
     <constant name="Ecal_barrel_outer_radius" value="(Ecal_barrel_inner_radius+Ecal_barrel_thickness)/cos(pi/8)"/>
-    <constant name="Ecal_barrel_half_length"  value="3350*mm"/>
+    <constant name="Ecal_barrel_half_length"  value="3300*mm"/>
     <constant name="Ecal_barrel_symmetry"    value="8"/>
 
     <constant name="Ecal_endcap_inner_radius" value="350*mm"/>
     <constant name="Ecal_endcap_outer_radius" value="Ecal_barrel_inner_radius+Ecal_barrel_thickness"/>
     <constant name="Ecal_endcap_zmin"        value="3050*mm"/>
-    <constant name="Ecal_endcap_zmax"        value="3350*mm"/>
+    <constant name="Ecal_endcap_zmax"        value="3300*mm"/>
     <constant name="Ecal_endcap_symmetry"    value="8"/>
     <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
     <constant name="EcalEndcap_outer_radius" value="Ecal_barrel_outer_radius"/>

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02-onlyEcalB.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02-onlyEcalB.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+  <info name="CRD_o1_v02"
+        title="CepC reference detctor with coil inside Hcal, pixel SIT and strip SET"
+        author="C.D.Fu, "
+        url="http://cepc.ihep.ac.cn"
+        status="developing"
+        version="v02">
+    <comment>CepC reference detector simulation models used for detector study </comment>
+  </info>
+  
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="../CRD_common_v01/materials.xml"/>
+  </includes>
+  
+  <define>
+    <constant name="world_size" value="25*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+  </define>
+
+  <include ref="./CRD_Dimensions_v01_02.xml"/>
+
+  <!--include ref="../CRD_common_v01/Beampipe_v01_01.xml"/>
+  <include ref="../CRD_common_v01/VXD_v01_01.xml"/>
+  <include ref="../CRD_common_v01/FTD_SkewRing_v01_01.xml"/>
+  <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_02.xml"/>
+  <include ref="../CRD_common_v01/SET_SimplePlanar_v01_01.xml"/-->
+  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
+  <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->
+  <!--include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Hcal_Rpc_Barrel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Hcal_Rpc_Endcaps_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Yoke_Barrel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Yoke_Endcaps_v01_01.xml"/-->
+  <!--include ref="../CRD_common_v01/Lcal_v01_01.xml"/-->
+
+  <fields>
+    <field name="InnerSolenoid" type="solenoid"
+           inner_field="Field_nominal_value"
+           outer_field="0"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="SolenoidCoil_center_radius"
+           outer_radius="Solenoid_outer_radius">
+    </field>
+    <field name="OuterSolenoid" type="solenoid"
+           inner_field="0"
+           outer_field="Field_outer_nominal_value"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="Solenoid_outer_radius"
+           outer_radius="Yoke_barrel_inner_radius">
+    </field>
+  </fields>
+
+</lccdd>

--- a/Detector/DetCRD/src/Calorimeter/CRDEcal_v01.cpp
+++ b/Detector/DetCRD/src/Calorimeter/CRDEcal_v01.cpp
@@ -46,29 +46,33 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
   double Z0 = theDetector.constant<double>("ecalbarrel_zlength");
   double barx = theDetector.constant<double>("bar_x");   //Crystal size in R direction. 
   double bary = theDetector.constant<double>("bar_y");   //Crystal size in z/phi direction (z for odd layer, phi for even layer).
-  
-  double dim_x1 = R0*tan(22.5*degree) + sqrt(2)*h0/2.;
-  double dim_x2 = dim_x1 - h0;
+  //int Nsymm = theDetector.constant<int>("n_symm");    //Only support 8 and 12 now. 
+  //double rotAngle = 360./Nsymm;  
+  int Nsymm = 8;    //Only support 8 and 12 now. 
+  double rotAngle = 45.;  
+
+  double dim_x1 = R0*tan(rotAngle*degree/2.) + h0/(2.*sin(rotAngle*degree));
+  double dim_x2 = dim_x1 - h0/tan(rotAngle*degree);
   double dim_y = Z0/2.;
   double dim_z = h0/2.;		                 
-  double dx = dim_x1 - R0*tan(22.5*degree);  //transport distance in x-axis
-  double r0 = R0+h0/2.;                      //rotation radius 
+  double dx = dim_x1 - R0*tan(rotAngle*degree/2.);  //transport distance in x-axis
+  double r0 = R0+h0/2.;                             //rotation radius 
   
   //Crystal bar size
-  int Nlayers = (int)h0/(2*barx);         //14 double-layers. 
-  int Nblock_z   = 11;                    //block number in z direction
-  int Nblock_phi = 4;                     //block number in phi direction
-  double barz_s0;                         //Crystal bar lenghth in sub-layer 0(phi direction). Depends on layer number. 
-  double barz_s1 = Z0/Nblock_z;           //Crystal bar lenghth in sub-layer 1(z direction, 46cm).
-  int Nbar_phi;                           //Crystal bar number in each block, in phi direction.
-  int Nbar_z = (int)barz_s1/bary;         //Crystal bar number in each block, in z direction.
+  int Nlayers = (int)h0/(2*barx);                             //14 double-layers. 
+  int Nblock_z = theDetector.constant<int>("Nblock_z");       //block number in z direction
+  int Nblock_phi = theDetector.constant<int>("Nblock_phi");   //block number in phi direction
+  double barz_s0;                                             //Crystal bar lenghth in sub-layer 0(phi direction). Depends on layer number. 
+  double barz_s1 = Z0/Nblock_z;                               //Crystal bar lenghth in sub-layer 1(z direction, ~60cm).
+  int Nbar_phi;                                               //Crystal bar number in each block, in phi direction.
+  int Nbar_z = (int)barz_s1/bary;                             //Crystal bar number in each block, in z direction.
   
   //Define detector and motherVolume(world)
   dd4hep::DetElement ECAL(det_name, detid);
   dd4hep::Volume motherVol = theDetector.pickMotherVolume(ECAL);
   
   // Create a Tube-like envelope representing the whole detector volume
-  dd4hep::PolyhedraRegular envelope(8, 22.5*degree, R0, (R0+h0), Z0);
+  dd4hep::PolyhedraRegular envelope(Nsymm, rotAngle/2.*degree, R0, (R0+h0), Z0);
   dd4hep::Material	air(theDetector.material("Air"));
   dd4hep::Volume	   envelopeVol(det_name, envelope, air);
   dd4hep::PlacedVolume	envelopePlv = motherVol.placeVolume(envelopeVol, Position(0,0,0));
@@ -107,8 +111,8 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
   }
 
   caloData->layoutType = LayeredCalorimeterData::BarrelLayout ;
-  caloData->inner_symmetry = 8  ;
-  caloData->outer_symmetry = 8  ;
+  caloData->inner_symmetry = Nsymm  ;
+  caloData->outer_symmetry = Nsymm  ;
   caloData->phi0 = 0 ; // hardcoded
 
   // extent of the calorimeter in the r-z-plane [ rmin, rmax, zmin, zmax ] in mm.
@@ -141,7 +145,7 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
     
         //sub-layer 0: bars along phi. length=barz_s0. Bar num=Nbar_z
       for(int ibar0=1;ibar0<=Nbar_z;ibar0++){
-    	    dd4hep::PlacedVolume plv_bar0 = block.placeVolume(bar_s0, Position(0,(2*ibar0-1)*bary/2-barz_s1/2, -barx/2));
+    	    dd4hep::PlacedVolume plv_bar0 = block.placeVolume(bar_s0, Position(0, barz_s1/2-(2*ibar0-1)*bary/2, -barx/2));
     	    plv_bar0.addPhysVolID("slayer",0).addPhysVolID("bar",ibar0);
     	    std::string barname0 = "CrystalBar_s0_"+std::to_string(ibar0);	
     	    dd4hep::DetElement bardet0(sd, barname0, detid);
@@ -150,7 +154,7 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
     
     	  //sub-layer1 
     	  for(int ibar1=1;ibar1<=Nbar_phi;ibar1++){
-    	    dd4hep::PlacedVolume plv_bar1 = block.placeVolume(bar_s1, Position((2*ibar1-1)*bary/2-barz_s0/2, 0, barx/2));
+    	    dd4hep::PlacedVolume plv_bar1 = block.placeVolume(bar_s1, Position( barz_s0/2-(2*ibar1-1)*bary/2, 0, barx/2));
     	  	 plv_bar1.addPhysVolID("slayer",1).addPhysVolID("bar",ibar1);
     	  	 std::string barname1 = "CrystalBar_s1_"+std::to_string(ibar1);
     	  	 dd4hep::DetElement bardet1(sd, barname1, detid);
@@ -166,21 +170,21 @@ static dd4hep::Ref_t create_detector(dd4hep::Detector& theDetector,
     }
 
   for(int iz=1; iz<=Nblock_z; iz++){
-    dd4hep::PlacedVolume plv = det_vol.placeVolume(det_stave, Position(0, (2*iz-1)*barz_s1/2-dim_y, 0) );
+    dd4hep::PlacedVolume plv = det_vol.placeVolume(det_stave, Position(0, dim_y-(2*iz-1)*barz_s1/2, 0) );
     plv.addPhysVolID("stave", iz);
     DetElement sd(stavedet, _toString(iz,"stave%3d"), detid);
     sd.setPlacement(plv);    
   }
   
-  for(int i=0;i<8;i++){
-    double rotAngle = 45*i*degree;
-    double posx = -r0*sin(rotAngle) - dx*cos(rotAngle);
-  	 double posy = r0*cos(rotAngle) - dx*sin(rotAngle);
-  	 dd4hep::Transform3D transform(dd4hep::RotationZ(rotAngle)*dd4hep::RotationX(-90*degree),  dd4hep::Position(posx, posy, 0.));
-  	 dd4hep::PlacedVolume plv = envelopeVol.placeVolume(det_vol, transform);
-  	 plv.addPhysVolID("module", i);
-  	 DetElement sd(ECAL, _toString(i,"trap%3d"), detid);
-  	 sd.setPlacement(plv);
+  for(int i=0;i<Nsymm;i++){
+    double m_rot = rotAngle*i*degree;
+    double posx = -r0*sin(m_rot) - dx*cos(m_rot);
+    double posy = r0*cos(m_rot) - dx*sin(m_rot);
+    dd4hep::Transform3D transform(dd4hep::RotationZ(m_rot)*dd4hep::RotationX(-90*degree),  dd4hep::Position(posx, posy, 0.));
+    dd4hep::PlacedVolume plv = envelopeVol.placeVolume(det_vol, transform);
+    plv.addPhysVolID("module", i);
+    DetElement sd(ECAL, _toString(i,"trap%3d"), detid);
+    sd.setPlacement(plv);
   }
   
   sens.setType("calorimeter");


### PR DESCRIPTION
Update the crystal ECAL barrel geometry: 
  - Extract some parameters from src file to config file. (Symmetry number is only validated for nsymm=8.)
  - Change ECAL size: half z from 3350mm to 3300mm to avoid gaps between crystal bars (for Nblock=11).

