### PR TITLE
Use decltype to avoid the hardcode size for covMatrix. 

### DIFF
--- a/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
@@ -2698,7 +2698,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       // setup initial dummy covariance matrix
       //std::vector<float> covMatrix;
       //covMatrix.resize(15);
-      std::array<float,15> covMatrix;
+      decltype(edm4hep::TrackState::covMatrix) covMatrix;
 
       for (unsigned icov = 0; icov<covMatrix.size(); ++icov) {
         covMatrix[icov] = 0;

--- a/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
@@ -214,7 +214,7 @@ StatusCode TrackSubsetAlg::execute(){
       trackerHits.push_back(Navigation::Instance()->GetTrackerHit(trackerHitsObj[i].getObjectID()));
     } 
     // setup initial dummy covariance matrix
-    std::array<float,15> covMatrix;
+    decltype(edm4hep::TrackState::covMatrix) covMatrix;
     for (unsigned icov = 0; icov<covMatrix.size(); ++icov) {
       covMatrix[icov] = 0;
     }

--- a/Reconstruction/Tracking/include/Tracking/TrackingHelper.h
+++ b/Reconstruction/Tracking/include/Tracking/TrackingHelper.h
@@ -27,9 +27,9 @@ inline edm4hep::TrackState getTrackStateAt(edm4hep::Track track, int location) {
     return edm4hep::TrackState();
 }
 
-inline std::array<float,15> getCovMatrix(const edm4hep::Track &track) {
+inline decltype(edm4hep::TrackState::covMatrix) getCovMatrix(const edm4hep::Track &track) {
   if(track.trackStates_size()>0) return track.getTrackStates(0).covMatrix;
-  std::array<float,15> dummy{};
+  decltype(edm4hep::TrackState::covMatrix) dummy{};
   return dummy;
 }
 inline float getTanLambda(const edm4hep::Track &track) {

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
@@ -1361,7 +1361,7 @@ start:
 				tsBase.Z0 = 0;
 				tsBase.tanLambda = 0;
 				tsBase.referencePoint = edm4hep::Vector3f(0,0,0);
-				tsBase.covMatrix = std::array<float, 15>{};
+				tsBase.covMatrix = decltype(edm4hep::TrackState::covMatrix){};
 				edm4hep::TrackState tsIP(tsBase);
 				edm4hep::TrackState tsFH(tsBase);
 				edm4hep::TrackState tsLH(tsBase);

--- a/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp
+++ b/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp
@@ -288,7 +288,7 @@ void FullLDCTrackingAlg::AddTrackColToEvt(TrackExtendedVec & trkVec, edm4hep::Tr
     edm4hep::MutableTrack track;// = new edm4hep::Track;
     
     // setup initial dummy covariance matrix
-    std::array<float,15> covMatrix;
+    decltype(edm4hep::TrackState::covMatrix) covMatrix;
     
     for (unsigned icov = 0; icov<covMatrix.size(); ++icov) {
       covMatrix[icov] = 0;
@@ -1115,9 +1115,10 @@ void FullLDCTrackingAlg::prepareVectors() {
       //param[3] = getD0(tpcTrack);
       //param[4] = getZ0(tpcTrack);
       
-      std::array<float, 15> Cov = getCovMatrix(tpcTrack);
+      auto Cov = getCovMatrix(tpcTrack);
       int NC = int(Cov.size());
       for (int ic=0;ic<NC;ic++) {
+        if (ic>=(sizeof(cov)/sizeof(float))) break;
         cov[ic] =  Cov[ic];
       }
       
@@ -1179,9 +1180,10 @@ void FullLDCTrackingAlg::prepareVectors() {
       //param[3] = getD0(siTrack);
       //param[4] = getZ0(siTrack);
             
-      std::array<float, 15> Cov = getCovMatrix(siTrack);
+      auto Cov = getCovMatrix(siTrack);
       int NC = int(Cov.size());
       for (int ic=0;ic<NC;ic++) {
+        if (ic>=(sizeof(cov)/sizeof(float))) break;
         cov[ic] =  Cov[ic];
       }
       trackExt->setCovMatrix(cov);
@@ -1571,7 +1573,7 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
   }
   
   // setup initial dummy covariance matrix
-  std::array<float,15> covMatrix;
+  decltype(edm4hep::TrackState::covMatrix) covMatrix;
   
   for (unsigned icov = 0; icov<covMatrix.size(); ++icov) {
     covMatrix[icov] = 0;
@@ -3628,7 +3630,7 @@ void FullLDCTrackingAlg::AssignOuterHitsToTracks(TrackerHitExtendedVec hitVec, f
           
           pre_fit.location = 1/*lcio::TrackState::AtIP*/;
           // setup initial dummy covariance matrix
-          std::array<float,15> covMatrix;
+          decltype(edm4hep::TrackState::covMatrix) covMatrix;
           
           for (unsigned icov = 0; icov<covMatrix.size(); ++icov) {
             covMatrix[icov] = 0;
@@ -4134,7 +4136,7 @@ void FullLDCTrackingAlg::AssignSiHitsToTracks(TrackerHitExtendedVec hitVec,
         pre_fit.location = 1/*lcio::TrackState::AtIP*/;
         
         // setup initial dummy covariance matrix
-        std::array<float,15> covMatrix;
+        decltype(edm4hep::TrackState::covMatrix) covMatrix;
 
         for (unsigned icov = 0; icov<covMatrix.size(); ++icov) {
           covMatrix[icov] = 0;

--- a/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.cpp
+++ b/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.cpp
@@ -207,8 +207,8 @@ StatusCode TruthTrackerAlg::execute()
         trackState.Z0=helix.getZ0();
         trackState.tanLambda=helix.getTanLambda();
         trackState.referencePoint=helix.getReferencePoint();
-        std::array<float,15> covMatrix;
-        for(int i=0;i<15;i++){covMatrix[i]=999.;}//FIXME
+        decltype(trackState.covMatrix) covMatrix;
+        for(int i=0;i<covMatrix.size();i++){covMatrix[i]=999.;}//FIXME
         trackState.covMatrix=covMatrix;
         dcTrack.addToTrackStates(trackState);
         //dcTrack.setType();//TODO

--- a/Service/TrackSystemSvc/include/TrackSystemSvc/MarlinTrkUtils.h
+++ b/Service/TrackSystemSvc/include/TrackSystemSvc/MarlinTrkUtils.h
@@ -55,7 +55,7 @@ namespace MarlinTrk{
       std::vector<edm4hep::TrackerHit>& hit_list,
       edm4hep::MutableTrack* track,
       bool fit_backwards,
-      const std::array<float,15>& initial_cov_for_prefit,
+      const decltype(edm4hep::TrackState::covMatrix)& initial_cov_for_prefit,
       float bfield_z,
       double maxChi2Increment=DBL_MAX);
   

--- a/Service/TrackSystemSvc/src/LCIOTrackPropagators.cc
+++ b/Service/TrackSystemSvc/src/LCIOTrackPropagators.cc
@@ -100,7 +100,7 @@ namespace LCIOTrackPropagators{
     
     CLHEP::HepSymMatrix covPrime =  cov0.similarity(propagatorMatrix);
     
-    std::array<float,15> cov;
+    decltype(edm4hep::TrackState::covMatrix) cov;
     
     icov = 0 ;
     

--- a/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
+++ b/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
@@ -376,7 +376,7 @@ namespace MarlinTrk {
                         bfield_z );
     
     TMatrixD cov(5,5) ;   
-    std::array<float, 15> covLCIO = ts.covMatrix;
+    auto covLCIO = ts.covMatrix;
     
     cov( 0 , 0 ) =   covLCIO[ 0] ;                   //   d0, d0
     cov( 0 , 1 ) = - covLCIO[ 1] ;                   //   d0, phi
@@ -1599,7 +1599,7 @@ namespace MarlinTrk {
     Double_t cpa  = helix.GetKappa();
     double alpha = omega / cpa  ; // conversion factor for omega (1/R) to kappa (1/Pt) 
     
-    std::array<float, 15> covLCIO; 
+    decltype(ts.covMatrix) covLCIO; 
     covLCIO[ 0] =   covK( 0 , 0 )   ; //   d0,   d0
     
     covLCIO[ 1] = - covK( 1 , 0 )   ; //   phi0, d0

--- a/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
+++ b/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
@@ -94,7 +94,7 @@ namespace MarlinTrk {
   
   int createTrackStateAtCaloFace( IMarlinTrack* marlinTrk, edm4hep::TrackState* track, edm4hep::TrackerHit trkhit, bool tanL_is_positive );
   
-  int createFinalisedLCIOTrack( IMarlinTrack* marlinTrk, std::vector<edm4hep::TrackerHit>& hit_list, edm4hep::MutableTrack* track, bool fit_backwards, const std::array<float,15>& initial_cov_for_prefit, float bfield_z, double maxChi2Increment){
+    int createFinalisedLCIOTrack( IMarlinTrack* marlinTrk, std::vector<edm4hep::TrackerHit>& hit_list, edm4hep::MutableTrack* track, bool fit_backwards, const decltype(edm4hep::TrackState::covMatrix)& initial_cov_for_prefit, float bfield_z, double maxChi2Increment){
     
     ///////////////////////////////////////////////////////
     // check inputs 

--- a/Utilities/KiTrack/src/Tools/Fitter.cc
+++ b/Utilities/KiTrack/src/Tools/Fitter.cc
@@ -349,7 +349,7 @@ void Fitter::fit(){
   /**********************************************************************************************/
   /*       Create a TrackStateImpl from the helix values and use it to initalise the fit        */
   /**********************************************************************************************/
-  std::array<float,15> covMatrix;
+  decltype(edm4hep::TrackState::covMatrix) covMatrix;
   for (unsigned icov = 0; icov<covMatrix.size(); ++icov) {
     covMatrix[icov] = 0;
   }

--- a/Utilities/KiTrack/src/Tools/Fitter.cc
+++ b/Utilities/KiTrack/src/Tools/Fitter.cc
@@ -166,7 +166,7 @@ void Fitter::fitVXD(){
   /**********************************************************************************************/
   /*       Create a TrackStateImpl from the helix values and use it to initalise the fit        */
   /**********************************************************************************************/
-  std::array<float,15> covMatrix;
+  decltype(edm4hep::TrackState::covMatrix) covMatrix;
   
   for (unsigned icov = 0; icov<covMatrix.size(); ++icov) {
     covMatrix[icov] = 0;


### PR DESCRIPTION
This should fix #217 .

Hi @fucd @ihepzhangyao , could you have a look at my update? In the future version of EDM4hep, the size of covMatrix is changed from 15 to 21. Please check your reconstruction algorithms. Thank you in advance. 

Tao