### PR TITLE
Change capitalization of track subdetectorHitNumbers vector member

### DIFF
--- a/Analysis/DumpEvent/src/DumpTrackAlg.cpp
+++ b/Analysis/DumpEvent/src/DumpTrackAlg.cpp
@@ -1,5 +1,15 @@
 #include "DumpTrackAlg.h"
 
+#if __has_include("edm4hep/EDM4hepVersion.h")
+#include "edm4hep/EDM4hepVersion.h"
+#else
+// Copy the necessary parts from  the header above to make whatever we need to work here
+#define EDM4HEP_VERSION(major, minor, patch) ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | (UINT64_C(patch)))
+// v00-09 is the last version without the capitalization change of the track vector members
+#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 9, 0)
+#endif
+
+
 #include "GaudiKernel/DataObject.h"
 #include "GaudiKernel/IHistogramSvc.h"
 #include "GaudiKernel/MsgStream.h"
@@ -119,6 +129,15 @@ StatusCode DumpTrackAlg::execute(){
 	//  std::cout << track.getSubDetectorHitNumbers(ii) << " ";
 	//}
 	//std::cout << std::endl;
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+	if(track.subdetectorHitNumbers_size()>=5){
+	  m_nHitsVXD[m_nTracks] = track.getSubdetectorHitNumbers(0);
+	  m_nHitsFTD[m_nTracks] = track.getSubdetectorHitNumbers(1);
+	  m_nHitsSIT[m_nTracks] = track.getSubdetectorHitNumbers(2);
+	  m_nHitsGAS[m_nTracks] = track.getSubdetectorHitNumbers(3);
+	  m_nHitsSET[m_nTracks] = track.getSubdetectorHitNumbers(4);
+	}
+#else
 	if(track.subDetectorHitNumbers_size()>=5){
 	  m_nHitsVXD[m_nTracks] = track.getSubDetectorHitNumbers(0);
 	  m_nHitsFTD[m_nTracks] = track.getSubDetectorHitNumbers(1);
@@ -126,6 +145,7 @@ StatusCode DumpTrackAlg::execute(){
 	  m_nHitsGAS[m_nTracks] = track.getSubDetectorHitNumbers(3);
 	  m_nHitsSET[m_nTracks] = track.getSubDetectorHitNumbers(4);
 	}
+#endif
 	else{
 	  m_nHitsVXD[m_nTracks] = 0;
           m_nHitsSIT[m_nTracks] = 0;

--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/TrackCreator.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/TrackCreator.cpp
@@ -10,6 +10,14 @@
 #include "edm4hep/Vertex.h"
 #include "edm4hep/Vector3f.h"
 #include "edm4hep/ReconstructedParticle.h"
+#if __has_include("edm4hep/EDM4hepVersion.h")
+#include "edm4hep/EDM4hepVersion.h"
+#else
+// Copy the necessary parts from  the header above to make whatever we need to work here
+#define EDM4HEP_VERSION(major, minor, patch) ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | (UINT64_C(patch)))
+// v00-09 is the last version without the capitalization change of the track vector members
+#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 9, 0)
+#endif
 
 #include "gear/BField.h"
 #include "gear/CalorimeterParameters.h"
@@ -1020,9 +1028,15 @@ int TrackCreator::GetNTpcHits(const edm4hep::Track *const pTrack) const
         //According to FG: [ 2 * lcio::ILDDetID::TPC - 2 ] is the first number and it is supposed to
         //be the number of hits in the fit and this is what should be used !
         // at least for DD4hep/DDSim
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+        return pTrack->getSubdetectorHitNumbers(3);//FIXME https://github.com/wenxingfang/CEPCSW/blob/master/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp#L483
+    }
+    else return pTrack->getSubdetectorHitNumbers(2 * 4 - 1);// lcio::ILDDetID::TPC=4, still use LCIO code now
+#else
         return pTrack->getSubDetectorHitNumbers(3);//FIXME https://github.com/wenxingfang/CEPCSW/blob/master/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp#L483
     }
     else return pTrack->getSubDetectorHitNumbers(2 * 4 - 1);// lcio::ILDDetID::TPC=4, still use LCIO code now
+#endif
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -1036,9 +1050,16 @@ int TrackCreator::GetNFtdHits(const edm4hep::Track *const pTrack) const
     // ---- use hitsInFit :
     //return pTrack->getSubdetectorHitNumbers()[ 2 * lcio::ILDDetID::FTD - 1 ];
     if(m_settings.m_use_dd4hep_geo){
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+        return pTrack->getSubdetectorHitNumbers(1);//FIXME https://github.com/wenxingfang/CEPCSW/blob/master/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp#L481
+    }
+    else return pTrack->getSubdetectorHitNumbers( 2 * 3 - 1 );// lcio::ILDDetID::FTD=3
+#else
         return pTrack->getSubDetectorHitNumbers(1);//FIXME https://github.com/wenxingfang/CEPCSW/blob/master/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp#L481
     }
     else return pTrack->getSubDetectorHitNumbers( 2 * 3 - 1 );// lcio::ILDDetID::FTD=3
