### PR TITLE
WIP: fix memory leak & run crash

### DIFF
--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02-onlyTracker.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_o1_v02-onlyTracker.xml
@@ -31,7 +31,7 @@
   <include ref="../CRD_common_v01/VXD_v01_01.xml"/>
   <include ref="../CRD_common_v01/FTD_SkewRing_v01_01.xml"/>
   <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_02.xml"/>
   <include ref="../CRD_common_v01/SET_SimplePlanar_v01_01.xml"/>
 
   <fields>

--- a/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03-onlyTracker.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03-onlyTracker.xml
@@ -32,7 +32,7 @@
   <include ref="../CRD_common_v01/VXD_StaggeredLadder_v01_01.xml"/>
   <include ref="../CRD_common_v01/FTD_SkewRing_v01_01.xml"/>
   <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_02.xml"/>
   <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
   
   <fields>

--- a/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v03/CRD_o1_v03.xml
@@ -31,7 +31,7 @@
   <include ref="../CRD_common_v01/VXD_StaggeredLadder_v01_01.xml"/>
   <include ref="../CRD_common_v01/FTD_SkewRing_v01_01.xml"/>
   <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_02.xml"/>
   <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
   <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
   <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->

--- a/Detector/DetCRD/compact/CRD_o1_v04/CRD_Dimensions_v01_04.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v04/CRD_Dimensions_v01_04.xml
@@ -110,10 +110,10 @@
     <constant name="DC_inner_radius" value="DC_chamber_layer_rbegin-SDT_inner_wall_thickness-DC_safe_distance"/>
     <constant name="DC_outer_radius" value="DC_chamber_layer_rend+SDT_outer_wall_thickness+DC_safe_distance"/>
 
-    <constant name="SIT1_inner_radius"   value="80*mm"/>
-    <constant name="SIT3_inner_radius"   value="DC_chamber_layer_rbegin-30*mm"/>
-    <constant name="SIT2_inner_radius"   value="0.5*(SIT1_inner_radius+SIT3_inner_radius)"/>
-    <constant name="SIT4_inner_radius"   value="770*mm"/>
+    <constant name="SIT1_inner_radius"   value="150*mm"/>
+    <constant name="SIT2_inner_radius"   value="350*mm"/>
+    <constant name="SIT4_inner_radius"   value="DC_chamber_layer_rbegin-30*mm"/>
+    <constant name="SIT3_inner_radius"   value="0.5*(SIT2_inner_radius+SIT4_inner_radius)"/>
     <constant name="SIT1_half_length"    value="461*mm"/>
     <constant name="SIT2_half_length"    value="691*mm"/>
     <constant name="SIT3_half_length"    value="1013*mm"/>
@@ -128,14 +128,14 @@
     <constant name="SiTracker_endcap_z3" value="SIT1_half_length+SiTracker_barrel_endcap_gap"/>
     <constant name="SiTracker_endcap_z4" value="SIT2_half_length+SiTracker_barrel_endcap_gap"/>
     <constant name="SiTracker_endcap_z5" value="SIT3_half_length+SiTracker_barrel_endcap_gap"/>
-    <constant name="SiTracker_endcap_z6" value="0.5*(SIT3_half_length+MainTracker_half_length)"/>
+    <constant name="SiTracker_endcap_z6" value="SIT4_half_length+SiTracker_barrel_endcap_gap"/>
     <constant name="SiTracker_endcap_z7" value="MainTracker_half_length+SiTracker_DC_endcap_gap"/>
-    <constant name="SiTracker_endcap_outer_radius1" value="Vertex_outer_radius"/>
-    <constant name="SiTracker_endcap_outer_radius2" value="Vertex_outer_radius"/>
+    <constant name="SiTracker_endcap_outer_radius1" value="SIT1_inner_radius"/>
+    <constant name="SiTracker_endcap_outer_radius2" value="SIT1_inner_radius"/>
     <constant name="SiTracker_endcap_outer_radius3" value="SIT1_inner_radius+SiTracker_barrel_endcap_gap"/>
     <constant name="SiTracker_endcap_outer_radius4" value="SIT2_inner_radius+SiTracker_barrel_endcap_gap"/>
     <constant name="SiTracker_endcap_outer_radius5" value="SIT3_inner_radius+SiTracker_barrel_endcap_gap"/>
