### PR TITLE
GEOM: open shape unsupported in old DD4hep

### DIFF
--- a/Detector/DetCEPCv4/compact/CepCBeamPipe_v01_01.xml
+++ b/Detector/DetCEPCv4/compact/CepCBeamPipe_v01_01.xml
@@ -34,7 +34,7 @@
   </define>
 
   <detectors>        
-    <detector name="BeamPipe" type="DD4hep_CRDBeamPipe_v01" vis="BeamPipeVis">
+    <detector name="BeamPipe" type="CRDBeamPipe_v01" vis="BeamPipeVis">
       <parameter crossingangle="CepC_Main_Crossing_Angle" />
       <envelope vis="BlueVis">
 	<shape type="Assembly"/>
@@ -66,14 +66,14 @@
 	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
       </section>
       <!--CrotchAsymUp&CrotchAsymDn not work to fix, because of problem on convert from TGeo to Geant4--> 
-      <!--section type="CrotchAsymUp" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
+      <section type="CrotchAsymUp" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
 	       rStart="BeamPipe_Expanded_inner_radius" rEnd="BeamPipe_Upstream_inner_radius" size="BeamPipe_Crotch_hole_height">
 	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" thicknessEnd="ForkAsymThickness"/>
       </section>
       <section type="CrotchAsymDn" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
 	       rStart="BeamPipe_Expanded_inner_radius" rEnd="BeamPipe_Dnstream_inner_radius" size="BeamPipe_Crotch_hole_height">
         <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
-      </section-->
+      </section>
       <section type="FlareLegUp" name="FirstDoublePipe" zStart="BeamPipe_Crotch_zmax" zEnd="BeamPipe_FirstSeparated_zmax" rStart="0">
 	<layer material="beam" thickness="BeamPipe_Upstream_inner_radius" thicknessEnd="BeamPipe_Dnstream_inner_radius"/>
 	<layer material="G4_Cu" thickness="ForkAsymThickness" thicknessEnd="BeamPipe_Cu_thickness"/>


### PR DESCRIPTION
This problem has been correct in CRD, but not in CepC_v4. This commit will update.