### PR TITLE
GEOM: new type and option for new beampipe design

### DIFF
--- a/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_01.xml
@@ -13,53 +13,54 @@
   </define>
 
   <detectors>        
-    <detector name="BeamPipe" type="DD4hep_CRDBeamPipe_v01" vis="BeamPipeVis">
+    <detector name="BeamPipe" type="CRDBeamPipe_v01" vis="VacVis">
       <parameter crossingangle="CrossingAngle" />
       <envelope>
 	<shape type="Assembly"/>
       </envelope>
 
       <section type ="Center" name="IPInnerTube" zStart="0" zEnd="BeamPipe_CentralBe_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Central_inner_radius"/>
-	<layer material="G4_Be" thickness="BeamPipe_Be_inner_thickness"/>
-	<layer material="G4_PARAFFIN" thickness="BeamPipe_Cooling_thickness"/>
-	<layer material="G4_Be" thickness="BeamPipe_Be_outer_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Central_inner_radius" vis="VacVis"/>
+	<layer material="G4_Be" thickness="BeamPipe_Be_inner_thickness" vis="TubeVis"/>
+	<layer material="G4_PARAFFIN" thickness="BeamPipe_Cooling_thickness" vis="GrayVis"/>
+	<layer material="G4_Be" thickness="BeamPipe_Be_outer_thickness" vis="TubeVis"/>
       </section>
       <section type="Center" name="IPAl" zStart="BeamPipe_CentralBe_zmax" zEnd="BeamPipe_CentralAl_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Central_inner_radius"/>
-	<layer material="G4_Al" thickness="BeamPipe_Al_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Central_inner_radius" vis="VacVis"/>
+	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" vis="TubeVis"/>
       </section>
       <section type="Center" name="ExpandPipe" zStart="BeamPipe_CentralAl_zmax" zEnd="BeamPipe_ConeAl_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Central_inner_radius" thicknessEnd="BeamPipe_Expanded_inner_radius"/>
-	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" thicknessEnd="BeamPipe_Al_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Central_inner_radius" thicknessEnd="BeamPipe_Expanded_inner_radius" vis="VacVis"/>
+	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" thicknessEnd="BeamPipe_Al_thickness" vis="TubeVis"/>
       </section>
       <section type="Center" name="ThickPipe" zStart="BeamPipe_ConeAl_zmax" zEnd="BeamPipe_LinkerAl_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Expanded_inner_radius"/>
-	<layer material="G4_Al" thickness="BeamPipe_Al_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Expanded_inner_radius" vis="VacVis"/>
+	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" vis="TubeVis"/>
       </section>
       <section type="CenterSide" name="OutsideLink" zStart="BeamPipe_LinkerAl_zmax" zEnd="BeamPipe_LinkerCu_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Expanded_inner_radius"/>
-	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Expanded_inner_radius" vis="VacVis"/>
+	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
       </section>
       <section type="FatWaist" name="Waist" zStart="BeamPipe_LinkerCu_zmax" zEnd="BeamPipe_Waist_zmax" rStart="BeamPipe_Expanded_inner_radius" size="BeamPipe_Crotch_hole_height">
-	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
+	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
       </section>
-      <!--CrotchAsymUp&CrotchAsymDn not work to fix, because of problem on convert from TGeo to Geant4--> 
-      <!--section type="CrotchAsymUp" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
+      <!--CrotchAsymUp&CrotchAsymDn not work to fix, because of problem on convert from TGeo to Geant4-->
+      <!--Since lcg101, they work-->
+      <section type="CrotchAsymUp" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
 	       rStart="BeamPipe_Expanded_inner_radius" rEnd="BeamPipe_Upstream_inner_radius" size="BeamPipe_Crotch_hole_height">
-	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" thicknessEnd="ForkAsymThickness"/>
+	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" thicknessEnd="ForkAsymThickness" vis="TubeVis"/>
       </section>
       <section type="CrotchAsymDn" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
 	       rStart="BeamPipe_Expanded_inner_radius" rEnd="BeamPipe_Dnstream_inner_radius" size="BeamPipe_Crotch_hole_height">
-        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
-      </section-->
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
+      </section>
       <section type="FlareLegUp" name="FirstDoublePipe" zStart="BeamPipe_Crotch_zmax" zEnd="BeamPipe_FirstSeparated_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Upstream_inner_radius" thicknessEnd="BeamPipe_Dnstream_inner_radius"/>
-	<layer material="G4_Cu" thickness="ForkAsymThickness" thicknessEnd="BeamPipe_Cu_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Upstream_inner_radius" thicknessEnd="BeamPipe_Dnstream_inner_radius" vis="VacVis"/>
+	<layer material="G4_Cu" thickness="ForkAsymThickness" thicknessEnd="BeamPipe_Cu_thickness" vis="TubeVis"/>
       </section>
       <section type="FlareLegDn" name="FirstDoublePipe" zStart="BeamPipe_Crotch_zmax" zEnd="BeamPipe_FirstSeparated_zmax" rStart="0">
-        <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius"/>
-        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
+        <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius" vis="VacVis"/>
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
       </section>
     </detector>
   </detectors>        