-    <constant name="SiTracker_endcap_outer_radius6" value="SIT3_inner_radius+SiTracker_barrel_endcap_gap"/>
+    <constant name="SiTracker_endcap_outer_radius6" value="SIT4_inner_radius+SiTracker_barrel_endcap_gap"/>
     <constant name="SiTracker_endcap_outer_radius7" value="SET_inner_radius+SiTracker_barrel_endcap_gap"/>
     <!--obseleted -->
     <constant name="FTD_BeamPipe_cable_clearance"     value="10*mm"/> 
@@ -262,7 +262,7 @@
     <vis name="YOKEVis"          alpha="1.0" r="0.64"  g="0.75"    b="0.99"  showDaughters="false" visible="true"/>
     <vis name="LCALVis"          alpha="1.0" r="0.25"  g="0.88"    b="0.81"  showDaughters="true"  visible="true"/>
     <vis name="SupportVis"       alpha="1.0" r="0.2"   g="0.2"     b="0.2"   showDaughters="true"  visible="true"/>
-    <vis name="ShellVis"         alpha="1.0" r="0.83"  g="0.55"    b="0.89"  showDaughters="false" visible="true"/>
+    <vis name="ShellVis"         alpha="1.0" r="0.82"  g="0.59"    b="0.36"  showDaughters="false" visible="true"/>
 
     <vis name="WhiteVis"         alpha="0.0" r=".96" g=".96"  b=".96"   showDaughters="true"  visible="true"/>
     <vis name="LightGrayVis"     alpha="0.0" r=".75" g=".75"  b=".75"   showDaughters="true"  visible="true"/>

--- a/Detector/DetCRD/compact/CRD_o1_v04/CRD_o1_v04-onlyTracker.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v04/CRD_o1_v04-onlyTracker.xml
@@ -31,7 +31,7 @@
   <include ref="../CRD_common_v01/VXD_v01_03.xml"/>
   <include ref="../CRD_common_v01/FTD_SkewRing_v01_03.xml"/>
   <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_02.xml"/>
   <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
 
   <fields>

--- a/Detector/DetCRD/compact/CRD_o1_v04/CRD_o1_v04.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v04/CRD_o1_v04.xml
@@ -31,7 +31,7 @@
   <include ref="../CRD_common_v01/VXD_v01_03.xml"/>
   <include ref="../CRD_common_v01/FTD_SkewRing_v01_03.xml"/>
   <include ref="../CRD_common_v01/SIT_SimplePixel_v01_01.xml"/>
-  <include ref="../CRD_common_v01/DC_Simple_v01_01.xml"/>
+  <include ref="../CRD_common_v01/DC_Simple_v01_02.xml"/>
   <include ref="../CRD_common_v01/SET_SimplePixel_v01_01.xml"/>
   <include ref="../CRD_common_v01/Ecal_Crystal_Barrel_v01_01.xml"/>
   <!--include ref="../CRD_common_v01/Ecal_Crystal_Endcap_v01_01.xml"/-->

