### PR TITLE
GEOM: update and create CRD_o1_v04

### DIFF
--- a/Detector/DetCEPCv4/src/calorimeter/SHcalSc04_Barrel_v04.cpp
+++ b/Detector/DetCEPCv4/src/calorimeter/SHcalSc04_Barrel_v04.cpp
@@ -46,11 +46,11 @@ using dd4hep::rec::LayeredCalorimeterData;
 
 // After reading in all the necessary parameters.
 // To check the radius range and the space for placing the total layers
-static bool validateEnvelope(double rInner, double rOuter, double radiatorThickness, double layerThickness, int layerNumber){
+static bool validateEnvelope(double rInner, double rOuter, double radiatorThickness, double layerThickness, int layerNumber, int symmetry){
   
   bool Error = false;
   bool Warning = false;
-  double spaceAllowed = rOuter*cos(M_PI/16.) - rInner;
+  double spaceAllowed = rOuter*cos(M_PI/symmetry) - rInner;
   double spaceNeeded  = (radiatorThickness + layerThickness)* layerNumber;
   double spaceToleranted  = (radiatorThickness + layerThickness)* (layerNumber+1);
   double rOuterRecommaned = ( rInner + spaceNeeded )/cos(M_PI/16.);
@@ -59,17 +59,17 @@ static bool validateEnvelope(double rInner, double rOuter, double radiatorThickn
   
   if( spaceNeeded > spaceAllowed )
     {
-      printout( dd4hep::ERROR,  "SHcalSc04_Barrel_v01", " Layer number is more than it can be built! "  ) ;
+      printout( dd4hep::ERROR,  "SHcalSc04_Barrel_v04", " Layer number is more than it can be built! "  ) ;
       Error = true;
     }
   else if ( spaceToleranted < spaceAllowed )
     {
-      printout( dd4hep::WARNING,  "SHcalSc04_Barrel_v01", " Layer number is less than it is able to build!" ) ;
+      printout( dd4hep::WARNING,  "SHcalSc04_Barrel_v04", " Layer number is less than it is able to build!" ) ;
       Warning = true;
     }
   else
     {
-      printout( dd4hep::DEBUG,  "SHcalSc04_Barrel_v01"," has been validated and start to build it." ) ;
+      printout( dd4hep::DEBUG,  "SHcalSc04_Barrel_v04"," has been validated and start to build it." ) ;
       Error = false;
       Warning = false;
     }
@@ -179,13 +179,8 @@ static Ref_t create_detector(Detector& theDetector, xml_h element, SensitiveDete
 
   int         Hcal_nlayers                     = theDetector.constant<int>("Hcal_nlayers");
 
-  double      TPC_outer_radius               = theDetector.constant<double>("TPC_outer_radius");
-
-  double      Ecal_outer_radius               = theDetector.constant<double>("Ecal_outer_radius");
-
-  printout( dd4hep::DEBUG,  "SHcalSc04_Barrel_v04", "TPC_outer_radius : %e   - Ecal_outer_radius: %e ", TPC_outer_radius , Ecal_outer_radius) ;
-
-  validateEnvelope(Hcal_inner_radius, Hcal_outer_radius, Hcal_radiator_thickness, Hcal_chamber_thickness, Hcal_nlayers);
+  printout( dd4hep::INFO, "SHcalSc04_Barrel_v04", "Hcal_inner_radius : %e   - Hcal_outer_radius %e ", Hcal_inner_radius , Hcal_outer_radius);
+  validateEnvelope(Hcal_inner_radius, Hcal_outer_radius, Hcal_radiator_thickness, Hcal_chamber_thickness, Hcal_nlayers, Hcal_inner_symmetry);
 
   Readout readout = sens.readout();
   dd4hep::Segmentation seg = readout.segmentation();

--- a/Detector/DetCEPCv4/src/calorimeter/SHcalSc04_Barrel_v04.cpp
+++ b/Detector/DetCEPCv4/src/calorimeter/SHcalSc04_Barrel_v04.cpp
@@ -46,11 +46,11 @@ using dd4hep::rec::LayeredCalorimeterData;
 
 // After reading in all the necessary parameters.
 // To check the radius range and the space for placing the total layers
-static bool validateEnvelope(double rInner, double rOuter, double radiatorThickness, double layerThickness, int layerNumber, int symmetry){
+static bool validateEnvelope(double rInner, double rOuter, double radiatorThickness, double layerThickness, int layerNumber, int nsymmetry){
   
   bool Error = false;
   bool Warning = false;
-  double spaceAllowed = rOuter*cos(M_PI/symmetry) - rInner;
+  double spaceAllowed = rOuter*cos(M_PI/nsymmetry) - rInner;
   double spaceNeeded  = (radiatorThickness + layerThickness)* layerNumber;
   double spaceToleranted  = (radiatorThickness + layerThickness)* (layerNumber+1);
   double rOuterRecommaned = ( rInner + spaceNeeded )/cos(M_PI/16.);

--- a/Detector/DetCEPCv4/src/tracker/FTD_Simple_Staggered_geo.cpp
+++ b/Detector/DetCEPCv4/src/tracker/FTD_Simple_Staggered_geo.cpp
@@ -1274,7 +1274,9 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
   ftd.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
   
   //--------------------------------------
-  
+  if ( x_det.hasAttr(_U(combineHits)) ) {
+    ftd.setCombineHits(x_det.attr<bool>(_U(combineHits)),sens);
+  }
 
   return ftd;
 }

--- a/Detector/DetCEPCv4/src/tracker/FTD_cepc_geo.cpp
+++ b/Detector/DetCEPCv4/src/tracker/FTD_cepc_geo.cpp
@@ -1273,7 +1273,9 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
   ftd.addExtension< ZDiskPetalsData >( zDiskPetalsData ) ;
   
   //--------------------------------------
-  
+  if ( x_det.hasAttr(_U(combineHits)) ) {
+    ftd.setCombineHits(x_det.attr<bool>(_U(combineHits)),sens);
+  }
 
   return ftd;
 }

--- a/Detector/DetCEPCv4/src/tracker/SET_Simple_Planar_geo.cpp
+++ b/Detector/DetCEPCv4/src/tracker/SET_Simple_Planar_geo.cpp
@@ -456,6 +456,10 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& theDetector, xml_h e, dd4h
   
   
   set.setVisAttributes( theDetector, x_det.visStr(), envelope );
+
+  if ( x_det.hasAttr(_U(combineHits)) ) {
+    set.setCombineHits(x_det.attr<bool>(_U(combineHits)),sens);
+  }
   
   return set;
 }

--- a/Detector/DetCEPCv4/src/tracker/SIT_Simple_Planar_geo.cpp
+++ b/Detector/DetCEPCv4/src/tracker/SIT_Simple_Planar_geo.cpp
@@ -473,6 +473,10 @@ static dd4hep::Ref_t create_element(dd4hep::Detector& theDetector, xml_h e, dd4h
   //--------------------------------------
   
   sit.setVisAttributes( theDetector, x_det.visStr(), envelope );
+
+  if ( x_det.hasAttr(_U(combineHits)) ) {
+    sit.setCombineHits(x_det.attr<bool>(_U(combineHits)),sens);
+  }
   
   return sit;
 }

--- a/Detector/DetCEPCv4/src/tracker/VXD04_geo.cpp
+++ b/Detector/DetCEPCv4/src/tracker/VXD04_geo.cpp
@@ -1582,9 +1582,11 @@ static Ref_t create_element(Detector& theDetector, xml_h e, SensitiveDetector se
 
   
   //--------------------------------------
-  
-  
   vxd.setVisAttributes( theDetector, x_det.visStr(), envelope );
+
+  if ( x_det.hasAttr(_U(combineHits)) ) {
+    vxd.setCombineHits(x_det.attr<bool>(_U(combineHits)),sens);
+  }
 
   return vxd;
 }

--- a/Detector/DetCRD/compact/CRD_common_v01/FTD_SkewRing_v01_03.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/FTD_SkewRing_v01_03.xml
@@ -1,0 +1,64 @@
+<lccdd>
+  <define>
+    <constant name="SiliconThickness" value="0.2*mm"/>
+    <constant name="SupportThickness" value="1.0*mm"/>
+    <constant name="ModuleZGap"       value="1.0*mm"/>
+    <constant name="ModuleRPhiGap"    value="-10*mm"/>
+  </define>
+
+  <detectors>
+    <detector id="DetID_FTD" name="FTD" type="SiTrackerSkewRing_v01" vis="FTDVis" readout="FTDCollection" insideTrackingVolume="true" reflect="true">
+      <envelope>
+	<shape type="Assembly"/>
+      </envelope>
+
+      <type_flags type="DetType_TRACKER +  DetType_ENDCAP  + DetType_PIXEL "/>
+
+      <reconstruction strip_width="0.05*mm" strip_length="92*mm" strip_pitch="0" strip_angle="0"/>
+
+      <layer id="0" z="SiTracker_endcap_z1" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z1*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius1"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+	<component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+	<component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="1" z="SiTracker_endcap_z2" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z2*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius2"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="2" z="SiTracker_endcap_z3" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z3*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius3"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="3" z="SiTracker_endcap_z4" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z4*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius4"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="4" z="SiTracker_endcap_z5" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z5*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius5"
+	     phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="5" z="SiTracker_endcap_z6" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z6*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius6"
+             phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+      <layer id="6" z="SiTracker_endcap_z7" dz="0.5*ModuleZGap" inner_r="SiTracker_endcap_z7*tan(acos(Global_endcap_costheta))*cos(pi/16)" outer_r="SiTracker_endcap_outer_radius7"
+             phi0="0" gap="ModuleRPhiGap" is_pixel="true" nmodules="16" vis="SeeThrough">
+        <component material="G4_Si"       thickness="SiliconThickness" vis="FTDSensitiveVis" sensitive="yes"/>
+        <component material="CarbonFiber" thickness="SupportThickness" vis="FTDSupportVis"/>
+      </layer>
+
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="FTDCollection">
+      <id>system:5,side:-2,layer:9,module:8,sensor:8</id>
+    </readout>
+  </readouts>
+
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_common_v01/VXD_StaggeredLadder_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/VXD_StaggeredLadder_v01_01.xml
@@ -22,7 +22,7 @@
       <envelope>
 	<shape type="BooleanShape" operation="Subtraction" material="Air" >
 	  <shape type="BooleanShape" operation="Subtraction" material="Air" >
-            <shape type="Tube" rmin="VXD_inner_radius+1*mm" rmax="VXD_outer_radius" dz="VXD_half_length" />
+            <shape type="Tube" rmin="VXD_inner_radius" rmax="VXD_outer_radius" dz="VXD_half_length" />
             <shape type="Cone" rmin1="0" rmax1="BeamPipe_VertexRegion_rmax" rmin2="0" rmax2="Vertex_Side_rmin" z="(VXD_half_length-BeamPipe_CentralAl_zmax)/2." />
             <position x="0" y="0" z="VXD_half_length-(VXD_half_length-BeamPipe_CentralAl_zmax)/2."/>
           </shape>

--- a/Detector/DetCRD/compact/CRD_common_v01/VXD_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/VXD_v01_01.xml
@@ -3,7 +3,7 @@
     <constant name="VXD_inner_radius" value="Vertex_inner_radius"/>
     <constant name="VXD_outer_radius" value="Vertex_outer_radius"/>
     <constant name="VXD_half_length"  value="Vertex_half_length"/>
-    <constant name="VXD_inner_radius_1" value="BeamPipe_VertexRegion_rmax"/>
+    <constant name="VXD_inner_radius_1" value="Vertex_Side_rmin"/><!--BeamPipe_VertexRegion_rmax"/-->
     <constant name="VXD_radius_r1" value="16*mm"/>
     <constant name="VXD_radius_r3" value="37*mm"/>
     <constant name="VXD_radius_r5" value="58*mm"/>
@@ -22,10 +22,10 @@
 	    <shape type="BooleanShape" operation="Subtraction" material="Air" >
 	      <shape type="BooleanShape" operation="Subtraction" material="Air" >
 		<shape type="Tube" rmin="VXD_inner_radius" rmax="VXD_outer_radius" dz="VXD_half_length" />
-		<shape type="Tube" rmin="0." rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
+		<shape type="Tube" rmin="0" rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
 		<position x="0" y="0" z="VXD_half_length-(VXD_half_length - VXD_cone_max_z)/2.+ env_safety"/> 
 	      </shape>
-	      <shape type="Tube" rmin="0." rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
+	      <shape type="Tube" rmin="0" rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
 	      <position x="0" y="0" z="- ( VXD_half_length-(VXD_half_length - VXD_cone_max_z)/2.+ env_safety ) "/> 
 	      <rotation x="0" y="180.*deg" z="0" />
 	    </shape>

--- a/Detector/DetCRD/compact/CRD_common_v01/VXD_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/VXD_v01_02.xml
@@ -1,0 +1,109 @@
+<lccdd>
+  <define>
+    <constant name="VXD_inner_radius" value="Vertex_inner_radius"/>
+    <constant name="VXD_outer_radius" value="Vertex_outer_radius"/>
+    <constant name="VXD_half_length"  value="Vertex_half_length"/>
+    <constant name="VXD_inner_radius_1" value="BeamPipe_VertexRegion_rmax"/>
+    <constant name="VXD_radius_r1" value="16*mm"/>
+    <constant name="VXD_radius_r3" value="37*mm"/>
+    <constant name="VXD_radius_r5" value="58*mm"/>
+    <constant name="VXD_length_r1" value="113*mm"/>
+    <constant name="VXD_length_r3" value="408*mm"/>
+    <constant name="VXD_length_r5" value="408*mm"/>
+    <constant name="VXD_cone_max_z" value="Vertex_half_length-10*mm"/>
+    <constant name="VXD_cone_min_z" value="VXD_length_r5+10*mm"/>
+  </define>
+
+  <detectors>
+    <detector id="DetID_VXD" name="VXD" type="VXD04" vis="SeeThrough" readout="VXDCollection" insideTrackingVolume="true">
+      <envelope>
+	<shape type="Assembly"/>
+	<!--shape type="BooleanShape" operation="Subtraction" material="Air" >
+	  <shape type="BooleanShape" operation="Subtraction" material="Air" >
+	    <shape type="BooleanShape" operation="Subtraction" material="Air" >
+	      <shape type="BooleanShape" operation="Subtraction" material="Air" >
+		<shape type="Tube" rmin="VXD_inner_radius" rmax="VXD_outer_radius" dz="VXD_half_length" />
+		<shape type="Tube" rmin="0." rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
+		<position x="0" y="0" z="VXD_half_length-(VXD_half_length - VXD_cone_max_z)/2.+ env_safety"/> 
+	      </shape>
+	      <shape type="Tube" rmin="0." rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
+	      <position x="0" y="0" z="- ( VXD_half_length-(VXD_half_length - VXD_cone_max_z)/2.+ env_safety ) "/> 
+	      <rotation x="0" y="180.*deg" z="0" />
+	    </shape>
+	    <shape type="Cone" rmin1="0" rmax1="VXD_inner_radius" rmin2="0" rmax2="VXD_inner_radius_1" 
+		   z="(VXD_cone_max_z-VXD_cone_min_z)/2. + env_safety "/>
+	    <position x="0" y="0" z="VXD_cone_min_z+(VXD_cone_max_z-VXD_cone_min_z)/2."/> 
+	  </shape>
+	  <shape type="Cone" rmin1="0" rmax1="VXD_inner_radius" rmin2="0" rmax2="VXD_inner_radius_1" 
+		 z="(VXD_cone_max_z-VXD_cone_min_z)/2. + env_safety "/>
+	  <position x="0" y="0" z="-(VXD_cone_min_z+(VXD_cone_max_z-VXD_cone_min_z)/2.)"/> 
+	  <rotation x="0" y="180.*deg" z="0" />
+	</shape-->
+	
+      </envelope>
+
+      <!-- set the detecor type flag - note: using the '+' operator here as the evaluator does not understand '|' 
+	   -> be carefull not to add any flags twice !!!     -->
+      <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX "/>
+  
+      <!-- database : TMP_DB10 -->
+      <!-- SQL command: "select * from layers_common_parameters;"  -->
+      <layers_common_parameters id="1"
+				electronics_structure_thickness="0.1*mm"
+				active_silicon_thickness="0.05*mm"
+				support_structure_radial_thickness="0.49392*mm"
+				end_electronics_half_z="5*mm" 
+				strip_final_beampipe_radious="VXD_inner_radius_1"	
+				side_band_electronics_option="1"
+				end_ladd_electronics_option="1"
+				side_band_electronics_width="0.5*mm" 
+				side_band_electronics_thickness="0.05*mm"
+				active_side_band_electronics_option="0"
+				layer_gap="2*mm"
+				flex_cable_material="G4_KAPTON"
+				flex_cable_thickness="0.05*mm"
+				foam_spacer_material="SiC_foam"
+				foam_spacer_thickness="0.94*mm"
+				metal_traces_material="G4_Al"
+				metal_traces_thickness="0.01*mm"
+				cool_pipe_material="titanium" 
+				cool_pipe_inner_radius="0.75*mm"
+				cool_pipe_outer_radius="1*mm"
+				external_kapton_thickness="0.05*mm"
+				external_metal_thickness="0.009*mm"  />
+      <!-- SQL command: "SELECT * FROM cryostat;"  -->
+      <cryostat id="1" alu_skin_inner_radious="85*mm" alu_skin_tickness="0.5*mm" foam_inner_radious="80*mm" foam_tickness="10*mm" foam_half_z="466*mm" 
+		endplate_inner_radious="VXD_inner_radius_1" 
+		cryostat_option="0" cryostat_apperture="30*mm" cryostat_apperture_radius="1.5*mm"  />
+      <!-- SQL command: "select * from support_shell;"  -->
+      <support_shell id="0" inner_radious="65*mm" half_z="435*mm" thickess="0.49392*mm" endplate_inner_radious="30*mm" endplate_inner_radius_L1="15.7*mm" endplate_outer_radius_L1="20*mm" 
+		     offset_ladder_block="0.28224*mm" beryllium_ladder_block_length="5*mm" beryllium_ladder_block_thickness="0.25*mm" shell_endplate_thickness="2*mm" forward_shell_half_z="6.5*mm"  />
+      <!-- SQL command: "select * from layer;"  -->
+      <layer id="0" layer_radius="VXD_radius_r1" ladder_length="VXD_length_r1" ladder_width="5.5*mm" nb_ladder="10" ladder_gap="0*mm" end_electronics_width="5.5*mm" 
+	     initial_kapton_striplines_thickness="0.04566*mm" final_kapton_striplines_thickness="0.02435*mm" initial_metal_striplines_thickness="0.00806*mm" 
+	     final_metal_striplines_thickness="0.0043*mm" support_width="4.5*mm"  />
+      <layer id="1" layer_radius="VXD_radius_r1" ladder_length="VXD_length_r1" ladder_width="5.5*mm" nb_ladder="10" ladder_gap="0*mm" end_electronics_width="5.5*mm" 
+	     initial_kapton_striplines_thickness="0.04566*mm" final_kapton_striplines_thickness="0.02435*mm" initial_metal_striplines_thickness="0.00806*mm" 
+	     final_metal_striplines_thickness="0.0043*mm" support_width="4.5*mm"  />
+      <layer id="2" layer_radius="VXD_radius_r3" ladder_length="VXD_length_r3" ladder_width="11*mm" nb_ladder="11" ladder_gap="0*mm" end_electronics_width="11*mm" 
+	     initial_kapton_striplines_thickness="0.04102*mm" final_kapton_striplines_thickness="0.05059*mm" initial_metal_striplines_thickness="0.00724*mm" 
+	     final_metal_striplines_thickness="0.00893*mm" support_width="10*mm"  />
+      <layer id="3" layer_radius="VXD_radius_r3" ladder_length="VXD_length_r3" ladder_width="11*mm" nb_ladder="11" ladder_gap="0*mm" end_electronics_width="11*mm" 
+	     initial_kapton_striplines_thickness="0.04102*mm" final_kapton_striplines_thickness="0.05059*mm" initial_metal_striplines_thickness="0.00724*mm" 
+	     final_metal_striplines_thickness="0.00893*mm" support_width="10*mm"  />
+      <layer id="4" layer_radius="VXD_radius_r5" ladder_length="VXD_length_r5" ladder_width="11*mm" nb_ladder="17" ladder_gap="0*mm" end_electronics_width="11*mm" 
+	     initial_kapton_striplines_thickness="0.04044*mm" final_kapton_striplines_thickness="0.07819*mm" initial_metal_striplines_thickness="0.00714*mm" 
+	     final_metal_striplines_thickness="0.0138*mm" support_width="10*mm"  />
+      <layer id="5" layer_radius="VXD_radius_r5" ladder_length="VXD_length_r5" ladder_width="11*mm" nb_ladder="17" ladder_gap="0*mm" end_electronics_width="11*mm" 
+	     initial_kapton_striplines_thickness="0.04044*mm" final_kapton_striplines_thickness="0.07819*mm" initial_metal_striplines_thickness="0.00714*mm" 
+	     final_metal_striplines_thickness="0.0138*mm" support_width="10*mm"  />
+    </detector>
+    
+  </detectors>
+  
+  <readouts>
+    <readout name="VXDCollection">
+      <id>system:5,side:-2,layer:9,module:8,sensor:8,barrelside:-2</id>
+    </readout>
+  </readouts>
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_common_v01/VXD_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/VXD_v01_02.xml
@@ -3,7 +3,7 @@
     <constant name="VXD_inner_radius" value="Vertex_inner_radius"/>
     <constant name="VXD_outer_radius" value="Vertex_outer_radius"/>
     <constant name="VXD_half_length"  value="Vertex_half_length"/>
-    <constant name="VXD_inner_radius_1" value="BeamPipe_VertexRegion_rmax"/>
+    <constant name="VXD_inner_radius_1" value="Vertex_Side_rmin"/>
     <constant name="VXD_radius_r1" value="16*mm"/>
     <constant name="VXD_radius_r3" value="37*mm"/>
     <constant name="VXD_radius_r5" value="58*mm"/>
@@ -18,28 +18,6 @@
     <detector id="DetID_VXD" name="VXD" type="VXD04" vis="SeeThrough" readout="VXDCollection" insideTrackingVolume="true">
       <envelope>
 	<shape type="Assembly"/>
-	<!--shape type="BooleanShape" operation="Subtraction" material="Air" >
-	  <shape type="BooleanShape" operation="Subtraction" material="Air" >
-	    <shape type="BooleanShape" operation="Subtraction" material="Air" >
-	      <shape type="BooleanShape" operation="Subtraction" material="Air" >
-		<shape type="Tube" rmin="VXD_inner_radius" rmax="VXD_outer_radius" dz="VXD_half_length" />
-		<shape type="Tube" rmin="0." rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
-		<position x="0" y="0" z="VXD_half_length-(VXD_half_length - VXD_cone_max_z)/2.+ env_safety"/> 
-	      </shape>
-	      <shape type="Tube" rmin="0." rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
-	      <position x="0" y="0" z="- ( VXD_half_length-(VXD_half_length - VXD_cone_max_z)/2.+ env_safety ) "/> 
-	      <rotation x="0" y="180.*deg" z="0" />
-	    </shape>
-	    <shape type="Cone" rmin1="0" rmax1="VXD_inner_radius" rmin2="0" rmax2="VXD_inner_radius_1" 
-		   z="(VXD_cone_max_z-VXD_cone_min_z)/2. + env_safety "/>
-	    <position x="0" y="0" z="VXD_cone_min_z+(VXD_cone_max_z-VXD_cone_min_z)/2."/> 
-	  </shape>
-	  <shape type="Cone" rmin1="0" rmax1="VXD_inner_radius" rmin2="0" rmax2="VXD_inner_radius_1" 
-		 z="(VXD_cone_max_z-VXD_cone_min_z)/2. + env_safety "/>
-	  <position x="0" y="0" z="-(VXD_cone_min_z+(VXD_cone_max_z-VXD_cone_min_z)/2.)"/> 
-	  <rotation x="0" y="180.*deg" z="0" />
-	</shape-->
-	
       </envelope>
 
       <!-- set the detecor type flag - note: using the '+' operator here as the evaluator does not understand '|' 

--- a/Detector/DetCRD/compact/CRD_common_v01/VXD_v01_03.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/VXD_v01_03.xml
@@ -1,0 +1,107 @@
+<lccdd>
+  <define>
+    <constant name="VXD_inner_radius" value="Vertex_inner_radius"/>
+    <constant name="VXD_outer_radius" value="Vertex_outer_radius"/>
+    <constant name="VXD_half_length"  value="Vertex_half_length"/>
+    <constant name="VXD_inner_radius_1" value="Vertex_Side_rmin"/>
+    <constant name="VXD_radius_r1" value="12*mm"/>
+    <constant name="VXD_radius_r3" value="34*mm"/>
+    <constant name="VXD_radius_r5" value="58*mm"/>
+    <constant name="VXD_length_r1" value="62.5*mm"/>
+    <constant name="VXD_length_r3" value="125*mm"/>
+    <constant name="VXD_length_r5" value="125*mm"/>
+    <constant name="VXD_cone_max_z" value="Vertex_half_length-10*mm"/>
+    <constant name="VXD_cone_min_z" value="VXD_length_r5+10*mm"/>
+  </define>
+
+  <detectors>
+    <detector id="DetID_VXD" name="VXD" type="VXD04" vis="VXDVis" readout="VXDCollection" insideTrackingVolume="true" combineHits="true">
+      <envelope>
+	<shape type="BooleanShape" operation="Subtraction" material="Air" >
+	  <shape type="BooleanShape" operation="Subtraction" material="Air" >
+	    <shape type="BooleanShape" operation="Subtraction" material="Air" >
+	      <shape type="BooleanShape" operation="Subtraction" material="Air" >
+		<shape type="Tube" rmin="VXD_inner_radius" rmax="VXD_outer_radius" dz="VXD_half_length" />
+		<shape type="Tube" rmin="0." rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
+		<position x="0" y="0" z="VXD_half_length-(VXD_half_length - VXD_cone_max_z)/2.+ env_safety"/> 
+	      </shape>
+	      <shape type="Tube" rmin="0." rmax="VXD_inner_radius_1" dz="(VXD_half_length - VXD_cone_max_z)/2. + env_safety " />
+	      <position x="0" y="0" z="- ( VXD_half_length-(VXD_half_length - VXD_cone_max_z)/2.+ env_safety ) "/> 
+	      <rotation x="0" y="180.*deg" z="0" />
+	    </shape>
+	    <shape type="Cone" rmin1="0" rmax1="VXD_inner_radius" rmin2="0" rmax2="VXD_inner_radius_1" 
+		   z="(VXD_cone_max_z-VXD_cone_min_z)/2. + env_safety "/>
+	    <position x="0" y="0" z="VXD_cone_min_z+(VXD_cone_max_z-VXD_cone_min_z)/2."/> 
+	  </shape>
+	  <shape type="Cone" rmin1="0" rmax1="VXD_inner_radius" rmin2="0" rmax2="VXD_inner_radius_1" 
+		 z="(VXD_cone_max_z-VXD_cone_min_z)/2. + env_safety "/>
+	  <position x="0" y="0" z="-(VXD_cone_min_z+(VXD_cone_max_z-VXD_cone_min_z)/2.)"/> 
+	  <rotation x="0" y="180.*deg" z="0" />
+	</shape>
+      </envelope>
+
+      <!-- set the detecor type flag - note: using the '+' operator here as the evaluator does not understand '|' 
+	   -> be carefull not to add any flags twice !!!     -->
+      <type_flags type=" DetType_TRACKER + DetType_PIXEL + DetType_VERTEX "/>
+  
+      <!-- database : TMP_DB10 -->
+      <!-- SQL command: "select * from layers_common_parameters;"  -->
+      <layers_common_parameters id="1"
+				electronics_structure_thickness="0.1*mm"
+				active_silicon_thickness="0.05*mm"
+				support_structure_radial_thickness="0.49392*mm"
+				end_electronics_half_z="5*mm" 
+				strip_final_beampipe_radious="VXD_inner_radius_1"	
+				side_band_electronics_option="1"
+				end_ladd_electronics_option="1"
+				side_band_electronics_width="0.5*mm" 
+				side_band_electronics_thickness="0.05*mm"
+				active_side_band_electronics_option="0"
+				layer_gap="2*mm"
+				flex_cable_material="G4_KAPTON"
+				flex_cable_thickness="0.05*mm"
+				foam_spacer_material="SiC_foam"
+				foam_spacer_thickness="0.94*mm"
+				metal_traces_material="G4_Al"
+				metal_traces_thickness="0.01*mm"
+				cool_pipe_material="titanium" 
+				cool_pipe_inner_radius="0.75*mm"
+				cool_pipe_outer_radius="1*mm"
+				external_kapton_thickness="0.05*mm"
+				external_metal_thickness="0.009*mm"  />
+      <!-- SQL command: "SELECT * FROM cryostat;"  -->
+      <cryostat id="1" alu_skin_inner_radious="100*mm" alu_skin_tickness="0.5*mm" foam_inner_radious="90*mm" foam_tickness="10*mm" foam_half_z="166.6*mm" 
+		endplate_inner_radious="VXD_inner_radius_1" 
+		cryostat_option="0" cryostat_apperture="30*mm" cryostat_apperture_radius="1.5*mm"  />
+      <!-- SQL command: "select * from support_shell;"  -->
+      <support_shell id="0" inner_radious="65*mm" half_z="145*mm" thickess="0.49392*mm" endplate_inner_radious="30*mm" endplate_inner_radius_L1="15.7*mm" endplate_outer_radius_L1="20*mm" 
+		     offset_ladder_block="0.28224*mm" beryllium_ladder_block_length="5*mm" beryllium_ladder_block_thickness="0.25*mm" shell_endplate_thickness="2*mm" forward_shell_half_z="6.5*mm"  />
+      <!-- SQL command: "select * from layer;"  -->
+      <layer id="0" layer_radius="VXD_radius_r1" ladder_length="VXD_length_r1" ladder_width="5.2*mm" nb_ladder="8" ladder_gap="0" strip_line_final_z="150*mm" end_electronics_width="5.2*mm" 
+	     initial_kapton_striplines_thickness="0.04566*mm" final_kapton_striplines_thickness="0.02435*mm" initial_metal_striplines_thickness="0.00806*mm" 
+	     final_metal_striplines_thickness="0.0043*mm" support_width="4.5*mm"  />
+      <layer id="1" layer_radius="VXD_radius_r1" ladder_length="VXD_length_r1" ladder_width="5.2*mm" nb_ladder="8" ladder_gap="0" strip_line_final_z="150*mm" end_electronics_width="5.2*mm" 
+	     initial_kapton_striplines_thickness="0.04566*mm" final_kapton_striplines_thickness="0.02435*mm" initial_metal_striplines_thickness="0.00806*mm" 
+	     final_metal_striplines_thickness="0.0043*mm" support_width="4.5*mm"  />
+      <layer id="2" layer_radius="VXD_radius_r3" ladder_length="VXD_length_r3" ladder_width="10.2*mm" nb_ladder="11" ladder_gap="0*mm" strip_line_final_z="150*mm" end_electronics_width="10.2*mm" 
+	     initial_kapton_striplines_thickness="0.04102*mm" final_kapton_striplines_thickness="0.05059*mm" initial_metal_striplines_thickness="0.00724*mm" 
+	     final_metal_striplines_thickness="0.00893*mm" support_width="9.2*mm"  />
+      <layer id="3" layer_radius="VXD_radius_r3" ladder_length="VXD_length_r3" ladder_width="10.2*mm" nb_ladder="11" ladder_gap="0*mm" strip_line_final_z="150*mm" end_electronics_width="10.2*mm" 
+	     initial_kapton_striplines_thickness="0.04102*mm" final_kapton_striplines_thickness="0.05059*mm" initial_metal_striplines_thickness="0.00724*mm" 
+	     final_metal_striplines_thickness="0.00893*mm" support_width="9.2*mm"  />
+      <layer id="4" layer_radius="VXD_radius_r5" ladder_length="VXD_length_r3" ladder_width="11*mm" nb_ladder="17" ladder_gap="0*mm" strip_line_final_z="150*mm" end_electronics_width="11*mm" 
+	     initial_kapton_striplines_thickness="0.04044*mm" final_kapton_striplines_thickness="0.07819*mm" initial_metal_striplines_thickness="0.00714*mm" 
+	     final_metal_striplines_thickness="0.0138*mm" support_width="10*mm"  />
+      <layer id="5" layer_radius="VXD_radius_r5" ladder_length="VXD_length_r3" ladder_width="11*mm" nb_ladder="17" ladder_gap="0*mm" strip_line_final_z="150*mm" end_electronics_width="11*mm" 
+	     initial_kapton_striplines_thickness="0.04044*mm" final_kapton_striplines_thickness="0.07819*mm" initial_metal_striplines_thickness="0.00714*mm" 
+	     final_metal_striplines_thickness="0.0138*mm" support_width="10*mm"  />
+    </detector>
+    
+  </detectors>
+  
+  <readouts>
+    <readout name="VXDCollection">
+      <id>system:5,side:-2,layer:9,module:8,sensor:8,barrelside:-2</id>
+    </readout>
+  </readouts>
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
@@ -82,6 +82,7 @@
     <constant name="Vertex_inner_radius" value="BeamPipe_Central_inner_radius+BeamPipe_Be_total_thickness"/>
     <constant name="Vertex_outer_radius" value="101*mm"/>
     <constant name="Vertex_half_length"  value="200*mm"/>
+    <constant name="Vertex_Side_rmin"    value="BeamPipe_VertexRegion_rmax"/>
 
     <constant name="DC_Endcap_dz" value="0.1*mm"/>
     <constant name="DC_half_length"  value="2980*mm" />
@@ -150,7 +151,7 @@
     <constant name="Ecal_barrel_inner_radius" value="1860*mm"/><!--1900->1860, since 1900-2180 is range for symmetry=12, but now fixed as 8 in constructor code-->
     <constant name="Ecal_barrel_thickness"    value="280*mm"/>
     <constant name="Ecal_barrel_outer_radius" value="(Ecal_barrel_inner_radius+Ecal_barrel_thickness)/cos(pi/8)"/>
-    <constant name="Ecal_barrel_half_length"  value="3350*mm"/>
+    <constant name="Ecal_barrel_half_length"  value="3300*mm"/>
     <constant name="Ecal_barrel_symmetry"    value="8"/>
 
     <constant name="Ecal_endcap_inner_radius" value="350*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01-onlyTracker.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_o1_v01-onlyTracker.xml
@@ -13,7 +13,6 @@
   
   <includes>
     <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
-    <!--gdmlFile  ref="../CRD_common_v01/materials-woIsotope.xml"/-->
     <gdmlFile  ref="../CRD_common_v01/materials.xml"/>
   </includes>
   

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
@@ -82,6 +82,7 @@
     <constant name="Vertex_inner_radius" value="BeamPipe_Central_inner_radius+BeamPipe_Be_total_thickness"/>
     <constant name="Vertex_outer_radius" value="101*mm"/>
     <constant name="Vertex_half_length"  value="200*mm"/>
+    <constant name="Vertex_Side_rmin"    value="BeamPipe_VertexRegion_rmax"/>
 
     <constant name="DC_Endcap_dz" value="0.1*mm"/>
     <constant name="DC_half_length"  value="2980*mm" />
@@ -156,7 +157,7 @@
     <constant name="Ecal_endcap_inner_radius" value="350*mm"/>
     <constant name="Ecal_endcap_outer_radius" value="Ecal_barrel_inner_radius+Ecal_barrel_thickness"/>
     <constant name="Ecal_endcap_zmin"        value="3050*mm"/>
-    <constant name="Ecal_endcap_zmax"        value="3300*mm"/>
+    <constant name="Ecal_endcap_zmax"        value="3350*mm"/>
     <constant name="Ecal_endcap_symmetry"    value="8"/>
     <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
     <constant name="EcalEndcap_outer_radius" value="Ecal_barrel_outer_radius"/>

--- a/Detector/DetCRD/compact/CRD_o1_v03/CRD_Dimensions_v01_03.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v03/CRD_Dimensions_v01_03.xml
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="CRDDimensions"
+       title="master file with includes and world dimension"
+       author="C.D.Fu, Mengyao Liu"
+       url="no"
+       status="development"
+       version="1.0">
+    <comment>
+      undeterminded parameters
+    </comment>
+  </info>
+
+  <define>
+    <constant name="CrossingAngle" value="0.033*rad"/>  
+
+    <constant name="Global_endcap_costheta" value="0.99"/>
+
+    <constant name="GlobalTrackerReadoutID_DCH" type="string" value="system:8,chamber:1,layer:7,phi:16"/>
+    <constant name="GlobalTrackerReadoutID" type="string" value="system:5,side:-2,layer:9,module:8,sensor:8,barrelside:-2"/>
+
+    <constant name="Field_nominal_value" value="3*tesla"/>
+    <constant name="Field_outer_nominal_value" value="-1.3*tesla"/>
+
+    <constant name="env_safety" value="0.1*mm"/>
+
+    <constant name="DetID_NOTUSED"      value="  0"/>
+    <constant name="DetID_VXD"          value="  1"/>
+    <constant name="DetID_SIT"          value="  2"/>
+    <constant name="DetID_FTD"          value="  3"/>
+    <constant name="DetID_TPC"          value="  4"/>
+    <constant name="DetID_SET"          value="  5"/>
+    <constant name="DetID_ETD"          value="  6"/>
+    <constant name="DetID_DC"           value="  4"/> <!--in order to cheat Clupatra, same as TPC--> 
+    
+    <constant name="DetID_ECAL"         value=" 20"/>
+    <constant name="DetID_ECAL_PLUG"    value=" 21"/>
+    <constant name="DetID_HCAL"         value=" 22"/>
+    <constant name="DetID_HCAL_RING"    value=" 23"/>
+    <constant name="DetID_LCAL"         value=" 24"/>
+    <constant name="DetID_BCAL"         value=" 25"/>
+    <constant name="DetID_LHCAL"        value=" 26"/>
+    <constant name="DetID_YOKE"         value=" 27"/>
+    <constant name="DetID_COIL"         value=" 28"/>
+    <constant name="DetID_ECAL_ENDCAP"  value=" 29"/>
+    <constant name="DetID_HCAL_ENDCAP"  value=" 30"/>
+    <constant name="DetID_YOKE_ENDCAP"  value=" 31"/>
+    
+    <constant name="DetID_bwd"       value="-1"/>
+    <constant name="DetID_barrel"    value=" 0"/>
+    <constant name="DetID_fwd"       value="+1"/>
+    
+    <constant name="BeamPipe_Be_inner_thickness"   value="0.5*mm"/>
+    <constant name="BeamPipe_Cooling_thickness"    value="0.5*mm"/>
+    <constant name="BeamPipe_Be_outer_thickness"   value="0.3*mm"/>
+    <constant name="BeamPipe_Be_total_thickness"   value="BeamPipe_Be_inner_thickness+BeamPipe_Cooling_thickness+BeamPipe_Be_outer_thickness"/>
+    <constant name="BeamPipe_Al_thickness"         value="BeamPipe_Be_total_thickness"/>
+    <constant name="BeamPipe_Cu_thickness"         value="2.0*mm"/>
+    
+    <constant name="BeamPipe_CentralBe_zmax"       value="120*mm"/>
+    <constant name="BeamPipe_CentralAl_zmax"       value="205*mm"/>
+    <constant name="BeamPipe_ConeAl_zmax"          value="655*mm"/>
+    <constant name="BeamPipe_LinkerAl_zmax"        value="700*mm"/>
+    <constant name="BeamPipe_LinkerCu_zmax"        value="780*mm"/>
+    <constant name="BeamPipe_Waist_zmax"           value="805*mm"/>
+    <constant name="BeamPipe_Crotch_zmax"          value="855*mm"/>
+    <constant name="BeamPipe_FirstSeparated_zmax"  value="1110*mm"/>
+    <constant name="BeamPipe_SecondSeparated_zmax" value="2200*mm"/>
+    <constant name="BeamPipe_end_z"                value="12*m"/>
+
+    <constant name="BeamPipe_Central_inner_radius"  value="14*mm"/>
+    <constant name="BeamPipe_Expanded_inner_radius" value="20*mm"/>
+    <constant name="BeamPipe_Upstream_inner_radius" value="6*mm"/>
+    <constant name="BeamPipe_Dnstream_inner_radius" value="10*mm"/>
+    <constant name="BeamPipe_Crotch_hole_height"    value="30.67*mm"/>
+    <constant name="BeamPipe_VertexRegion_rmax"     value="BeamPipe_Central_inner_radius+BeamPipe_Al_thickness"/>
+    <constant name="BeamPipe_ForwardRegion_rmax"    value="BeamPipe_Expanded_inner_radius+BeamPipe_Cu_thickness"/>
+
+    <constant name="Vertex_inner_radius" value="BeamPipe_Central_inner_radius+BeamPipe_Be_total_thickness"/>
+    <constant name="Vertex_outer_radius" value="101*mm"/>
+    <constant name="Vertex_half_length"  value="205*mm"/>
+    <constant name="Vertex_Side_rmin"    value="BeamPipe_VertexRegion_rmax"/>
+
+    <constant name="DC_Endcap_dz" value="0.1*mm"/>
+    <constant name="DC_half_length"  value="2980*mm" />
+    <constant name="DC_safe_distance" value="0.02*mm"/>
+    <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
+    <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
+    <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_dz" />
+
+    <!--obselete for single drift chamber-->
+    <constant name="InnerTracker_half_length"  value="DC_half_length" />
+    <constant name="InnerTracker_inner_radius" value="234*mm"/>
+    <constant name="InnerTracker_outer_radius" value="909*mm"/>
+    <constant name="OuterTracker_half_length"  value="DC_half_length"/>
+    <constant name="OuterTracker_inner_radius" value="1082.18*mm"/>
+    <constant name="OuterTracker_outer_radius" value="1723*mm"/>
+
+    <!-- Parameters of single drift chamber  -->
+    <constant name="DC_chamber_layer_rbegin" value="800*mm"/>
+    <constant name="DC_chamber_layer_rend" value="1800*mm"/>
+
+    <constant name="DC_inner_radius" value="DC_chamber_layer_rbegin-SDT_inner_wall_thickness-DC_safe_distance"/>
+    <constant name="DC_outer_radius" value="DC_chamber_layer_rend+SDT_outer_wall_thickness+DC_safe_distance"/>
+
+    <constant name="SIT1_inner_radius"   value="230*mm"/>
+    <constant name="SIT2_inner_radius"   value="410*mm"/>
+    <constant name="SIT3_inner_radius"   value="590*mm"/>
+    <constant name="SIT4_inner_radius"   value="770*mm"/>
+    <constant name="SIT1_half_length"    value="461*mm"/>
+    <constant name="SIT2_half_length"    value="691*mm"/>
+    <constant name="SIT3_half_length"    value="1013*mm"/>
+    <constant name="SIT4_half_length"    value="1335*mm"/>
+
+    <constant name="SET_inner_radius"    value="1815*mm"/>
+
+    <constant name="SiTracker_barrel_endcap_gap" value="5*mm"/>
+    <constant name="SiTracker_DC_endcap_gap"     value="10*mm"/>
+    <constant name="SiTracker_endcap_z1" value="SIT1_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z2" value="SIT2_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z3" value="SIT3_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z4" value="SIT4_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z5" value="MainTracker_half_length+SiTracker_DC_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius1" value="SIT1_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius2" value="SIT2_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius3" value="SIT3_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius4" value="SIT4_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius5" value="SET_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <!--obseleted -->
+    <constant name="FTD_BeamPipe_cable_clearance"     value="10*mm"/> 
+    <constant name="FTD_BeamPipe_gap"     value="15*mm"/>
+    <constant name="FTD_InnerTracker_gap" value="5*mm"/>
+
+    <!--obseleted constance, used by old construct, should be removed while creating new constrcut--> 
+    <constant name="TPC_Ecal_Hcal_barrel_halfZ"   value="MainTracker_half_length"/>
+    <constant name="TPC_inner_radius"             value="InnerTracker_inner_radius"/>
+    <constant name="TPC_outer_radius"             value="OuterTracker_outer_radius"/>
+    <constant name="SIT1_Radius"                  value="SIT1_inner_radius"/>
+    <constant name="SIT1_Half_Length_Z"           value="SIT1_half_length"/>
+    <constant name="SIT2_Radius"                  value="InnerTracker_inner_radius"/> <!--fake, used by FTD_Simple_Staggered and FTD_cepc, now should be determined by inner tracker-->
+    <constant name="SIT2_Half_Length_Z"           value="SIT2_half_length"/>
+    <constant name="TUBE_IPOuterTube_end_z"       value="BeamPipe_CentralAl_zmax"/>
+    <constant name="TUBE_IPOuterTube_end_radius"  value="BeamPipe_Central_inner_radius+BeamPipe_Al_thickness"/>
+    <constant name="TUBE_IPOuterBulge_end_z"      value="BeamPipe_Crotch_zmax"/><!--"BeamPipe_ConeAl_zmax"/-->
+    <constant name="TUBE_IPOuterBulge_end_radius" value="BeamPipe_Crotch_zmax*tan(CrossingAngle/2)+BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness"/>
+    <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
+
+    <constant name="Ecal_barrel_inner_radius" value="1860*mm"/><!--1900->1860, since 1900-2180 is range for symmetry=12, but now fixed as 8 in constructor code-->
+    <constant name="Ecal_barrel_thickness"    value="280*mm"/>
+    <constant name="Ecal_barrel_outer_radius" value="(Ecal_barrel_inner_radius+Ecal_barrel_thickness)/cos(pi/8)"/>
+    <constant name="Ecal_barrel_half_length"  value="3300*mm"/>
+    <constant name="Ecal_barrel_symmetry"    value="8"/>
+
+    <constant name="Ecal_endcap_inner_radius" value="350*mm"/>
+    <constant name="Ecal_endcap_outer_radius" value="Ecal_barrel_inner_radius+Ecal_barrel_thickness"/>
+    <constant name="Ecal_endcap_zmin"        value="3050*mm"/>
+    <constant name="Ecal_endcap_zmax"        value="3350*mm"/>
+    <constant name="Ecal_endcap_symmetry"    value="8"/>
+    <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
+    <constant name="EcalEndcap_outer_radius" value="Ecal_barrel_outer_radius"/>
+    
+    <constant name="Solenoid_inner_radius" value="2330*mm"/>
+    <constant name="Solenoid_outer_radius" value="2480*mm"/>
+    <constant name="Solenoid_half_length" value="3830*mm"/>
+    <constant name="SolenoidCoil_half_length" value="3800*mm"/>
+    <constant name="SolenoidCoil_radius" value="2351*mm"/>
+    <constant name="SolenoidCoil_center_radius" value="(Solenoid_inner_radius+Solenoid_outer_radius)/2"/>
+
+    <constant name="Hcal_barrel_inner_radius" value="2530*mm"/>
+    <constant name="Hcal_barrel_outer_radius" value="3610*mm"/>
+    <constant name="Hcal_barrel_half_length"  value="4480*mm"/>
+    <constant name="Hcal_barrel_symmetry"    value="12"/>
+    
+    <constant name="Hcal_endcap_inner_radius" value="400*mm"/>
+    <constant name="Hcal_endcap_outer_radius" value="Ecal_barrel_outer_radius"/>
+    <constant name="Hcal_endcap_zmin" value="3400*mm"/>
+    <constant name="Hcal_endcap_zmax" value="4480*mm"/>
+    <constant name="Hcal_endcap_symmetry" value="12"/>
+    <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
+    <constant name="HcalEndcap_max_z" value="Hcal_endcap_zmax"/>
+    <constant name="Hcal_endcap_outer_symmetry" value="Hcal_endcap_symmetry"/>
+    <constant name="Hcal_outer_radius" value="Hcal_endcap_outer_radius"/>
+
+    <!--constant name="Hcal_ring_inner_radius" value="Hcal_endcap_inner_radius"/>
+    <constant name="Hcal_ring_outer_radius" value="Solenoid_inner_radius"/>
+    <constant name="Hcal_ring_zmin" value="2600*mm"/>
+    <constant name="Hcal_ring_zmax" value="Hcal_endcap_zmin-10*mm"/>
+    <constant name="Hcal_ring_symmetry" value="8"/-->
+        
+    <constant name="Yoke_barrel_inner_radius" value="3660*mm"/>
+    <constant name="Yoke_barrel_outer_radius" value="4260*mm"/>
+    <constant name="Yoke_barrel_half_length" value="Hcal_endcap_zmax"/>
+    <constant name="Yoke_barrel_symmetry" value="12"/>
+    
+    <constant name="Yoke_endcap_inner_radius" value="400*mm"/>
+    <constant name="Yoke_endcap_outer_radius" value="Yoke_barrel_outer_radius"/>
+    <constant name="Yoke_endcap_zmin" value="4660*mm"/>
+    <constant name="Yoke_endcap_zmax" value="5460*mm"/>
+    <constant name="Yoke_endcap_outer_symmetry" value="Yoke_barrel_symmetry"/>
+    <constant name="Yoke_endcap_inner_symmetry" value="0"/>
+    <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
+    <constant name="Yoke_Z_start_endcaps" value="Yoke_endcap_zmin"/>
+    
+    <!--constant name="LumiCal_zmax" value="805*mm" />
+    <constant name="LumiCal_zmin" value="700*mm"/>
+    <constant name="LumiCal_thickness" value="(LumiCal_zmax-LumiCal_zmin)/2.0"/>
+    <constant name="LumiCal_inner_radius" value="35.0*mm"/>
+    <constant name="LumiCal_outer_radius" value="100.0*mm- env_safety"/-->
+        
+    <constant name="tracker_region_zmax" value="OuterTracker_half_length"/>
+    <constant name="tracker_region_rmax" value="OuterTracker_outer_radius"/>
+
+  </define>
+  
+  <limits>
+    <limitset name="cal_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+    <limitset name="dc_limits">
+      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+    </limitset>
+    <limitset name="tracker_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+  </limits>
+
+  <regions>
+    <region name="BeampipeRegion"/>
+    <region name="VertexRegion"/>
+    <region name="ForwardRegion"/>
+  </regions>
+
+  <display>
+    <vis name="VXDVis"           alpha="0.1" r="0.1"   g=".5"      b=".5"    showDaughters="true"  visible="true"/>
+    <vis name="VXDLayerVis"      alpha="1.0" r="0.1"   g=".5"      b=".5"    showDaughters="true"  visible="true"/>
+    <vis name="VXDSupportVis"    alpha="1.0" r="0.0"   g="1.0"     b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="FTDVis"           alpha="1.0" r="0.5"   g="0.87"    b="0.11"  showDaughters="true"  visible="true"/>
+    <vis name="FTDSupportVis"    alpha="1.0" r="0.3"   g="0.3"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="FTDSensitiveVis"  alpha="1.0" r="0.3"   g="0.5"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="DCVis"            alpha="1.0" r="0.96"  g="0.64"    b="0.90"  showDaughters="true"  visible="true"/>
+    <vis name="DCLayerVis"       alpha="1.0" r="0.96"  g="0.64"    b="0.90"  showDaughters="false" visible="true"/>
+    <vis name="SITVis"           alpha="0.0" r="0.54"  g="0.59"    b="0.93"  showDaughters="true"  visible="false"/>
+    <vis name="SITSupportVis"    alpha="1.0" r="0.0"   g="0.0"     b="1.0"   showDaughters="false" visible="true"/>
+    <vis name="SITSensitiveVis"  alpha="1.0" r="0.67"  g="0.99"    b="0.78"  showDaughters="false" visible="true"/>
+    <vis name="SETVis"           alpha="0.0" r="0.8"   g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
+    <vis name="SETSupportVis"    alpha="1.0" r="1.0"   g="0.0"     b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="SETSensitiveVis"  alpha="1.0" r="0.0"   g="0.0"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="ECALVis"          alpha="1.0" r="0.2"   g="0.6"     b="0"     showDaughters="true"  visible="true"/>
+    <vis name="HCALVis"          alpha="1.0" r="0.95"  g="0.78"    b="0.69"  showDaughters="true"  visible="true"/>
+    <vis name="SOLVis"           alpha="1.0" r="0.4"   g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
+    <vis name="YOKEVis"          alpha="1.0" r="0.64"  g="0.75"    b="0.99"  showDaughters="false" visible="true"/>
+    <vis name="LCALVis"          alpha="1.0" r="0.25"  g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
+    <vis name="SupportVis"       alpha="1.0" r="0.2"   g="0.2"     b="0.2"   showDaughters="true"  visible="true"/>
+    <vis name="ShellVis"         alpha="1.0" r="0.83"  g="0.55"    b="0.89"  showDaughters="false" visible="true"/>
+
+    <vis name="WhiteVis"         alpha="0.0" r=".96" g=".96"  b=".96"   showDaughters="true"  visible="true"/>
+    <vis name="LightGrayVis"     alpha="0.0" r=".75" g=".75"  b=".75"   showDaughters="true"  visible="true"/>
+    <vis name="Invisible"        alpha="0.0" r="0.0" g="0.0"  b="0.0"   showDaughters="false"  visible="false"/>
+    <vis name="SeeThrough"       alpha="0.0" r="0.0" g="0.0"  b="0.0"   showDaughters="true"  visible="false"/>
+    <vis name="RedVis"           alpha="1.0" r="1.0" g="0.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="GreenVis"         alpha="1.0" r="0.0" g="1.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="BlueVis"          alpha="1.0" r="0.0" g="0.0"  b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="CyanVis"          alpha="1.0" r="0.0" g="1.0"  b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="MagentaVis"       alpha="1.0" r="1.0" g="0.0"  b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="YellowVis"        alpha="1.0" r="1.0" g="1.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="BlackVis"         alpha="1.0" r="0.0" g="0.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="GrayVis"          alpha="1.0" r="0.5" g="0.5"  b="0.5"   showDaughters="true"  visible="true"/>
+  </display>
+
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03-onlyTracker.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03-onlyTracker.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+  <info name="CRD_o1_v03"
+        title="CepC reference detctor with coil inside Hcal, pixel SIT/SET"
+        author="C.D.Fu, "
+        url="http://cepc.ihep.ac.cn"
+        status="developing"
+        version="v03">
+    <comment>CepC reference detector simulation models used for detector study </comment>
+  </info>
+  
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="../CRD_common_v01/materials.xml"/>
+    <gdmlFile  ref="../materials.xml"/>
+  </includes>
+  
+  <define>
+    <constant name="world_size" value="25*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+  </define>
+
+  <include ref="./CRD_Dimensions_v01_03.xml"/>
+
+  <include ref="../CRD_common_v01/Beampipe_v01_01.xml"/>
+  <include ref="../CRD_common_v01/VXD_StaggeredLadder_v01_01.xml"/>
+  <include ref="../CRD_common_v01/FTD_SkewRing_v01_01.xml"/>
+  <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
+  
+  <fields>
+    <field name="InnerSolenoid" type="solenoid"
+           inner_field="Field_nominal_value"
+           outer_field="0"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="SolenoidCoil_center_radius"
+           outer_radius="Solenoid_outer_radius">
+    </field>
+    <field name="OuterSolenoid" type="solenoid"
+           inner_field="0"
+           outer_field="Field_outer_nominal_value"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="Solenoid_outer_radius"
+           outer_radius="Yoke_barrel_inner_radius">
+    </field>
+  </fields>
+
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03-onlyVXD.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03-onlyVXD.xml
@@ -2,12 +2,12 @@
 <lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
        xmlns:xs="http://www.w3.org/2001/XMLSchema"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
-  <info name="CRD_o1_v02"
+  <info name="CRD_o1_v03"
         title="CepC reference detctor with coil inside Hcal, pixel SIT and strip SET"
         author="Hao Zeng"
         url="http://cepc.ihep.ac.cn"
         status="developing"
-        version="v01">
+        version="v03">
     <comment>CepC reference detector simulation models used for detector study </comment>
   </info>
   
@@ -26,7 +26,7 @@
     <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
   </define>
 
-  <include ref="../CRD_o1_v02/CRD_Dimensions_v01_02.xml"/>
+  <include ref="./CRD_Dimensions_v01_03.xml"/>
 
   <include ref="../CRD_common_v01/VXD_StaggeredLadder_v01_01.xml"/>
 

--- a/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+  <info name="CRD_o1_v03"
+        title="CepC reference detctor with coil inside Hcal, pixel SIT/SET"
+        author="C.D.Fu, "
+        url="http://cepc.ihep.ac.cn"
+        status="developing"
+        version="v03">
+    <comment>CepC reference detector simulation models used for detector study </comment>
+  </info>
+  
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="../CRD_common_v01/materials.xml"/>
+  </includes>
+  
+  <define>
+    <constant name="world_size" value="25*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+  </define>
+
+  <include ref="./CRD_Dimensions_v01_03.xml"/>
+
+  <include ref="../CRD_common_v01/Beampipe_v01_01.xml"/>
+  <include ref="../CRD_common_v01/VXD_StaggeredLadder_v01_01.xml"/>
+  <include ref="../CRD_common_v01/FTD_SkewRing_v01_01.xml"/>
+  <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
+  <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->
+  <include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Hcal_Rpc_Barrel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Hcal_Rpc_Endcaps_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Yoke_Barrel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Yoke_Endcaps_v01_01.xml"/>
+  <!--include ref="../CRD_common_v01/Lcal_v01_01.xml"/-->
+  
+  <fields>
+    <field name="InnerSolenoid" type="solenoid"
+           inner_field="Field_nominal_value"
+           outer_field="0"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="SolenoidCoil_center_radius"
+           outer_radius="Solenoid_outer_radius">
+    </field>
+    <field name="OuterSolenoid" type="solenoid"
+           inner_field="0"
+           outer_field="Field_outer_nominal_value"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="Solenoid_outer_radius"
+           outer_radius="Yoke_barrel_inner_radius">
+    </field>
+  </fields>
+
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_o1_v04/CRD_Dimensions_v01_04.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v04/CRD_Dimensions_v01_04.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+
+  <info name="CRDDimensions"
+       title="master file with includes and world dimension"
+       author="C.D.Fu"
+       url="no"
+       status="development"
+       version="1.0">
+    <comment>
+      undeterminded parameters
+    </comment>
+  </info>
+
+  <define>
+    <constant name="CrossingAngle" value="0.033*rad"/>  
+
+    <constant name="Global_endcap_costheta" value="0.99"/>
+
+    <constant name="GlobalTrackerReadoutID_DCH" type="string" value="system:8,chamber:1,layer:7,phi:16"/>
+    <constant name="GlobalTrackerReadoutID" type="string" value="system:5,side:-2,layer:9,module:8,sensor:8,barrelside:-2"/>
+
+    <constant name="Field_nominal_value" value="3*tesla"/>
+    <constant name="Field_outer_nominal_value" value="-1.3*tesla"/>
+
+    <constant name="env_safety" value="0.1*mm"/>
+
+    <constant name="DetID_NOTUSED"      value="  0"/>
+    <constant name="DetID_VXD"          value="  1"/>
+    <constant name="DetID_SIT"          value="  2"/>
+    <constant name="DetID_FTD"          value="  3"/>
+    <constant name="DetID_TPC"          value="  4"/>
+    <constant name="DetID_SET"          value="  5"/>
+    <constant name="DetID_ETD"          value="  6"/>
+    <constant name="DetID_DC"           value="  4"/> <!--in order to cheat Clupatra, same as TPC--> 
+    
+    <constant name="DetID_ECAL"         value=" 20"/>
+    <constant name="DetID_ECAL_PLUG"    value=" 21"/>
+    <constant name="DetID_HCAL"         value=" 22"/>
+    <constant name="DetID_HCAL_RING"    value=" 23"/>
+    <constant name="DetID_LCAL"         value=" 24"/>
+    <constant name="DetID_BCAL"         value=" 25"/>
+    <constant name="DetID_LHCAL"        value=" 26"/>
+    <constant name="DetID_YOKE"         value=" 27"/>
+    <constant name="DetID_COIL"         value=" 28"/>
+    <constant name="DetID_ECAL_ENDCAP"  value=" 29"/>
+    <constant name="DetID_HCAL_ENDCAP"  value=" 30"/>
+    <constant name="DetID_YOKE_ENDCAP"  value=" 31"/>
+    
+    <constant name="DetID_bwd"       value="-1"/>
+    <constant name="DetID_barrel"    value=" 0"/>
+    <constant name="DetID_fwd"       value="+1"/>
+    
+    <constant name="BeamPipe_Be_inner_thickness"   value="0.2*mm"/>
+    <constant name="BeamPipe_Cooling_thickness"    value="0.35*mm"/>
+    <constant name="BeamPipe_Be_outer_thickness"   value="0.15*mm"/>
+    <constant name="BeamPipe_Be_total_thickness"   value="BeamPipe_Be_inner_thickness+BeamPipe_Cooling_thickness+BeamPipe_Be_outer_thickness"/>
+    <constant name="BeamPipe_Al_thickness"         value="BeamPipe_Be_total_thickness"/>
+    <constant name="BeamPipe_Cu_thickness"         value="4.0*mm"/>
+    
+    <constant name="BeamPipe_CentralBe_zmax"       value="85*mm"/>
+    <constant name="BeamPipe_CentralAl_zmax"       value="180*mm"/>
+    <constant name="BeamPipe_ExpandAl_zmax"        value="655*mm"/>
+    <constant name="BeamPipe_Linker_zmin"          value="700*mm"/>
+    <constant name="BeamPipe_Linker_zmax"          value="780*mm"/>
+    <constant name="BeamPipe_Waist_zmax"           value="805*mm"/>
+    <constant name="BeamPipe_Crotch_zmax"          value="855*mm"/>
+    <constant name="BeamPipe_FirstSeparated_zmax"  value="1110*mm"/>
+    <constant name="BeamPipe_Mask_zmin"            value="1210*mm"/>
+    <constant name="BeamPipe_Mask_zmax"            value="1230*mm"/>
+    <constant name="BeamPipe_SecondSeparated_zmax" value="2200*mm"/>
+    <constant name="BeamPipe_end_z"                value="12*m"/>
+
+    <constant name="BeamPipe_Central_inner_radius"  value="10*mm"/>
+    <constant name="BeamPipe_Fork_inner_radius"     value="10*mm"/>
+    <constant name="BeamPipe_FirstExpand_width"     value="35*mm"/>
+    <constant name="BeamPipe_SecondExpand_width"    value="39*mm"/>
+    <constant name="BeamPipe_Mask_inner_radius"     value="6*mm"/>
+    <constant name="BeamPipe_VertexRegion_rmax"     value="BeamPipe_Central_inner_radius+BeamPipe_Al_thickness"/>
+    <constant name="BeamPipe_FrontLinker_rmax"      value="BeamPipe_FirstExpand_width/2+BeamPipe_Al_thickness"/>
+    <constant name="BeamPipe_ForwardRegion_rmax"    value="BeamPipe_SecondExpand_width/2+BeamPipe_Cu_thickness"/>
+
+    <constant name="Vertex_inner_radius" value="BeamPipe_Central_inner_radius+BeamPipe_Be_total_thickness"/>
+    <constant name="Vertex_outer_radius" value="70*mm"/>
+    <constant name="Vertex_half_length"  value="200*mm"/>
+    <constant name="Vertex_Side_rmin"    value="BeamPipe_VertexRegion_rmax+(BeamPipe_FrontLinker_rmax-BeamPipe_VertexRegion_rmax)/(BeamPipe_ExpandAl_zmax-BeamPipe_CentralAl_zmax)
+						                          *(Vertex_half_length-BeamPipe_CentralAl_zmax)"/>
+
+    <constant name="DC_Endcap_dz" value="0.1*mm"/>
+    <constant name="DC_half_length"  value="2980*mm" />
+    <constant name="DC_safe_distance" value="0.02*mm"/>
+    <constant name="SDT_inner_wall_thickness" value="0.315*mm"/>
+    <constant name="SDT_outer_wall_thickness" value="3.86*mm"/>
+    <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_dz" />
+
+    <!--obselete for single drift chamber-->
+    <constant name="InnerTracker_half_length"  value="DC_half_length" />
+    <constant name="InnerTracker_inner_radius" value="234*mm"/>
+    <constant name="InnerTracker_outer_radius" value="909*mm"/>
+    <constant name="OuterTracker_half_length"  value="DC_half_length"/>
+    <constant name="OuterTracker_inner_radius" value="1082.18*mm"/>
+    <constant name="OuterTracker_outer_radius" value="1723*mm"/>
+
+    <!-- Parameters of single drift chamber  -->
+    <constant name="DC_chamber_layer_rbegin" value="1000*mm"/>
+    <constant name="DC_chamber_layer_rend" value="1800*mm"/>
+
+    <constant name="DC_inner_radius" value="DC_chamber_layer_rbegin-SDT_inner_wall_thickness-DC_safe_distance"/>
+    <constant name="DC_outer_radius" value="DC_chamber_layer_rend+SDT_outer_wall_thickness+DC_safe_distance"/>
+
+    <constant name="SIT1_inner_radius"   value="80*mm"/>
+    <constant name="SIT3_inner_radius"   value="DC_chamber_layer_rbegin-30*mm"/>
+    <constant name="SIT2_inner_radius"   value="0.5*(SIT1_inner_radius+SIT3_inner_radius)"/>
+    <constant name="SIT4_inner_radius"   value="770*mm"/>
+    <constant name="SIT1_half_length"    value="461*mm"/>
+    <constant name="SIT2_half_length"    value="691*mm"/>
+    <constant name="SIT3_half_length"    value="1013*mm"/>
+    <constant name="SIT4_half_length"    value="1335*mm"/>
+
+    <constant name="SET_inner_radius"    value="1815*mm"/>
+
+    <constant name="SiTracker_barrel_endcap_gap" value="5*mm"/>
+    <constant name="SiTracker_DC_endcap_gap"     value="10*mm"/>
+    <constant name="SiTracker_endcap_z1" value="Vertex_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z2" value="SiTracker_endcap_z1+100*mm"/>
+    <constant name="SiTracker_endcap_z3" value="SIT1_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z4" value="SIT2_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z5" value="SIT3_half_length+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_z6" value="0.5*(SIT3_half_length+MainTracker_half_length)"/>
+    <constant name="SiTracker_endcap_z7" value="MainTracker_half_length+SiTracker_DC_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius1" value="Vertex_outer_radius"/>
+    <constant name="SiTracker_endcap_outer_radius2" value="Vertex_outer_radius"/>
+    <constant name="SiTracker_endcap_outer_radius3" value="SIT1_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius4" value="SIT2_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius5" value="SIT3_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius6" value="SIT3_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius7" value="SET_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <!--obseleted -->
+    <constant name="FTD_BeamPipe_cable_clearance"     value="10*mm"/> 
+    <constant name="FTD_BeamPipe_gap"     value="15*mm"/>
+    <constant name="FTD_InnerTracker_gap" value="5*mm"/>
+
+    <!--obseleted constance, used by old construct, should be removed while creating new constrcut--> 
+    <constant name="TPC_Ecal_Hcal_barrel_halfZ"   value="MainTracker_half_length"/>
+    <constant name="TPC_inner_radius"             value="InnerTracker_inner_radius"/>
+    <constant name="TPC_outer_radius"             value="OuterTracker_outer_radius"/>
+    <constant name="SIT1_Radius"                  value="SIT1_inner_radius"/>
+    <constant name="SIT1_Half_Length_Z"           value="SIT1_half_length"/>
+    <constant name="SIT2_Radius"                  value="InnerTracker_inner_radius"/> <!--fake, used by FTD_Simple_Staggered and FTD_cepc, now should be determined by inner tracker-->
+    <constant name="SIT2_Half_Length_Z"           value="SIT2_half_length"/>
+    <constant name="TUBE_IPOuterTube_end_z"       value="BeamPipe_CentralAl_zmax"/>
+    <constant name="TUBE_IPOuterTube_end_radius"  value="BeamPipe_Central_inner_radius+BeamPipe_Al_thickness"/>
+    <constant name="TUBE_IPOuterBulge_end_z"      value="BeamPipe_Crotch_zmax"/><!--"BeamPipe_ConeAl_zmax"/-->
+    <!--constant name="TUBE_IPOuterBulge_end_radius" value="BeamPipe_Crotch_zmax*tan(CrossingAngle/2)+BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness"/-->
+    <!--"BeamPipe_Expanded_inner_radius+BeamPipe_Al_thickness+5*mm"/-->
+
+    <constant name="Ecal_barrel_inner_radius" value="1860*mm"/><!--1900->1860, since 1900-2180 is range for symmetry=12, but now fixed as 8 in constructor code-->
+    <constant name="Ecal_barrel_thickness"    value="280*mm"/>
+    <constant name="Ecal_barrel_outer_radius" value="(Ecal_barrel_inner_radius+Ecal_barrel_thickness)/cos(pi/8)"/>
+    <constant name="Ecal_barrel_half_length"  value="3300*mm"/>
+    <constant name="Ecal_barrel_symmetry"    value="8"/>
+
+    <constant name="Ecal_endcap_inner_radius" value="350*mm"/>
+    <constant name="Ecal_endcap_outer_radius" value="Ecal_barrel_inner_radius+Ecal_barrel_thickness"/>
+    <constant name="Ecal_endcap_zmin"        value="3050*mm"/>
+    <constant name="Ecal_endcap_zmax"        value="3350*mm"/>
+    <constant name="Ecal_endcap_symmetry"    value="8"/>
+    <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
+    <constant name="EcalEndcap_outer_radius" value="Ecal_barrel_outer_radius"/>
+    
+    <constant name="Solenoid_inner_radius" value="2330*mm"/>
+    <constant name="Solenoid_outer_radius" value="2480*mm"/>
+    <constant name="Solenoid_half_length" value="3830*mm"/>
+    <constant name="SolenoidCoil_half_length" value="3800*mm"/>
+    <constant name="SolenoidCoil_radius" value="2351*mm"/>
+    <constant name="SolenoidCoil_center_radius" value="(Solenoid_inner_radius+Solenoid_outer_radius)/2"/>
+
+    <constant name="Hcal_barrel_inner_radius" value="2530*mm"/>
+    <constant name="Hcal_barrel_outer_radius" value="3610*mm"/>
+    <constant name="Hcal_barrel_half_length"  value="4480*mm"/>
+    <constant name="Hcal_barrel_symmetry"    value="12"/>
+    
+    <constant name="Hcal_endcap_inner_radius" value="400*mm"/>
+    <constant name="Hcal_endcap_outer_radius" value="Ecal_barrel_outer_radius"/>
+    <constant name="Hcal_endcap_zmin" value="3400*mm"/>
+    <constant name="Hcal_endcap_zmax" value="4480*mm"/>
+    <constant name="Hcal_endcap_symmetry" value="12"/>
+    <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
+    <constant name="HcalEndcap_max_z" value="Hcal_endcap_zmax"/>
+    <constant name="Hcal_endcap_outer_symmetry" value="Hcal_endcap_symmetry"/>
+    <constant name="Hcal_outer_radius" value="Hcal_endcap_outer_radius"/>
+
+    <!--constant name="Hcal_ring_inner_radius" value="Hcal_endcap_inner_radius"/>
+    <constant name="Hcal_ring_outer_radius" value="Solenoid_inner_radius"/>
+    <constant name="Hcal_ring_zmin" value="2600*mm"/>
+    <constant name="Hcal_ring_zmax" value="Hcal_endcap_zmin-10*mm"/>
+    <constant name="Hcal_ring_symmetry" value="8"/-->
+        
+    <constant name="Yoke_barrel_inner_radius" value="3660*mm"/>
+    <constant name="Yoke_barrel_outer_radius" value="4260*mm"/>
+    <constant name="Yoke_barrel_half_length" value="Hcal_endcap_zmax"/>
+    <constant name="Yoke_barrel_symmetry" value="12"/>
+    
+    <constant name="Yoke_endcap_inner_radius" value="400*mm"/>
+    <constant name="Yoke_endcap_outer_radius" value="Yoke_barrel_outer_radius"/>
+    <constant name="Yoke_endcap_zmin" value="4660*mm"/>
+    <constant name="Yoke_endcap_zmax" value="5460*mm"/>
+    <constant name="Yoke_endcap_outer_symmetry" value="Yoke_barrel_symmetry"/>
+    <constant name="Yoke_endcap_inner_symmetry" value="0"/>
+    <!--obseleted constance, used by old construct, should be removed while creating new constrcut-->
+    <constant name="Yoke_Z_start_endcaps" value="Yoke_endcap_zmin"/>
+    
+    <!--constant name="LumiCal_zmax" value="805*mm" />
+    <constant name="LumiCal_zmin" value="700*mm"/>
+    <constant name="LumiCal_thickness" value="(LumiCal_zmax-LumiCal_zmin)/2.0"/>
+    <constant name="LumiCal_inner_radius" value="35.0*mm"/>
+    <constant name="LumiCal_outer_radius" value="100.0*mm- env_safety"/-->
+        
+    <constant name="tracker_region_zmax" value="OuterTracker_half_length"/>
+    <constant name="tracker_region_rmax" value="OuterTracker_outer_radius"/>
+
+  </define>
+  
+  <limits>
+    <limitset name="cal_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+    <limitset name="dc_limits">
+      <limit name="step_length_max" particles="*" value="10.0" unit="mm" />
+    </limitset>
+    <limitset name="tracker_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+  </limits>
+
+  <regions>
+    <region name="BeampipeRegion"/>
+    <region name="VertexRegion"/>
+    <region name="ForwardRegion"/>
+  </regions>
+
+  <display>
+    <vis name="VXDVis"           alpha="0.1" r="0.1"   g=".5"      b=".5"    showDaughters="true"  visible="true"/>
+    <vis name="VXDLayerVis"      alpha="1.0" r="0.1"   g=".5"      b=".5"    showDaughters="true"  visible="true"/>
+    <vis name="VXDSupportVis"    alpha="1.0" r="0.0"   g="1.0"     b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="FTDVis"           alpha="1.0" r="0.5"   g="0.87"    b="0.11"  showDaughters="true"  visible="true"/>
+    <vis name="FTDSupportVis"    alpha="1.0" r="0.3"   g="0.3"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="FTDSensitiveVis"  alpha="1.0" r="0.3"   g="0.5"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="DCVis"            alpha="1.0" r="0.96"  g="0.64"    b="0.90"  showDaughters="true"  visible="true"/>
+    <vis name="DCLayerVis"       alpha="1.0" r="0.96"  g="0.64"    b="0.90"  showDaughters="false" visible="true"/>
+    <vis name="SITVis"           alpha="0.0" r="0.54"  g="0.59"    b="0.93"  showDaughters="true"  visible="false"/>
+    <vis name="SITSupportVis"    alpha="1.0" r="0.0"   g="0.0"     b="1.0"   showDaughters="false" visible="true"/>
+    <vis name="SITSensitiveVis"  alpha="1.0" r="0.67"  g="0.99"    b="0.78"  showDaughters="false" visible="true"/>
+    <vis name="SETVis"           alpha="0.0" r="0.8"   g="0.8"     b="0.4"   showDaughters="true"  visible="false"/>
+    <vis name="SETSupportVis"    alpha="1.0" r="1.0"   g="0.0"     b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="SETSensitiveVis"  alpha="1.0" r="0.0"   g="0.0"     b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="ECALVis"          alpha="1.0" r="0.2"   g="0.6"     b="0"     showDaughters="true"  visible="true"/>
+    <vis name="HCALVis"          alpha="1.0" r="0.95"  g="0.78"    b="0.69"  showDaughters="true"  visible="true"/>
+    <vis name="SOLVis"           alpha="1.0" r="0.4"   g="0.4"     b="0.4"   showDaughters="true"  visible="true"/>
+    <vis name="YOKEVis"          alpha="1.0" r="0.64"  g="0.75"    b="0.99"  showDaughters="false" visible="true"/>
+    <vis name="LCALVis"          alpha="1.0" r="0.25"  g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
+    <vis name="SupportVis"       alpha="1.0" r="0.2"   g="0.2"     b="0.2"   showDaughters="true"  visible="true"/>
+    <vis name="ShellVis"         alpha="1.0" r="0.83"  g="0.55"    b="0.89"  showDaughters="false" visible="true"/>
+
+    <vis name="WhiteVis"         alpha="0.0" r=".96" g=".96"  b=".96"   showDaughters="true"  visible="true"/>
+    <vis name="LightGrayVis"     alpha="0.0" r=".75" g=".75"  b=".75"   showDaughters="true"  visible="true"/>
+    <vis name="Invisible"        alpha="0.0" r="0.0" g="0.0"  b="0.0"   showDaughters="false"  visible="false"/>
+    <vis name="SeeThrough"       alpha="0.0" r="0.0" g="0.0"  b="0.0"   showDaughters="true"  visible="false"/>
+    <vis name="RedVis"           alpha="1.0" r="1.0" g="0.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="GreenVis"         alpha="1.0" r="0.0" g="1.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="BlueVis"          alpha="1.0" r="0.0" g="0.0"  b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="CyanVis"          alpha="1.0" r="0.0" g="1.0"  b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="MagentaVis"       alpha="1.0" r="1.0" g="0.0"  b="1.0"   showDaughters="true"  visible="true"/>
+    <vis name="YellowVis"        alpha="1.0" r="1.0" g="1.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="BlackVis"         alpha="1.0" r="0.0" g="0.0"  b="0.0"   showDaughters="true"  visible="true"/>
+    <vis name="GrayVis"          alpha="1.0" r="0.5" g="0.5"  b="0.5"   showDaughters="true"  visible="true"/>
+  </display>
+
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_o1_v04/CRD_Dimensions_v01_04.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v04/CRD_Dimensions_v01_04.xml
@@ -5,7 +5,7 @@
 
   <info name="CRDDimensions"
        title="master file with includes and world dimension"
-       author="C.D.Fu"
+       author="C.D.Fu, Mengyao Liu"
        url="no"
        status="development"
        version="1.0">
@@ -91,8 +91,8 @@
     <constant name="DC_Endcap_dz" value="0.1*mm"/>
     <constant name="DC_half_length"  value="2980*mm" />
     <constant name="DC_safe_distance" value="0.02*mm"/>
-    <constant name="SDT_inner_wall_thickness" value="0.315*mm"/>
-    <constant name="SDT_outer_wall_thickness" value="3.86*mm"/>
+    <constant name="SDT_inner_wall_thickness" value="0.2*mm"/>
+    <constant name="SDT_outer_wall_thickness" value="2.8*mm"/>
     <constant name="MainTracker_half_length"  value="DC_half_length+DC_Endcap_dz" />
 
     <!--obselete for single drift chamber-->

--- a/Detector/DetCRD/compact/CRD_o1_v04/CRD_o1_v04-onlyTracker.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v04/CRD_o1_v04-onlyTracker.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+  <info name="CRD_o1_v04"
+        title="CepC reference detctor with coil inside Hcal, pixel SIT/SET"
+        author="C.D.Fu, "
+        url="http://cepc.ihep.ac.cn"
+        status="developing"
+        version="v04">
+    <comment>CepC reference detector simulation models used for detector study </comment>
+  </info>
+  
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="../CRD_common_v01/materials.xml"/>
+  </includes>
+  
+  <define>
+    <constant name="world_size" value="25*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+  </define>
+
+  <include ref="./CRD_Dimensions_v01_04.xml"/>
+
+  <include ref="../CRD_common_v01/Beampipe_v01_02.xml"/>
+  <include ref="../CRD_common_v01/VXD_v01_03.xml"/>
+  <include ref="../CRD_common_v01/FTD_SkewRing_v01_03.xml"/>
+  <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
+
+  <fields>
+    <field name="InnerSolenoid" type="solenoid"
+           inner_field="Field_nominal_value"
+           outer_field="0"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="SolenoidCoil_center_radius"
+           outer_radius="Solenoid_outer_radius">
+    </field>
+    <field name="OuterSolenoid" type="solenoid"
+           inner_field="0"
+           outer_field="Field_outer_nominal_value"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="Solenoid_outer_radius"
+           outer_radius="Yoke_barrel_inner_radius">
+    </field>
+  </fields>
+
+</lccdd>

--- a/Detector/DetCRD/compact/CRD_o1_v04/CRD_o1_v04.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v04/CRD_o1_v04.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+  <info name="CRD_o1_v04"
+        title="CepC reference detctor with coil inside Hcal, pixel SIT/SET"
+        author="C.D.Fu, "
+        url="http://cepc.ihep.ac.cn"
+        status="developing"
+        version="v04">
+    <comment>CepC reference detector simulation models used for detector study </comment>
+  </info>
+  
+  <includes>
+    <gdmlFile  ref="${DD4hepINSTALL}/DDDetectors/compact/elements.xml"/>
+    <gdmlFile  ref="../CRD_common_v01/materials.xml"/>
+  </includes>
+  
+  <define>
+    <constant name="world_size" value="25*m"/>
+    <constant name="world_x" value="world_size"/>
+    <constant name="world_y" value="world_size"/>
+    <constant name="world_z" value="world_size"/>
+
+    <include ref="${DD4hepINSTALL}/DDDetectors/compact/detector_types.xml"/>
+  </define>
+
+  <include ref="./CRD_Dimensions_v01_04.xml"/>
+
+  <include ref="../CRD_common_v01/Beampipe_v01_02.xml"/>
+  <include ref="../CRD_common_v01/VXD_v01_03.xml"/>
+  <include ref="../CRD_common_v01/FTD_SkewRing_v01_03.xml"/>
+  <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
+  <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->
+  <include ref="../CRD_common_v01/Coil_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Hcal_Rpc_Barrel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Hcal_Rpc_Endcaps_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Yoke_Barrel_v01_01.xml"/>
+  <include ref="../CRD_common_v01/Yoke_Endcaps_v01_01.xml"/>
+  
+  <fields>
+    <field name="InnerSolenoid" type="solenoid"
+           inner_field="Field_nominal_value"
+           outer_field="0"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="SolenoidCoil_center_radius"
+           outer_radius="Solenoid_outer_radius">
+    </field>
+    <field name="OuterSolenoid" type="solenoid"
+           inner_field="0"
+           outer_field="Field_outer_nominal_value"
+           zmax="SolenoidCoil_half_length"
+           inner_radius="Solenoid_outer_radius"
+           outer_radius="Yoke_barrel_inner_radius">
+    </field>
+  </fields>
+
+</lccdd>

--- a/Detector/DetCRD/compact/README.md
+++ b/Detector/DetCRD/compact/README.md
@@ -5,7 +5,9 @@ The following CRD detector models are available in CEPCSW
 | Model         |  Description                 | MainTracker |  Ecal   | Hcal | Status         |
 | ------------- | -----------------------------|------------ |---------|------|----------------|
 | CRD_o1_v01    | coil inside simulation model | SIT+DC+SET  | crystal | RPC  | developing     |
-| CRD_o1_v02    | pixel SET                    | SIT+DC+SET  | crystal | RPC  | developing     |
+| CRD_o1_v02    | strip SET                    | SIT+DC+SET  | crystal | RPC  | developing     |
+| CRD_o1_v03    | MOST2 vertex                 | SIT+DC+SET  | crystal | RPC  | developing     |
+| CRD_o1_v04    | smaller center beam pipe     | SIT+DC+SET  | crystal | RPC  | developing     |
 | ------------- | -----------------------------|-------------|---------|------|----------------|
  
 ## Details
@@ -47,3 +49,15 @@ The following CRD detector models are available in CEPCSW
  - strip SET: double layers
  - compact files:
          - [./CRD_o1_v02/CRD_o1_v02.xml](./CRD_o1_v02/CRD_o1_v02.xml)
+
+### CRD_o1_v03 (to update)
+ - based on CRD_o1_v01
+ - MOST2 vertex
+ - compact files:
+         - [./CRD_o1_v03/CRD_o1_v03.xml](./CRD_o1_v03/CRD_o1_v03.xml)
+
+### CRD_o1_v04 (to update)
+ - based on CRD_o1_v01
+ - smaller center beam pipe & new MDI: inner radius = 10mm, flat at y direction
+ - compact files:
+         - [./CRD_o1_v04/CRD_o1_v04.xml](./CRD_o1_v04/CRD_o1_v04.xml)


### PR DESCRIPTION
* complete CRD_o1_v03, created in PR#211 
  * note: based on CRD_o1_v01, but has the vertex detector designed from the MOST2 project
* create CRD_o1_v04
  * note:
    * based on CRD_o1_v01, but has new beam pipe (center pipe radius reduce from 14mm to 10mm) and moved corresponding VXD (first layer starts at r=12mm)
    * add more 2 FTD layers (5->7)
* fix Ecal length bug for CRD_o1_v01, just like PR#212 done for CRD_o1_v02
* re-define constant for VXD, Vertex_Side_rmin, will be more clear to use
* add combineHits option for silicon trackers, and then those hits from same particle and in same volume will be merged into one hit
  * can be set true or false (default) in compact file, like

```xml
<detector id="DetID_VXD" name="VXD" type="VXD04" vis="VXDVis" readout="VXDCollection" insideTrackingVolume="true"
   combineHits="true">
...
</detector>
```