--- a/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_02.xml
@@ -1,0 +1,67 @@
+<lccdd>
+  <info name="CRD" title="CRD Beam pipe" author="Chengdong Fu" url="no" status="development" version="1.0">
+    <comment>A beampipe for CRD</comment>
+  </info>
+
+  <display>
+    <vis name="TubeVis"   alpha="0.1" r="1.0" g="0.7"  b="0.5"   showDaughters="true"  visible="true"/>
+    <vis name="VacVis"   alpha="1.0" r="0.0" g="0.0"  b="0.0"   showDaughters="true"  visible="false"/>
+  </display>
+
+  <define>
+    <!--constant name="ForkAsymThickness" value="BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness-BeamPipe_Upstream_inner_radius"/-->
+  </define>
+
+  <detectors>        
+    <detector name="BeamPipe" type="CRDBeamPipe_v01" vis="VacVis">
+      <parameter crossingangle="CrossingAngle" />
+      <envelope>
+	<shape type="Assembly"/>
+      </envelope>
+
+      <section type ="Center" name="IPInnerTube" zStart="0" zEnd="BeamPipe_CentralBe_zmax" rStart="0">
+	<layer material="beam" thickness="BeamPipe_Central_inner_radius" vis="VacVis"/>
+	<layer material="G4_Be" thickness="BeamPipe_Be_inner_thickness" vis="TubeVis"/>
+	<layer material="G4_PARAFFIN" thickness="BeamPipe_Cooling_thickness" vis="GrayVis"/>
+	<layer material="G4_Be" thickness="BeamPipe_Be_outer_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Center" name="IPAl" zStart="BeamPipe_CentralBe_zmax" zEnd="BeamPipe_CentralAl_zmax" rStart="0">
+	<layer material="beam" thickness="BeamPipe_Central_inner_radius" vis="VacVis"/>
+	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Waist" name="Waist1st" zStart="BeamPipe_CentralAl_zmax" zEnd="BeamPipe_ExpandAl_zmax" rStart="BeamPipe_Central_inner_radius" size="BeamPipe_FirstExpand_width">
+	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Runway" name="Waist2nd" zStart="BeamPipe_ExpandAl_zmax" zEnd="BeamPipe_Linker_zmin" rStart="BeamPipe_Central_inner_radius" size="BeamPipe_FirstExpand_width">
+        <layer material="G4_Al" thickness="BeamPipe_Al_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Runway" name="Waist3rd" zStart="BeamPipe_Linker_zmin" zEnd="BeamPipe_Linker_zmax" rStart="BeamPipe_Central_inner_radius" size="BeamPipe_FirstExpand_width">
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Runway" name="Waist4th" zStart="BeamPipe_Linker_zmax" zEnd="BeamPipe_Waist_zmax" rStart="BeamPipe_Central_inner_radius" size="BeamPipe_FirstExpand_width"
+	       shift="BeamPipe_SecondExpand_width-BeamPipe_FirstExpand_width">
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Crotch" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
+	       rStart="BeamPipe_Central_inner_radius" rEnd="BeamPipe_Central_inner_radius" size="BeamPipe_SecondExpand_width">
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Legs" name="FirstDoublePipe" zStart="BeamPipe_Crotch_zmax" zEnd="BeamPipe_FirstSeparated_zmax" rStart="0">
+	<layer material="beam" thickness="BeamPipe_Fork_inner_radius" vis="VacVis"/>
+	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Legs" name="BeforeMask" zStart="BeamPipe_FirstSeparated_zmax" zEnd="BeamPipe_Mask_zmin" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Fork_inner_radius" vis="VacVis"/>
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Legs" name="Mask" zStart="BeamPipe_Mask_zmin" zEnd="BeamPipe_Mask_zmax" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Mask_inner_radius" vis="VacVis"/>
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness+BeamPipe_Fork_inner_radius-BeamPipe_Mask_inner_radius" vis="TubeVis"/>
+      </section>
+      <section type="Legs" name="SecondDoublePipe" zStart="BeamPipe_Mask_zmax" zEnd="BeamPipe_SecondSeparated_zmax" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Fork_inner_radius" vis="VacVis"/>
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
+      </section>
+    </detector>
+  </detectors>        
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_02.xml
@@ -9,6 +9,7 @@
   </display>
 
   <define>
+    <!--only needed for asymetry double pipe-->
     <!--constant name="ForkAsymThickness" value="BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness-BeamPipe_Upstream_inner_radius"/-->
   </define>
 

--- a/Detector/DetCRD/src/Other/OtherDetectorHelpers.h
+++ b/Detector/DetCRD/src/Other/OtherDetectorHelpers.h
@@ -16,7 +16,8 @@ namespace CEPC {
     kCrotchAsymDn               = 6,
     kLegs                       = 7,
     kFlareLegUp                 = 8,
-    kFlareLegDn                 = 9
+    kFlareLegDn                 = 9,
+    kRunway               = 10
   } ECrossType;
   
   inline ECrossType getCrossType( std::string const & type) {
@@ -30,7 +31,8 @@ namespace CEPC {
     CrossTypes["CrotchAsymDn"]          = CEPC::kCrotchAsymDn;
     CrossTypes["Legs"]                  = CEPC::kLegs;
     CrossTypes["FlareLegUp"]            = CEPC::kFlareLegUp;
-    CrossTypes["FlareLegDn"]           = CEPC::kFlareLegDn;
+    CrossTypes["FlareLegDn"]            = CEPC::kFlareLegDn;
+    CrossTypes["Runway"]                = CEPC::kRunway;
 
     std::map < std::string, CEPC::ECrossType>::const_iterator it = CrossTypes.find(type);
     if ( it == CrossTypes.end() ) {


### PR DESCRIPTION
* Add RunWay type for new design
  * [Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_02.xml]
* At the same time, also update
  * remove the prefix DD4hep_ in detector type
  * open the section which is closed because DD4hep did not support Scale in previous version
  * change hardcode Vis attribution to optional in xml 
![beampipe_design202205](https://user-images.githubusercontent.com/12792582/171337292-31c43e71-c5c6-4c53-89c2-d016ea57bc24.png)
![beampipe in CEPCSW](https://user-images.githubusercontent.com/12792582/171336910-c6ea26ed-499c-4518-bc68-3d006b212052.png)