### PR TITLE
GEOM: add pipe and magnet in range of QD0 and QF1

### DIFF
--- a/Detector/DetCEPCv4/compact/CepCBeamPipe_v01_01.xml
+++ b/Detector/DetCEPCv4/compact/CepCBeamPipe_v01_01.xml
@@ -10,6 +10,7 @@
     <constant name="BeamPipe_Be_total_thickness"   value="BeamPipe_Be_inner_thickness+BeamPipe_Cooling_thickness+BeamPipe_Be_outer_thickness"/>
     <constant name="BeamPipe_Al_thickness"         value="BeamPipe_Be_total_thickness"/>
     <constant name="BeamPipe_Cu_thickness"         value="2.0*mm"/>
+    <constant name="BeamPipe_Iron_thickness"       value="2.5*mm"/>
 
     <constant name="BeamPipe_CentralBe_zmax"       value="120*mm"/>
     <constant name="BeamPipe_CentralAl_zmax"       value="205*mm"/>
@@ -20,12 +21,16 @@
     <constant name="BeamPipe_Crotch_zmax"          value="855*mm"/>
     <constant name="BeamPipe_FirstSeparated_zmax"  value="1110*mm"/>
     <constant name="BeamPipe_SecondSeparated_zmax" value="2200*mm"/>
-    <constant name="BeamPipe_end_z"                value="12*m"/>
+    <constant name="BeamPipe_QD0_zmax"             value="3950*mm"/>
+    <constant name="BeamPipe_QF1_zmin"             value="4450*mm"/>
+    <constant name="BeamPipe_QF1_zmax"             value="4450*mm"/>
+    <constant name="BeamPipe_end_z"                value="7050*mm"/>
     
     <constant name="BeamPipe_Central_inner_radius"  value="14*mm"/>
     <constant name="BeamPipe_Expanded_inner_radius" value="20*mm"/>
     <constant name="BeamPipe_Upstream_inner_radius" value="6*mm"/>
     <constant name="BeamPipe_Dnstream_inner_radius" value="10*mm"/>
+    <constant name="BeamPipe_QF1_inner_radius"  value="20.5*mm"/>
     <constant name="BeamPipe_Crotch_hole_height"    value="30.67*mm"/>
     <constant name="BeamPipe_VertexRegion_rmax"     value="BeamPipe_Central_inner_radius+BeamPipe_Al_thickness"/>
     <constant name="BeamPipe_ForwardRegion_rmax"    value="BeamPipe_Expanded_inner_radius+BeamPipe_Cu_thickness"/>
@@ -36,51 +41,180 @@
   <detectors>        
     <detector name="BeamPipe" type="CRDBeamPipe_v01" vis="BeamPipeVis">
       <parameter crossingangle="CepC_Main_Crossing_Angle" />
-      <envelope vis="BlueVis">
+      <envelope>
 	<shape type="Assembly"/>
       </envelope>
 
       <section type ="Center" name="IPInnerTube" zStart="0" zEnd="BeamPipe_CentralBe_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Central_inner_radius"/>
-	<layer material="G4_Be" thickness="BeamPipe_Be_inner_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Central_inner_radius" vis="VacVis"/>
+	<layer material="G4_Be" thickness="BeamPipe_Be_inner_thickness" vis="BeamPipeVis"/>
 	<layer material="G4_PARAFFIN" thickness="BeamPipe_Cooling_thickness"/>
-	<layer material="G4_Be" thickness="BeamPipe_Be_outer_thickness"/>
+	<layer material="G4_Be" thickness="BeamPipe_Be_outer_thickness" vis="BeamPipeVis"/>
       </section>
       <section type="Center" name="IPAl" zStart="BeamPipe_CentralBe_zmax" zEnd="BeamPipe_CentralAl_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Central_inner_radius"/>
-	<layer material="G4_Al" thickness="BeamPipe_Al_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Central_inner_radius" vis="VacVis"/>
+	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" vis="BeamPipeVis"/>
       </section>
       <section type="Center" name="ExpandPipe" zStart="BeamPipe_CentralAl_zmax" zEnd="BeamPipe_ConeAl_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Central_inner_radius" thicknessEnd="BeamPipe_Expanded_inner_radius"/>
-	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" thicknessEnd="BeamPipe_Al_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Central_inner_radius" thicknessEnd="BeamPipe_Expanded_inner_radius" vis="VacVis"/>
+	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" thicknessEnd="BeamPipe_Al_thickness" vis="BeamPipeVis"/>
       </section>
       <section type="Center" name="ThickPipe" zStart="BeamPipe_ConeAl_zmax" zEnd="BeamPipe_LinkerAl_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Expanded_inner_radius"/>