+
+#endif
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/TrackCreator.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/TrackCreator.cpp
@@ -10,6 +10,14 @@
 
 #include "edm4hep/Vertex.h"
 #include "edm4hep/ReconstructedParticle.h"
+#if __has_include("edm4hep/EDM4hepVersion.h")
+#include "edm4hep/EDM4hepVersion.h"
+#else
+// Copy the necessary parts from  the header above to make whatever we need to work here
+#define EDM4HEP_VERSION(major, minor, patch) ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | (UINT64_C(patch)))
+// v00-09 is the last version without the capitalization change of the track vector members
+#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 9, 0)
+#endif
 
 #include "gear/BField.h"
 #include "gear/CalorimeterParameters.h"
@@ -870,14 +878,22 @@ bool TrackCreator::PassesQualityCuts(edm4hep::Track *const pTrack, const Pandora
 
 int TrackCreator::GetNTpcHits(edm4hep::Track *const pTrack) const
 {
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+    return pTrack->getSubdetectorHitNumbers(2 * lcio::ILDDetID::TPC - 1);// still use LCIO code now
+#else
     return pTrack->getSubDetectorHitNumbers(2 * lcio::ILDDetID::TPC - 1);// still use LCIO code now
+#endif
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 int TrackCreator::GetNFtdHits(edm4hep::Track *const pTrack) const
 {
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+    return pTrack->getSubdetectorHitNumbers( 2 * lcio::ILDDetID::FTD - 1 );
+#else
     return pTrack->getSubDetectorHitNumbers( 2 * lcio::ILDDetID::FTD - 1 );
+#endif
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
@@ -6,6 +6,14 @@
 #include "edm4hep/TrackerHit.h"
 #include "edm4hep/TrackerHit.h"
 #include "edm4hep/Track.h"
+#if __has_include("edm4hep/EDM4hepVersion.h")
+#include "edm4hep/EDM4hepVersion.h"
+#else
+// Copy the necessary parts from  the header above to make whatever we need to work here
+#define EDM4HEP_VERSION(major, minor, patch) ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | (UINT64_C(patch)))
+// v00-09 is the last version without the capitalization change of the track vector members
+#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 9, 0)
+#endif
 
 #include "UTIL/ILDConf.h"
 
@@ -1001,13 +1009,21 @@ void ForwardTrackingAlg::finaliseTrack( edm4hep::MutableTrack* trackImpl ){
   //trackImpl->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::TPC - 1 ] = hitNumbers[lcio::ILDDetID::TPC];
   //trackImpl->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::SET - 1 ] = hitNumbers[lcio::ILDDetID::SET];
   //trackImpl->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::ETD - 1 ] = hitNumbers[lcio::ILDDetID::ETD];
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+  trackImpl->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::VXD]);
+  trackImpl->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SIT]);
+  trackImpl->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::FTD]);
+  trackImpl->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::TPC]);
+  trackImpl->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SET]);
+  trackImpl->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::ETD]);
+#else
   trackImpl->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::VXD]);
   trackImpl->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SIT]);
   trackImpl->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::FTD]);
   trackImpl->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::TPC]);
   trackImpl->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SET]);
   trackImpl->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::ETD]);
-     
+#endif
   return;
 }
 

--- a/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
@@ -9,6 +9,14 @@
 //#include "edm4hep/TrackerHitPlane.h"
 #include "edm4hep/Track.h"
 #include "edm4hep/TrackState.h"
+#if __has_include("edm4hep/EDM4hepVersion.h")
+#include "edm4hep/EDM4hepVersion.h"
+#else
+// Copy the necessary parts from  the header above to make whatever we need to work here
+#define EDM4HEP_VERSION(major, minor, patch) ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | (UINT64_C(patch)))
+// v00-09 is the last version without the capitalization change of the track vector members
+#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 9, 0)
+#endif
 
 #include <iostream>
 #include <algorithm>
@@ -2833,10 +2841,15 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       MarlinTrk::addHitNumbersToTrack(&track, all_hits, false, cellID_encoder);
       
       delete marlinTrk;
-
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+      int nhits_in_vxd = track.getSubdetectorHitNumbers(0);
+      int nhits_in_ftd = track.getSubdetectorHitNumbers(1);
+      int nhits_in_sit = track.getSubdetectorHitNumbers(2);
+#else
       int nhits_in_vxd = track.getSubDetectorHitNumbers(0);
       int nhits_in_ftd = track.getSubDetectorHitNumbers(1);
       int nhits_in_sit = track.getSubDetectorHitNumbers(2);
+#endif
       
       //debug() << " Hit numbers for Track "<< track.id() << ": "
       debug() << " Hit numbers for Track "<< iTrk <<": "

--- a/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp
+++ b/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp
@@ -8,6 +8,14 @@
 #include <edm4hep/TrackerHit.h>
 #include <edm4hep/TrackerHit.h>
 #include <edm4hep/Track.h>
