### PR TITLE
WIP: according to Chengdong's suggestion, fix the memory leakage in simulation framework

### DIFF
--- a/Simulation/DetSimCore/src/DetSimSvc.cpp
+++ b/Simulation/DetSimCore/src/DetSimSvc.cpp
@@ -39,7 +39,7 @@ DetSimSvc::simulateEvent(int i_event) {
     StatusCode sc;
 
     m_runmgr->ProcessOneEvent(i_event);
-
+    m_runmgr->TerminateOneEvent();
     return sc;
 }
 


### PR DESCRIPTION
At end of the event, the event is not released. 