-	<layer material="G4_Al" thickness="BeamPipe_Al_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Expanded_inner_radius" vis="VacVis"/>
+	<layer material="G4_Al" thickness="BeamPipe_Al_thickness" vis="BeamPipeVis"/>
       </section>
       <section type="CenterSide" name="OutsideLink" zStart="BeamPipe_LinkerAl_zmax" zEnd="BeamPipe_LinkerCu_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Expanded_inner_radius"/>
-	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Expanded_inner_radius" vis="VacVis"/>
+	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="BeamPipeVis"/>
       </section>
       <section type="FatWaist" name="Waist" zStart="BeamPipe_LinkerCu_zmax" zEnd="BeamPipe_Waist_zmax" rStart="BeamPipe_Expanded_inner_radius" size="BeamPipe_Crotch_hole_height">
-	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
+	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="BeamPipeVis"/>
       </section>
-      <!--CrotchAsymUp&CrotchAsymDn not work to fix, because of problem on convert from TGeo to Geant4--> 
       <section type="CrotchAsymUp" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
 	       rStart="BeamPipe_Expanded_inner_radius" rEnd="BeamPipe_Upstream_inner_radius" size="BeamPipe_Crotch_hole_height">
-	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" thicknessEnd="ForkAsymThickness"/>
+	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" thicknessEnd="ForkAsymThickness" vis="BeamPipeVis"/>
       </section>
       <section type="CrotchAsymDn" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
 	       rStart="BeamPipe_Expanded_inner_radius" rEnd="BeamPipe_Dnstream_inner_radius" size="BeamPipe_Crotch_hole_height">
-        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="BeamPipeVis"/>
       </section>
       <section type="FlareLegUp" name="FirstDoublePipe" zStart="BeamPipe_Crotch_zmax" zEnd="BeamPipe_FirstSeparated_zmax" rStart="0">
-	<layer material="beam" thickness="BeamPipe_Upstream_inner_radius" thicknessEnd="BeamPipe_Dnstream_inner_radius"/>
-	<layer material="G4_Cu" thickness="ForkAsymThickness" thicknessEnd="BeamPipe_Cu_thickness"/>
+	<layer material="beam" thickness="BeamPipe_Upstream_inner_radius" thicknessEnd="BeamPipe_Dnstream_inner_radius" vis="VacVis"/>
+	<layer material="G4_Cu" thickness="ForkAsymThickness" thicknessEnd="BeamPipe_Cu_thickness" vis="BeamPipeVis"/>
       </section>
       <section type="FlareLegDn" name="FirstDoublePipe" zStart="BeamPipe_Crotch_zmax" zEnd="BeamPipe_FirstSeparated_zmax" rStart="0">