+#if __has_include("edm4hep/EDM4hepVersion.h")
+#include "edm4hep/EDM4hepVersion.h"
+#else
+// Copy the necessary parts from  the header above to make whatever we need to work here
+#define EDM4HEP_VERSION(major, minor, patch) ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | (UINT64_C(patch)))
+// v00-09 is the last version without the capitalization change of the track vector members
+#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 9, 0)
+#endif
 
 #include <iostream>
 #include <algorithm>
@@ -513,11 +521,19 @@ void FullLDCTrackingAlg::AddTrackColToEvt(TrackExtendedVec & trkVec, edm4hep::Tr
     float z0TrkCand = trkCand->getZ0();
     //    float phi0TrkCand = trkCand->getPhi();
     // FIXME, fucd
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+    int nhits_in_vxd = track.getSubdetectorHitNumbers(0);
+    int nhits_in_ftd = track.getSubdetectorHitNumbers(1);
+    int nhits_in_sit = track.getSubdetectorHitNumbers(2);
+    int nhits_in_tpc = track.getSubdetectorHitNumbers(3);
+    int nhits_in_set = track.getSubdetectorHitNumbers(4);
+#else
     int nhits_in_vxd = track.getSubDetectorHitNumbers(0);
     int nhits_in_ftd = track.getSubDetectorHitNumbers(1);
     int nhits_in_sit = track.getSubDetectorHitNumbers(2);
     int nhits_in_tpc = track.getSubDetectorHitNumbers(3);
     int nhits_in_set = track.getSubDetectorHitNumbers(4);
+#endif
     //int nhits_in_vxd = Track->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::VXD - 2 ];
     //int nhits_in_ftd = Track->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::FTD - 2 ];
     //int nhits_in_sit = Track->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::SIT - 2 ];

--- a/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
+++ b/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
@@ -16,6 +16,15 @@
 #include "edm4hep/Track.h"
 #include "edm4hep/MutableTrack.h"
 
+#if __has_include("edm4hep/EDM4hepVersion.h")
+#include "edm4hep/EDM4hepVersion.h"
+#else
+// Copy the necessary parts from  the header above to make whatever we need to work here
+#define EDM4HEP_VERSION(major, minor, patch) ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | (UINT64_C(patch)))
+// v00-09 is the last version without the capitalization change of the track vector members
+#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 9, 0)
+#endif
+
 #include <UTIL/BitField64.h>
 #include <UTIL/ILDConf.h>
 #include <UTIL/BitSet32.h>
@@ -694,12 +703,21 @@ namespace MarlinTrk {
     if ( hits_in_fit == false ) { // all hit atributed by patrec
       offset = 1 ;
     }
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::VXD]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::FTD]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SIT]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::TPC]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SET]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::ETD]);
+#else
     track->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::VXD]);
     track->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::FTD]);
     track->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SIT]);
     track->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::TPC]);
     track->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SET]);
     track->addToSubDetectorHitNumbers(hitNumbers[UTIL::ILDDetID::ETD]);
+#endif
     //track->subdetectorHitNumbers().resize(2 * lcio::ILDDetID::ETD);
     //track->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::VXD - offset ] = hitNumbers[lcio::ILDDetID::VXD];
     //track->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::FTD - offset ] = hitNumbers[lcio::ILDDetID::FTD];
@@ -738,12 +756,21 @@ namespace MarlinTrk {
     if ( hits_in_fit == false ) { // all hit atributed by patrec
       offset = 1 ;
     }
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::VXD]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::FTD]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SIT]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::TPC]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::SET]);
+    track->addToSubdetectorHitNumbers(hitNumbers[UTIL::ILDDetID::ETD]);
+#else
     track->addToSubDetectorHitNumbers(hitNumbers[lcio::ILDDetID::VXD]);
     track->addToSubDetectorHitNumbers(hitNumbers[lcio::ILDDetID::FTD]);
     track->addToSubDetectorHitNumbers(hitNumbers[lcio::ILDDetID::SIT]);
     track->addToSubDetectorHitNumbers(hitNumbers[lcio::ILDDetID::TPC]);
     track->addToSubDetectorHitNumbers(hitNumbers[lcio::ILDDetID::SET]);
     track->addToSubDetectorHitNumbers(hitNumbers[lcio::ILDDetID::ETD]);
+#endif
     //track->subdetectorHitNumbers().resize(2 * lcio::ILDDetID::ETD);
     //track->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::VXD - offset ] = hitNumbers[lcio::ILDDetID::VXD];
     //track->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::FTD - offset ] = hitNumbers[lcio::ILDDetID::FTD];


### PR DESCRIPTION
Renamed for more consistency in key4hep/EDM4hep#188. This PR also introduces the minimal preprocessor things that are necessary to make things work if `EDM4hepVersion.h` is not yet available. This is necessary to make the transition a bit smoother.