--- a/Detector/GeomSvc/src/GeomSvc.cpp
+++ b/Detector/GeomSvc/src/GeomSvc.cpp
@@ -44,6 +44,9 @@ GeomSvc::initialize() {
 StatusCode
 GeomSvc::finalize() {
   StatusCode sc;
+
+  dd4hep::Detector::destroyInstance();
+
   return sc;
 }
 

--- a/Digitisers/SimpleDigi/src/PlanarDigiAlg.h
+++ b/Digitisers/SimpleDigi/src/PlanarDigiAlg.h
@@ -82,13 +82,15 @@ protected:
   // whether use Planar tag for type and cov, if true, CEPCConf::TrkHitTypeBit::PLANAR bit is set as true
   // cov[0]=thetaU, cov[1]=phiU, cov[2]=resU, cov[0]=thetaV, cov[1]=phiV, cov[2]=resV
   Gaudi::Property<bool> _usePlanarTag{ this, "UsePlanarTag", true };
+  Gaudi::Property<float> _eThreshold{ this, "EnergyThreshold", 0 };
+  Gaudi::Property<float> _maxPull{ this, "PullCutToRetry", 1000. };
 
   // Input collections
   DataHandle<edm4hep::EventHeaderCollection> _headerCol{"EventHeaderCol", Gaudi::DataHandle::Reader, this};
   DataHandle<edm4hep::SimTrackerHitCollection> _inColHdl{"VXDCollection", Gaudi::DataHandle::Reader, this};
   // Output collections
   DataHandle<edm4hep::TrackerHitCollection> _outColHdl{"VXDTrackerHits", Gaudi::DataHandle::Writer, this};
-  DataHandle<edm4hep::MCRecoTrackerAssociationCollection> _outRelColHdl{"VTXTrackerHitRelations", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::MCRecoTrackerAssociationCollection> _outRelColHdl{"VXDTrackerHitRelations", Gaudi::DataHandle::Writer, this};
 };
 
 #endif

--- a/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
@@ -799,7 +799,7 @@ StatusCode ClupatraAlg::execute() {
 	//===============================================================================================
 
 	// FIXME Mingrui
-	debug()  << " ===========    refitting final " << cluList.size() << " track segments  "   << endmsg ;
+	debug()  << " =========== refitting final " << cluList.size() << " track segments chi2 cut = " << _dChi2Max << endmsg ;
 
 	//---- refit cluster tracks individually to save memory ( KalTest tracks have ~1MByte each)
 
@@ -811,10 +811,12 @@ StatusCode ClupatraAlg::execute() {
 			continue ;
 
 		MarlinTrk::IMarlinTrack* trk = fit( *icv ) ;
-		trk->smooth() ;
-		edm4hep::MutableTrack edm4hepTrk = converter( *icv ) ;
-		tsCol_tmp.push_back( new ClupaPlcioTrack(edm4hepTrk) ) ;
-		MarTrk_of_edm4hepTrack(edm4hepTrk) = 0 ;
+		if(trk){
+		  trk->smooth() ;
+		  edm4hep::MutableTrack edm4hepTrk = converter( *icv ) ;
+		  tsCol_tmp.push_back( new ClupaPlcioTrack(edm4hepTrk) ) ;
+		  MarTrk_of_edm4hepTrack(edm4hepTrk) = 0 ;
+		}
 		delete trk ;
 	}
 
@@ -883,14 +885,13 @@ StatusCode ClupatraAlg::execute() {
 
 			nntrkclu.cluster( incSegVec.begin() , incSegVec.end() , std::back_inserter( incSegCluVec ), trkMerge , 2  ) ;
 
-			// FIXME: Mingrui
-			// streamlog_out( DEBUG4 ) << " ===== merged track segments - # cluster: " << incSegCluVec.size()
-			//  << " from " << incSegVec.size() << " incomplete track segments "    << "  ============================== " << std::endl ;
+			debug() << " ===== merged track segments - # cluster: " << incSegCluVec.size()
+				<< " from " << incSegVec.size() << " incomplete track segments =====" << endmsg;
 
 			for(  TrackClusterer::cluster_vector::iterator it= incSegCluVec.begin() ; it != incSegCluVec.end() ; ++it) {
 
 				// FIXME: Mingrui
-				// streamlog_out( DEBUG4 ) <<  edm4hep::header<edm4hep::Track>() << std::endl ;
+                                // streamlog_out( DEBUG4 ) <<  edm4hep::header<edm4hep::Track>() << std::endl ;
 
 				TrackClusterer::cluster_type*  incSegClu = *it ;
 
@@ -951,8 +952,7 @@ StatusCode ClupatraAlg::execute() {
 				delete mTrk ;
 				computeTrackInfo( track ) ;
 
-				// FIXME: Mingrui
-				// streamlog_out( DEBUG4 ) << "   ******  created new track : " << " : " << lcshort( (Track*) track )  << std::endl ;
+				debug() << "   ******  created new track : " << " : " << track.id() << endmsg;
 
 			}
 		}// loop over l

--- a/Service/GearSvc/src/GearSvc.cpp
+++ b/Service/GearSvc/src/GearSvc.cpp
@@ -135,7 +135,7 @@ StatusCode GearSvc::initialize()
     m_gearMgr->setYokeBarrelParameters(barrelYokeParam) ;
     m_gearMgr->setYokeEndcapParameters(endcapYokeParam) ;
     m_gearMgr->setYokePlugParameters(plugYokeParam) ;
-    gear::TiXmlDocument* doc = new gear::TiXmlDocument ;
+
     gear::GearXML::createXMLFile(m_gearMgr, "test.xml");
   }
   

--- a/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
+++ b/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
@@ -258,7 +258,9 @@ namespace MarlinTrk {
     // set the initial track parameters  
     ///////////////////////////////////////////////////////
     
-    return_error = marlinTrk->initialise( *pre_fit, bfield_z, IMarlinTrack::backward ) ;
+    //return_error = marlinTrk->initialise( *pre_fit, bfield_z, IMarlinTrack::backward ) ;
+    // fucd: previous fixed as IMarlinTrack::backward, can not change? using input value now
+    return_error = marlinTrk->initialise( *pre_fit, bfield_z, fit_backwards ) ;
     if (return_error != IMarlinTrack::success) {
       
       std::cout << "MarlinTrk::createFit Initialisation of track fit failed with error : " << return_error << std::endl;
@@ -388,10 +390,10 @@ namespace MarlinTrk {
     return_error = marlintrk->getNDF(ndf);
 
     if ( return_error != IMarlinTrack::success) {
-      //streamlog_out(DEBUG3) << "MarlinTrk::finaliseLCIOTrack: getNDF returns " << return_error << std::endl;
+      //std::cout << "MarlinTrk::finaliseLCIOTrack: getNDF returns " << return_error << std::endl;
       return return_error;
     } else if( ndf < 0 ) {
-      //streamlog_out(DEBUG2) << "MarlinTrk::finaliseLCIOTrack: number of degrees of freedom less than 0 track dropped : NDF = " << ndf << std::endl;
+      //std::cout << "MarlinTrk::finaliseLCIOTrack: number of degrees of freedom less than 0 track dropped : NDF = " << ndf << std::endl;
       return IMarlinTrack::error;
     } else {
       //streamlog_out(DEBUG1) << "MarlinTrk::finaliseLCIOTrack: NDF = " << ndf << std::endl;
@@ -543,7 +545,6 @@ namespace MarlinTrk {
       track->addToTrackStates(*trkStateAtFirstHit);
     } else {
       //streamlog_out( WARNING ) << "  >>>>>>>>>>> MarlinTrk::finaliseLCIOTrack:  could not get TrackState at First Hit " << firstHit << std::endl ;
-      delete trkStateAtFirstHit;
     }
     
     double r_first = firstHit.getPosition()[0]*firstHit.getPosition()[0] + firstHit.getPosition()[1]*firstHit.getPosition()[1];
@@ -569,7 +570,7 @@ namespace MarlinTrk {
         track->addToTrackStates(*trkStateAtLastHit);
       } else {
 	std::cout << "ERROR>>>>>>>>>>> MarlinTrk::finaliseLCIOTrack:  could not get TrackState at Last Hit " << last_constrained_hit.id() << std::endl ;
-        delete trkStateAtLastHit;
+        //delete trkStateAtLastHit;
       }
       
 //      const EVENT::FloatVec& ma = trkStateAtLastHit->getCovMatrix();
@@ -587,17 +588,22 @@ namespace MarlinTrk {
 //      return_error = createTrackStateAtCaloFace(marlintrk, trkStateCalo, lastHit, tanL_is_positive);
       
       if ( return_error == 0 ) {
+	//std::cout << "fucdout referencePoint " << trkStateCalo.referencePoint << std::endl;
         trkStateCalo.location = MarlinTrk::Location::AtCalorimeter;
         track->addToTrackStates(trkStateCalo);
       } else {
-        //streamlog_out( WARNING ) << "  >>>>>>>>>>> MarlinTrk::finaliseLCIOTrack:  could not get TrackState at Calo Face "  << std::endl ;
+	std::cout << "  >>>>>>>>>>> MarlinTrk::finaliseLCIOTrack:  could not get TrackState at Calo Face "  << std::endl ;
         //delete trkStateCalo;
       }
     } else {
       track->addToTrackStates(*atLastHit);
       track->addToTrackStates(*atCaloFace);
+      //delete trkStateAtLastHit;
     }
-    
+
+    if(trkStateAtFirstHit) delete trkStateAtFirstHit;
+    if(trkStateAtLastHit)  delete trkStateAtLastHit;
+    if(trkStateIP)         delete trkStateIP;
     ///////////////////////////////////////////////////////
     // done
     ///////////////////////////////////////////////////////

--- a/Simulation/DetSimSD/src/GenericTrackerSensitiveDetector.cpp
+++ b/Simulation/DetSimSD/src/GenericTrackerSensitiveDetector.cpp
@@ -23,10 +23,11 @@ void GenericTrackerSensitiveDetector::Initialize(G4HCofThisEvent* HCE){
 }
 
 G4bool GenericTrackerSensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory*){
-  
   G4TouchableHandle touchPost = step->GetPostStepPoint()->GetTouchableHandle(); 
   G4TouchableHandle touchPre  = step->GetPreStepPoint()->GetTouchableHandle(); 
   dd4hep::sim::Geant4StepHandler h(step);
+  if (fabs(h.trackDef()->GetPDGCharge()) < 0.01) return true;
+
   dd4hep::Position prePos    = h.prePos();
   dd4hep::Position postPos   = h.postPos();
   dd4hep::Position direction = postPos - prePos;

--- a/Simulation/DetSimSD/src/TrackerCombineSensitiveDetector.cpp
+++ b/Simulation/DetSimSD/src/TrackerCombineSensitiveDetector.cpp
@@ -23,6 +23,8 @@ void TrackerCombineSensitiveDetector::Initialize(G4HCofThisEvent* HCE){
 
 G4bool TrackerCombineSensitiveDetector::ProcessHits(G4Step* step, G4TouchableHistory*){
   dd4hep::sim::Geant4StepHandler h(step);
+  if (fabs(h.trackDef()->GetPDGCharge()) < 0.01) return true;
+
   bool return_code = false;
   if ( userData.current == -1 ) userData.start(getCellID(step), step, h.pre);
   else if ( !userData.track || userData.current != h.track->GetTrackID() ) {

--- a/Utilities/KalTest/src/kaltracklib/TKalDetCradle.cxx
+++ b/Utilities/KalTest/src/kaltracklib/TKalDetCradle.cxx
@@ -29,6 +29,7 @@
 #include "TVSurface.h"       // from GeomLib
 #include <memory>            // from STL
 #include <iostream>          // from STL
+#include <map>
 
 ClassImp(TKalDetCradle)
 
@@ -45,6 +46,19 @@ fDone(kFALSE), fIsClosed(kFALSE)
 
 TKalDetCradle::~TKalDetCradle()
 {
+  //std::cout << "TKalDetCradle::~TKalDetCradle() " << this << " " << GetEntries() << std::endl;
+  std::map<TAttElement*, int> det_nelement;
+
+  TIter next(this);
+  TObject *mlp = 0;
+  while ((mlp = next())) {
+    TAttElement* det = const_cast<TAttElement*>(&(dynamic_cast<TAttElement *>(mlp)->GetParent(kFALSE)));
+    if(det_nelement.find(det)!=det_nelement.end()) det_nelement[det]++;
+    else det_nelement[det] = 1;
+  }
+  for (auto it : det_nelement) {
+    delete it.first;
+  }
 }
 
 //_________________________________________________________________________
@@ -71,6 +85,8 @@ void TKalDetCradle::Install(TVKalDetector &det)
     dynamic_cast<TAttElement *>(mlp)->SetParentPtr(&det);
     det.SetParentPtr(this);
   }
+  det.SetOwner(kFALSE);
+
   fDone = kFALSE;
 }
 


### PR DESCRIPTION
* fix memory leak： memory monitor shows memory upexpected increase while run silicon tracking algorithm
  * [Utilities/KalTest/src/kaltracklib/TKalDetCradle.cxx]: A has object pointers Cs from B, but after transfer them, B's pointer is set as C's parent pointer. While delete A, only Cs are deleted, Bs become lost. So add delete B. But because some Cs has same parent, map is used to merge same B to avoid double free. B aslo has Cs, A also has Cs. In order to avoid double free, B.SetOwner(kFALSE) is needed to release Cs, after B transfer Cs into A.
  * [Service/TrackSystemSvc/src/MarlinTrkUtils.cc]: new TrackState should always be deleted, because track->addToTrackStates(edm4hep::TrackState) will create a TrackState object.
  * [Detector/GeomSvc/src/GeomSvc.cpp]: dd4hep::Detector::destroyInstance to free dd4hep objects.
  * [Digitisers/SimpleDigi/src/PlanarDigiAlg.cpp]: gsl_rng_free(_rng) to free gsl_rng.
* fix run crash:
  * DriftChamberRegion use PAI model will cause crash (old problem, fixed for CRD_o1_v01, but others are missed), remove this region definition preliminary same as CRD_o1_v01.
  * [Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp]: add `if(trk)` to avoid `MarlinTrk::IMarlinTrack* trk = fit( *icv ) ;` return null pointer.
* correct the wrong-input detector parameters for CRD_o1_v04
  * because the parameters of 3rd and 4th layers are confused, the silicon trackers are defined not as expected. Let parameter use right sources. 
* Besides bug fix, also
  * fix hardcode for fit-direction: `marlinTrk->initialise( *pre_fit, bfield_z, IMarlinTrack::backward ) ;` => `marlinTrk->initialise( *pre_fit, bfield_z, fit_backwards ) ;` , here fit_backwards is as parameter, but IMarlinTrack::backward is a fixed.
  * add cut to produce SimTrackerHit/TrackerHit to avoid unexpected hit: before modifying, electron will produce many hits from radiation photon.
    * remove hits while passing neutral particles
    * add energy cut to keep TrackerHit, and add smearing condition pull region (default 1000) to drop thos far away from SimTrackerHit. Default is close not to apply the requirement, since 1000 is large enough. 
  * fix time lost while PlanarDigiAlg digitize SimTrackerHit to TrackerHit