-        <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius"/>
-        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness"/>
+        <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius" vis="VacVis"/>
+        <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="BeamPipeVis"/>
+      </section>
+      <section type="Legs" name="QD0Link" zStart="BeamPipe_FirstSeparated_zmax" zEnd="BeamPipe_SecondSeparated_zmax" rStart="0">
+	<layer material="beam" thickness="BeamPipe_Dnstream_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="BeamPipeVis"/>
+      </section>
+      <section type="Legs" name="QD0" zStart="BeamPipe_SecondSeparated_zmax" zEnd="BeamPipe_QD0_zmax" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="BeamPipeVis"/>
+	<layer material="G4_Cu" thickness="3.5*mm" vis="BeamPipeVis"/>
+	<layer material="superconductor" thickness="6.0*mm" vis="BeamPipeVis"/>
+	<layer material="stainless_steel" thickness="8.0*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="Legs" name="QF1Link" zStart="BeamPipe_QD0_zmax" zEnd="BeamPipe_QF1_zmin" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius" thicknessEnd="BeamPipe_QF1_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="BeamPipeVis"/>
+      </section>
+      <section type="Legs" name="QF1" zStart="BeamPipe_QF1_zmin" zEnd="BeamPipe_QF1_zmax" rStart="0">
+        <layer material="beam" thickness="BeamPipe_QF1_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="BeamPipeVis"/>
+	<layer material="G4_Cu" thickness="3.0*mm" vis="BeamPipeVis"/>
+        <layer material="superconductor" thickness="6.0*mm" vis="BeamPipeVis"/>
+        <layer material="stainless_steel" thickness="8.0*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="Legs" name="Farest" zStart="BeamPipe_QF1_zmax" zEnd="BeamPipe_end_z" rStart="0">
+        <layer material="beam" thickness="BeamPipe_QF1_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="BeamPipeVis"/>
+      </section>
+
+      <!-- Magnets and their cooling, support -->
+      <section type="CenterSide" name="Magnet_1" zStart="1160*mm" zEnd="1900*mm" rStart="90*mm">
+        <layer material="superconductor" thickness="20*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="Magnet_2" zStart="1930*mm" zEnd="3964*mm" rStart="120*mm">
+        <layer material="superconductor" thickness="10*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="Magnet_3" zStart="3970*mm" zEnd="7000*mm" rStart="185*mm">
+        <layer material="superconductor" thickness="10*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_1" zStart="970*mm" zEnd="1110*mm" rStart="31*mm">
+        <layer material="stainless_steel" thickness="1.5*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_2" zStart="1110*mm" zEnd="1115*mm" rStart="50.0*mm">
+        <layer material="stainless_steel" thickness="91.25*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_3" zStart="1115*mm" zEnd="1900*mm" rStart="130.75*mm" rEnd="175*mm">
+        <layer material="stainless_steel" thickness="10.5*mm" thicknessEnd="65*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_4" zStart="1900*mm" zEnd="3800*mm" rStart="175*mm">
+        <layer material="stainless_steel" thickness="65*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_5" zStart="3800*mm" zEnd="3910*mm" rStart="175*mm">
+        <layer material="stainless_steel" thickness="135*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_6" zStart="3910*mm" zEnd="7160*mm" rStart="240*mm">
+        <layer material="stainless_steel" thickness="70*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_1" zStart="1130*mm" zEnd="1135*mm" rStart="75*mm">
+        <layer material="stainless_steel" thickness="50*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_2i" zStart="1135*mm" zEnd="1925*mm" rStart="75*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_2o" zStart="1135*mm" zEnd="1900*mm" rStart="120*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_3l" zStart="1900*mm" zEnd="1905*mm" rStart="120*mm">
+        <layer material="stainless_steel" thickness="25*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_3r" zStart="1925*mm" zEnd="1930*mm" rStart="75*mm">
+        <layer material="stainless_steel" thickness="35*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_4i" zStart="1930*mm" zEnd="4000*mm" rStart="105*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_4o" zStart="1905*mm" zEnd="3940*mm" rStart="140*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_5l" zStart="3940*mm" zEnd="3945*mm" rStart="140*mm">
+        <layer material="stainless_steel" thickness="70*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_5r" zStart="4000*mm" zEnd="4005*mm" rStart="105*mm">
+        <layer material="stainless_steel" thickness="70*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_6i" zStart="4005*mm" zEnd="7050*mm" rStart="170*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_6o" zStart="3945*mm" zEnd="7050*mm" rStart="205*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_7" zStart="7050*mm" zEnd="7055*mm" rStart="170*mm">
+        <layer material="stainless_steel" thickness="40*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1l" zStart="1135*mm" zEnd="1160*mm" rStart="80*mm">
+        <layer material="lN2" thickness="40*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1i" zStart="1160*mm" zEnd="1900*mm" rStart="80*mm">
+        <layer material="lN2" thickness="10*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1o" zStart="1160*mm" zEnd="1900*mm" rStart="110*mm">
+        <layer material="lN2" thickness="10*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1r" zStart="1900*mm" zEnd="1925*mm" rStart="80*mm">
+        <layer material="lN2" thickness="40*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2l" zStart="1905*mm" zEnd="1930*mm" rStart="120*mm">
+        <layer material="lN2" thickness="20*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2i" zStart="1925*mm" zEnd="3964*mm" rStart="110*mm">
+        <layer material="lN2" thickness="10*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2o" zStart="1930*mm" zEnd="3945*mm" rStart="130*mm">
+        <layer material="lN2" thickness="10*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2r1" zStart="3964*mm" zEnd="4000*mm" rStart="110*mm">
+        <layer material="lN2" thickness="65*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2r2" zStart="3945*mm" zEnd="3964*mm" rStart="130*mm">
+        <layer material="lN2" thickness="45*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3l" zStart="3945*mm" zEnd="3970*mm" rStart="175*mm">
+        <layer material="lN2" thickness="30*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3i" zStart="3970*mm" zEnd="7000*mm" rStart="175*mm">
+        <layer material="lN2" thickness="10*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3o" zStart="3970*mm" zEnd="7000*mm" rStart="195*mm">
+        <layer material="lN2" thickness="10*mm" vis="BeamPipeVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3r" zStart="7000*mm" zEnd="7050*mm" rStart="175*mm">
+        <layer material="lN2" thickness="30*mm" vis="BeamPipeVis"/>
       </section>
     </detector>
   </detectors>        

--- a/Detector/DetCEPCv4/compact/SEcal05_siw_ECRing_02.xml
+++ b/Detector/DetCEPCv4/compact/SEcal05_siw_ECRing_02.xml
@@ -9,7 +9,7 @@
           <shape type="BooleanShape" operation="Subtraction" material="Air">
             <shape type="Box" dx="Ecal_endcap_center_box_size/2.0" dy="Ecal_endcap_center_box_size/2.0"
                    dz="EcalEndcapRing_max_z"/>
-            <shape type="Tube" rmin="0" rmax="EcalEndcapRing_inner_radius - env_safety" dz="2.0*EcalEndcapRing_max_z + env_safety"/>
+            <shape type="Tube" rmin="0" rmax="EcalEndcapRing_inner_radius" dz="2.0*EcalEndcapRing_max_z + env_safety"/>
 
             <position x="0.5*(EcalEndcapRing_min_z + EcalEndcapRing_max_z)*tan(Ecal_ECRing_Crossing_Angle/2)" y="0" z="0"/>
             <!-- position x="0" y="0" z="0"/ -->

--- a/Detector/DetCEPCv4/compact/ftd_cepc_02.xml
+++ b/Detector/DetCEPCv4/compact/ftd_cepc_02.xml
@@ -9,7 +9,8 @@
     <detector name="FTD" type="FTD_cepc" vis="FTDVis" id="ILDDetID_FTD" limits="Tracker_limits" readout="FTDCollection" insideTrackingVolume="true">
 
       <envelope vis="ILD_FTDVis">
-        <shape type="BooleanShape" operation="Subtraction" material="Air" >
+	<shape type="Assembly"/>
+        <!--shape type="BooleanShape" operation="Subtraction" material="Air" >
           <shape type="BooleanShape" operation="Subtraction" material="Air" >
             <shape type="BooleanShape" operation="Subtraction" material="Air" >
               <shape type="BooleanShape" operation="Subtraction" material="Air" >
@@ -29,7 +30,7 @@
                  z="(FTD_half_length-BeamPipe_CentralAl_zmax)/2. + env_safety "/>
           <position x="0" y="0" z="-BeamPipe_CentralAl_zmax-(FTD_half_length-BeamPipe_CentralAl_zmax)/2."/>
           <rotation x="0" y="180.*deg" z="0" />
-        </shape>
+        </shape-->
       </envelope>
 
       <type_flags type="DetType_TRACKER +  DetType_ENDCAP  + DetType_PIXEL + DetType_STRIP "/>

--- a/Detector/DetCEPCv4/compact/materials.xml
+++ b/Detector/DetCEPCv4/compact/materials.xml
@@ -548,5 +548,20 @@
        <fraction n="0.194" ref="Cu" />
     </material>
 
+    <material name="G4_PARAFFIN">
+      <D type="density" value="0.93" unit="g/cm3" />
+       <fraction n="0.148605" ref="H" />
+       <fraction n="0.851395" ref="C" />
+    </material>
 
+    <material name="superconductor">
+      <D type="density" value="6.78" unit="g/cm3" />
+       <fraction n="0.56" ref="Ni" />
+       <fraction n="0.44" ref="Ti" />
+    </material>
+
+    <material name="lN2">
+      <D type="density" value="0.807" unit="g/cm3" />
+       <fraction n="1" ref="N" />
+    </material>
   </materials>

--- a/Detector/DetCEPCv4/compact/top_defs.xml
+++ b/Detector/DetCEPCv4/compact/top_defs.xml
@@ -14,7 +14,7 @@
   <constant name="Field_outer_thickness" value="2550*mm"/>
 
   <!-- VXD -->
-  <constant name="top_VXD_inner_radius"   value="15*mm "/>
+  <constant name="top_VXD_inner_radius"   value="15.5*mm "/>
   <constant name="top_VXD_outer_radius"   value="101*mm "/>
   <constant name="top_VXD_half_length"    value="200*mm "/>
 

--- a/Detector/DetCEPCv4/compact/vxd07_01.xml
+++ b/Detector/DetCEPCv4/compact/vxd07_01.xml
@@ -61,7 +61,7 @@
 				external_metal_thickness="0.009*mm"  />
       <!-- SQL command: "SELECT * FROM cryostat;"  -->
       <cryostat id="1" alu_skin_inner_radious="100*mm" alu_skin_tickness="0.5*mm" foam_inner_radious="90*mm" foam_tickness="10*mm" foam_half_z="166.6*mm" 
-		endplate_inner_radious="VXD_inner_radius_1+5.6*mm" 
+		endplate_inner_radious="VXD_inner_radius_1"
 		cryostat_option="1" cryostat_apperture="30*mm" cryostat_apperture_radius="1.5*mm"  />
       <!-- SQL command: "select * from support_shell;"  -->
       <support_shell id="0" inner_radious="65*mm" half_z="145*mm" thickess="0.49392*mm" endplate_inner_radious="30*mm" endplate_inner_radius_L1="15.7*mm" endplate_outer_radius_L1="20*mm" 

--- a/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_01.xml
@@ -10,6 +10,11 @@
 
   <define>
     <constant name="ForkAsymThickness" value="BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness-BeamPipe_Upstream_inner_radius"/>
+    <constant name="BeamPipe_QD0_zmax"             value="3950*mm"/>
+    <constant name="BeamPipe_QF1_zmin"             value="4450*mm"/>
+    <constant name="BeamPipe_QF1_zmax"             value="4450*mm"/>
+    <constant name="BeamPipe_QF1_inner_radius"     value="20.5*mm"/>
+    <constant name="BeamPipe_Iron_thickness"       value="2.5*mm"/>
   </define>
 
   <detectors>        
@@ -44,8 +49,6 @@
       <section type="FatWaist" name="Waist" zStart="BeamPipe_LinkerCu_zmax" zEnd="BeamPipe_Waist_zmax" rStart="BeamPipe_Expanded_inner_radius" size="BeamPipe_Crotch_hole_height">
 	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
       </section>
-      <!--CrotchAsymUp&CrotchAsymDn not work to fix, because of problem on convert from TGeo to Geant4-->
-      <!--Since lcg101, they work-->
       <section type="CrotchAsymUp" name="Fork" zStart="BeamPipe_Waist_zmax" zEnd="BeamPipe_Crotch_zmax"
 	       rStart="BeamPipe_Expanded_inner_radius" rEnd="BeamPipe_Upstream_inner_radius" size="BeamPipe_Crotch_hole_height">
 	<layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" thicknessEnd="ForkAsymThickness" vis="TubeVis"/>
@@ -61,6 +64,136 @@
       <section type="FlareLegDn" name="FirstDoublePipe" zStart="BeamPipe_Crotch_zmax" zEnd="BeamPipe_FirstSeparated_zmax" rStart="0">
         <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius" vis="VacVis"/>
         <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Legs" name="QD0Link" zStart="BeamPipe_FirstSeparated_zmax" zEnd="BeamPipe_SecondSeparated_zmax" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Legs" name="QD0" zStart="BeamPipe_SecondSeparated_zmax" zEnd="BeamPipe_QD0_zmax" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="TubeVis"/>
+        <layer material="G4_Cu" thickness="3.5*mm" vis="TubeVis"/>
+        <layer material="superconductor" thickness="6.0*mm" vis="MagentaVis"/>
+        <layer material="stainless_steel" thickness="8.0*mm" vis="ShellVis"/>
+      </section>
+      <section type="Legs" name="QF1Link" zStart="BeamPipe_QD0_zmax" zEnd="BeamPipe_QF1_zmin" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Dnstream_inner_radius" thicknessEnd="BeamPipe_QF1_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Legs" name="QF1" zStart="BeamPipe_QF1_zmin" zEnd="BeamPipe_QF1_zmax" rStart="0">
+        <layer material="beam" thickness="BeamPipe_QF1_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="TubeVis"/>
+        <layer material="G4_Cu" thickness="3.0*mm" vis="TubeVis"/>
+        <layer material="superconductor" thickness="6.0*mm" vis="MagentaVis"/>
+        <layer material="stainless_steel" thickness="8.0*mm" vis="ShellVis"/>
+      </section>
+      <section type="Legs" name="Farest" zStart="BeamPipe_QF1_zmax" zEnd="BeamPipe_end_z" rStart="0">
+        <layer material="beam" thickness="BeamPipe_QF1_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="TubeVis"/>
+      </section>
+
+      <!-- Magnets and their cooling, support -->
+      <section type="CenterSide" name="Magnet_1" zStart="1160*mm" zEnd="1900*mm" rStart="90*mm">
+        <layer material="superconductor" thickness="20*mm" vis="MagentaVis"/>
+      </section>
+      <section type="CenterSide" name="Magnet_2" zStart="1930*mm" zEnd="3964*mm" rStart="120*mm">
+        <layer material="superconductor" thickness="10*mm" vis="MagentaVis"/>
+      </section>
+      <section type="CenterSide" name="Magnet_3" zStart="3970*mm" zEnd="7000*mm" rStart="185*mm">
+        <layer material="superconductor" thickness="10*mm" vis="MagentaVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_1" zStart="970*mm" zEnd="1110*mm" rStart="31*mm">
+        <layer material="stainless_steel" thickness="1.5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_2" zStart="1110*mm" zEnd="1115*mm" rStart="50.0*mm">
+        <layer material="stainless_steel" thickness="91.25*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_3" zStart="1115*mm" zEnd="1900*mm" rStart="130.75*mm" rEnd="175*mm">
+        <layer material="stainless_steel" thickness="10.5*mm" thicknessEnd="65*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_4" zStart="1900*mm" zEnd="3800*mm" rStart="175*mm">
+        <layer material="stainless_steel" thickness="65*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_5" zStart="3800*mm" zEnd="3910*mm" rStart="175*mm">
+        <layer material="stainless_steel" thickness="135*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_6" zStart="3910*mm" zEnd="7160*mm" rStart="240*mm">
+        <layer material="stainless_steel" thickness="70*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_1" zStart="1130*mm" zEnd="1135*mm" rStart="75*mm">
+        <layer material="stainless_steel" thickness="50*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_2i" zStart="1135*mm" zEnd="1925*mm" rStart="75*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_2o" zStart="1135*mm" zEnd="1900*mm" rStart="120*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_3l" zStart="1900*mm" zEnd="1905*mm" rStart="120*mm">
+        <layer material="stainless_steel" thickness="25*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_3r" zStart="1925*mm" zEnd="1930*mm" rStart="75*mm">
+        <layer material="stainless_steel" thickness="35*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_4i" zStart="1930*mm" zEnd="4000*mm" rStart="105*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_4o" zStart="1905*mm" zEnd="3940*mm" rStart="140*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_5l" zStart="3940*mm" zEnd="3945*mm" rStart="140*mm">
+        <layer material="stainless_steel" thickness="70*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_5r" zStart="4000*mm" zEnd="4005*mm" rStart="105*mm">
+        <layer material="stainless_steel" thickness="70*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_6i" zStart="4005*mm" zEnd="7050*mm" rStart="170*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_6o" zStart="3945*mm" zEnd="7050*mm" rStart="205*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_7" zStart="7050*mm" zEnd="7055*mm" rStart="170*mm">
+        <layer material="stainless_steel" thickness="40*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1l" zStart="1135*mm" zEnd="1160*mm" rStart="80*mm">
+        <layer material="lN2" thickness="40*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1i" zStart="1160*mm" zEnd="1900*mm" rStart="80*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1o" zStart="1160*mm" zEnd="1900*mm" rStart="110*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1r" zStart="1900*mm" zEnd="1925*mm" rStart="80*mm">
+        <layer material="lN2" thickness="40*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2l" zStart="1905*mm" zEnd="1930*mm" rStart="120*mm">
+        <layer material="lN2" thickness="20*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2i" zStart="1925*mm" zEnd="3964*mm" rStart="110*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2o" zStart="1930*mm" zEnd="3945*mm" rStart="130*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2r1" zStart="3964*mm" zEnd="4000*mm" rStart="110*mm">
+        <layer material="lN2" thickness="65*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2r2" zStart="3945*mm" zEnd="3964*mm" rStart="130*mm">
+        <layer material="lN2" thickness="45*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3l" zStart="3945*mm" zEnd="3970*mm" rStart="175*mm">
+        <layer material="lN2" thickness="30*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3i" zStart="3970*mm" zEnd="7000*mm" rStart="175*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3o" zStart="3970*mm" zEnd="7000*mm" rStart="195*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3r" zStart="7000*mm" zEnd="7050*mm" rStart="175*mm">
+        <layer material="lN2" thickness="30*mm" vis="BlueVis"/>
       </section>
     </detector>
   </detectors>        

--- a/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/Beampipe_v01_02.xml
@@ -11,6 +11,11 @@
   <define>
     <!--only needed for asymetry double pipe-->
     <!--constant name="ForkAsymThickness" value="BeamPipe_Dnstream_inner_radius+BeamPipe_Cu_thickness-BeamPipe_Upstream_inner_radius"/-->
+    <constant name="BeamPipe_QD0_zmax"             value="3950*mm"/>
+    <constant name="BeamPipe_QF1_zmin"             value="4450*mm"/>
+    <constant name="BeamPipe_QF1_zmax"             value="4450*mm"/>
+    <constant name="BeamPipe_QF1_inner_radius"     value="20.5*mm"/>
+    <constant name="BeamPipe_Iron_thickness"       value="2.5*mm"/>
   </define>
 
   <detectors>        
@@ -62,6 +67,132 @@
       <section type="Legs" name="SecondDoublePipe" zStart="BeamPipe_Mask_zmax" zEnd="BeamPipe_SecondSeparated_zmax" rStart="0">
         <layer material="beam" thickness="BeamPipe_Fork_inner_radius" vis="VacVis"/>
         <layer material="G4_Cu" thickness="BeamPipe_Cu_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Legs" name="QD0" zStart="BeamPipe_SecondSeparated_zmax" zEnd="BeamPipe_QD0_zmax" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Fork_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="TubeVis"/>
+        <layer material="G4_Cu" thickness="3.5*mm" vis="TubeVis"/>
+        <layer material="superconductor" thickness="6.0*mm" vis="MagentaVis"/>
+        <layer material="stainless_steel" thickness="8.0*mm" vis="ShellVis"/>
+      </section>
+      <section type="Legs" name="QF1Linker" zStart="BeamPipe_QD0_zmax" zEnd="BeamPipe_QF1_zmin" rStart="0">
+        <layer material="beam" thickness="BeamPipe_Fork_inner_radius" thicknessEnd="BeamPipe_QF1_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="TubeVis"/>
+      </section>
+      <section type="Legs" name="QF1" zStart="BeamPipe_QF1_zmin" zEnd="BeamPipe_QF1_zmax" rStart="0">
+        <layer material="beam" thickness="BeamPipe_QF1_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="TubeVis"/>
+        <layer material="G4_Cu" thickness="3.0*mm" vis="TubeVis"/>
+        <layer material="superconductor" thickness="6.0*mm" vis="MagentaVis"/>
+        <layer material="stainless_steel" thickness="8.0*mm" vis="ShellVis"/>
+      </section>
+      <section type="Legs" name="Farest" zStart="BeamPipe_QF1_zmax" zEnd="BeamPipe_end_z" rStart="0">
+        <layer material="beam" thickness="BeamPipe_QF1_inner_radius" vis="VacVis"/>
+        <layer material="stainless_steel" thickness="BeamPipe_Iron_thickness" vis="TubeVis"/>
+      </section>
+
+      <!-- Magnets and their cooling, support -->
+      <section type="CenterSide" name="Magnet_1" zStart="1160*mm" zEnd="1900*mm" rStart="90*mm">
+        <layer material="superconductor" thickness="20*mm" vis="MagentaVis"/>
+      </section>
+      <section type="CenterSide" name="Magnet_2" zStart="1930*mm" zEnd="3964*mm" rStart="120*mm">
+        <layer material="superconductor" thickness="10*mm" vis="MagentaVis"/>
+      </section>
+      <section type="CenterSide" name="Magnet_3" zStart="3970*mm" zEnd="7000*mm" rStart="185*mm">
+        <layer material="superconductor" thickness="10*mm" vis="MagentaVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_1" zStart="970*mm" zEnd="1110*mm" rStart="33*mm">
+        <layer material="stainless_steel" thickness="1.5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_2" zStart="1110*mm" zEnd="1115*mm" rStart="50.0*mm">
+        <layer material="stainless_steel" thickness="91.25*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_3" zStart="1115*mm" zEnd="1900*mm" rStart="130.75*mm" rEnd="175*mm">
+        <layer material="stainless_steel" thickness="10.5*mm" thicknessEnd="65*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_4" zStart="1900*mm" zEnd="3800*mm" rStart="175*mm">
+        <layer material="stainless_steel" thickness="65*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_5" zStart="3800*mm" zEnd="3910*mm" rStart="175*mm">
+        <layer material="stainless_steel" thickness="135*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetShell_6" zStart="3910*mm" zEnd="7160*mm" rStart="240*mm">
+        <layer material="stainless_steel" thickness="70*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_1" zStart="1130*mm" zEnd="1135*mm" rStart="75*mm">
+        <layer material="stainless_steel" thickness="50*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_2i" zStart="1135*mm" zEnd="1925*mm" rStart="75*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_2o" zStart="1135*mm" zEnd="1900*mm" rStart="120*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_3l" zStart="1900*mm" zEnd="1905*mm" rStart="120*mm">
+        <layer material="stainless_steel" thickness="25*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_3r" zStart="1925*mm" zEnd="1930*mm" rStart="75*mm">
+        <layer material="stainless_steel" thickness="35*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_4i" zStart="1930*mm" zEnd="4000*mm" rStart="105*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_4o" zStart="1905*mm" zEnd="3940*mm" rStart="140*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_5l" zStart="3940*mm" zEnd="3945*mm" rStart="140*mm">
+        <layer material="stainless_steel" thickness="70*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_5r" zStart="4000*mm" zEnd="4005*mm" rStart="105*mm">
+        <layer material="stainless_steel" thickness="70*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_6i" zStart="4005*mm" zEnd="7050*mm" rStart="170*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_6o" zStart="3945*mm" zEnd="7050*mm" rStart="205*mm">
+        <layer material="stainless_steel" thickness="5*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetSupport_7" zStart="7050*mm" zEnd="7055*mm" rStart="170*mm">
+        <layer material="stainless_steel" thickness="40*mm" vis="ShellVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1l" zStart="1135*mm" zEnd="1160*mm" rStart="80*mm">
+        <layer material="lN2" thickness="40*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1i" zStart="1160*mm" zEnd="1900*mm" rStart="80*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1o" zStart="1160*mm" zEnd="1900*mm" rStart="110*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_1r" zStart="1900*mm" zEnd="1925*mm" rStart="80*mm">
+        <layer material="lN2" thickness="40*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2l" zStart="1905*mm" zEnd="1930*mm" rStart="120*mm">
+        <layer material="lN2" thickness="20*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2i" zStart="1925*mm" zEnd="3964*mm" rStart="110*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2o" zStart="1930*mm" zEnd="3945*mm" rStart="130*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2r1" zStart="3964*mm" zEnd="4000*mm" rStart="110*mm">
+        <layer material="lN2" thickness="65*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_2r2" zStart="3945*mm" zEnd="3964*mm" rStart="130*mm">
+        <layer material="lN2" thickness="45*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3l" zStart="3945*mm" zEnd="3970*mm" rStart="175*mm">
+        <layer material="lN2" thickness="30*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3i" zStart="3970*mm" zEnd="7000*mm" rStart="175*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3o" zStart="3970*mm" zEnd="7000*mm" rStart="195*mm">
+        <layer material="lN2" thickness="10*mm" vis="BlueVis"/>
+      </section>
+      <section type="CenterSide" name="MagnetCooling_3r" zStart="7000*mm" zEnd="7050*mm" rStart="175*mm">
+        <layer material="lN2" thickness="30*mm" vis="BlueVis"/>
       </section>
     </detector>
   </detectors>        

--- a/Detector/DetCRD/compact/CRD_common_v01/materials.xml
+++ b/Detector/DetCRD/compact/CRD_common_v01/materials.xml
@@ -570,4 +570,15 @@
      <fraction n="0.5103012386298891" ref="C" />
    </material>
 
+   <material name="superconductor">
+      <D type="density" value="6.78" unit="g/cm3" />
+       <fraction n="0.56" ref="Ni" />
+       <fraction n="0.44" ref="Ti" />
+   </material>
+
+    <material name="lN2">
+      <D type="density" value="0.807" unit="g/cm3" />
+       <fraction n="1" ref="N" />
+    </material>
+
   </materials>

--- a/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v01/CRD_Dimensions_v01_01.xml
@@ -69,7 +69,7 @@
     <constant name="BeamPipe_Crotch_zmax"          value="855*mm"/>
     <constant name="BeamPipe_FirstSeparated_zmax"  value="1110*mm"/>
     <constant name="BeamPipe_SecondSeparated_zmax" value="2200*mm"/>
-    <constant name="BeamPipe_end_z"                value="12*m"/>
+    <constant name="BeamPipe_end_z"                value="7050*mm"/>
 
     <constant name="BeamPipe_Central_inner_radius"  value="14*mm"/>
     <constant name="BeamPipe_Expanded_inner_radius" value="20*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v02/CRD_Dimensions_v01_02.xml
@@ -69,7 +69,7 @@
     <constant name="BeamPipe_Crotch_zmax"          value="855*mm"/>
     <constant name="BeamPipe_FirstSeparated_zmax"  value="1110*mm"/>
     <constant name="BeamPipe_SecondSeparated_zmax" value="2200*mm"/>
-    <constant name="BeamPipe_end_z"                value="12*m"/>
+    <constant name="BeamPipe_end_z"                value="7050*mm"/>
 
     <constant name="BeamPipe_Central_inner_radius"  value="14*mm"/>
     <constant name="BeamPipe_Expanded_inner_radius" value="20*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v03/CRD_Dimensions_v01_03.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v03/CRD_Dimensions_v01_03.xml
@@ -69,7 +69,7 @@
     <constant name="BeamPipe_Crotch_zmax"          value="855*mm"/>
     <constant name="BeamPipe_FirstSeparated_zmax"  value="1110*mm"/>
     <constant name="BeamPipe_SecondSeparated_zmax" value="2200*mm"/>
-    <constant name="BeamPipe_end_z"                value="12*m"/>
+    <constant name="BeamPipe_end_z"                value="7050*mm"/>
 
     <constant name="BeamPipe_Central_inner_radius"  value="14*mm"/>
     <constant name="BeamPipe_Expanded_inner_radius" value="20*mm"/>

--- a/Detector/DetCRD/compact/CRD_o1_v04/CRD_Dimensions_v01_04.xml
+++ b/Detector/DetCRD/compact/CRD_o1_v04/CRD_Dimensions_v01_04.xml
@@ -71,7 +71,7 @@
     <constant name="BeamPipe_Mask_zmin"            value="1210*mm"/>
     <constant name="BeamPipe_Mask_zmax"            value="1230*mm"/>
     <constant name="BeamPipe_SecondSeparated_zmax" value="2200*mm"/>
-    <constant name="BeamPipe_end_z"                value="12*m"/>
+    <constant name="BeamPipe_end_z"                value="7050*mm"/>
 
     <constant name="BeamPipe_Central_inner_radius"  value="10*mm"/>
     <constant name="BeamPipe_Fork_inner_radius"     value="10*mm"/>

--- a/Detector/DetCRD/src/Other/CRDBeamPipe_v01_geo.cpp
+++ b/Detector/DetCRD/src/Other/CRDBeamPipe_v01_geo.cpp
@@ -160,7 +160,7 @@ static Ref_t create_detector(Detector& theDetector,
 	envelope.placeVolume(subLayerLog,  transformer);
 	envelope.placeVolume(subLayerLog,  transmirror);
 	
-        if(material.radLength()<10000*dd4hep::mm){
+        if(type==CEPC::kCenter && material.radLength()<10000*dd4hep::mm){
           double tEff    = thickness/material.radLength()*theDetector.material("G4_Be").radLength();
 	  double tEffEnd = thicknessEnd/material.radLength()*theDetector.material("G4_Be").radLength();
           if(pipeRadius==0)    pipeRadius    = radius;


### PR DESCRIPTION
![MDI](https://user-images.githubusercontent.com/12792582/206971344-0c10b041-6719-4347-807f-158791a25927.png)
As preliminary, the CDR design of MDI lying in range of QD0 and QF1 is implemented.
At the same time, some dimensions of other sub-detectors are modified to avoid overlap.