### PR TITLE
Fix ObjectID issues

### DIFF
--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/MCParticleCreator.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/MCParticleCreator.cpp
@@ -53,7 +53,7 @@ pandora::StatusCode MCParticleCreator::CreateMCParticles(const CollectionMaps& c
                     mcParticleParameters.m_particleId = pMcParticle.getPDG();
                     mcParticleParameters.m_mcParticleType = pandora::MC_3D;
                     mcParticleParameters.m_pParentAddress = &pMcParticle;
-                    unsigned int p_id = pMcParticle.id();
+                    unsigned int p_id = pMcParticle.id().index;
                     //auto p_mc = const_cast<edm4hep::MCParticle*>(&pMcParticle);
                     auto p_mc = &pMcParticle;
                     (*m_id_pMC_map) [p_id]   = p_mc;
@@ -131,8 +131,8 @@ pandora::StatusCode MCParticleCreator::CreateCaloHitToMCParticleRelationships(co
                             auto conb = pSimHit.getContributions(iCont);
                             auto ipa = conb.getParticle();
                             float  ien = conb.getEnergy();
-                            if( m_id_pMC_map->find(ipa.id()) == m_id_pMC_map->end() ) continue;
-                            auto p_tmp = (*m_id_pMC_map)[ipa.id()]; 
+                            if( m_id_pMC_map->find(ipa.id().index) == m_id_pMC_map->end() ) continue;
+                            auto p_tmp = (*m_id_pMC_map)[ipa.id().index];
                             mcParticleToEnergyWeightMap[p_tmp] += ien;
                         }
                         
@@ -190,13 +190,13 @@ pandora::StatusCode MCParticleCreator::CreateTrackToMCParticleRelationships(cons
                         if( pMCRecoTrackerAssociationCollection.at(ic).getRec().id() != pTrack->getTrackerHits(ith).id() ) continue;
                         auto pSimHit = pMCRecoTrackerAssociationCollection.at(ic).getSim();
                         auto ipa = pSimHit.getMCParticle();
-                        if( m_id_pMC_map->find(ipa.id()) == m_id_pMC_map->end() ) continue;
+                        if( m_id_pMC_map->find(ipa.id().index) == m_id_pMC_map->end() ) continue;
                         const float trueMomentum(pandora::CartesianVector(ipa.getMomentum()[0], ipa.getMomentum()[1], ipa.getMomentum()[2]).GetMagnitude());
                         const float deltaMomentum(std::fabs(recoMomentum - trueMomentum));
                         if (deltaMomentum < bestDeltaMomentum)
                         {
                             //pBestMCParticle =((*m_id_pMC_map)[ipa.id()]);
-                            best_mc_id = ipa.id() ;
+                            best_mc_id = ipa.id().index ;
                             bestDeltaMomentum = deltaMomentum;
                         }
                     }

--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/PandoraPFAlg.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/PandoraPFAlg.cpp
@@ -669,9 +669,9 @@ StatusCode PandoraPFAlg::CreateMCRecoParticleAssociation()
                         if(it->getRec().id() != hit.id()) continue;
                         for(auto itc = it->getSim().contributions_begin(); itc != it->getSim().contributions_end(); itc++)
                         {
-                            if(mc_map.find(itc->getParticle().id()) == mc_map.end()) mc_map[itc->getParticle().id()] = itc->getParticle() ;
-                            if(id_edep_map.find(itc->getParticle().id()) != id_edep_map.end()) id_edep_map[itc->getParticle().id()] = id_edep_map[itc->getParticle().id()] + itc->getEnergy() ;
-                            else                                                               id_edep_map[itc->getParticle().id()] = itc->getEnergy() ;
+                            if(mc_map.find(itc->getParticle().id().index) == mc_map.end()) mc_map[itc->getParticle().id().index] = itc->getParticle() ;
+                            if(id_edep_map.find(itc->getParticle().id().index) != id_edep_map.end()) id_edep_map[itc->getParticle().id().index] = id_edep_map[itc->getParticle().id().index] + itc->getEnergy() ;
+                            else                                                               id_edep_map[itc->getParticle().id().index] = itc->getEnergy() ;
                             tot_en += itc->getEnergy() ;
                         }
                     }

--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/TrackCreator.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/TrackCreator.cpp
@@ -321,7 +321,7 @@ pandora::StatusCode TrackCreator::ExtractKinks(const CollectionMaps& collectionM
                     for (unsigned int iTrack = 0, nTracks = pReconstructedParticle.tracks_size(); iTrack < nTracks; ++iTrack)
                     {
                         auto pTrack = pReconstructedParticle.getTracks(iTrack);
-                        (0 == iTrack) ? m_parentTrackList.insert(pTrack.id()) : m_daughterTrackList.insert(pTrack.id());
+                        (0 == iTrack) ? m_parentTrackList.insert(pTrack.id().index) : m_daughterTrackList.insert(pTrack.id().index);
 
                         int trackPdgCode = pandora::UNKNOWN_PARTICLE_TYPE;
 
@@ -421,7 +421,7 @@ pandora::StatusCode TrackCreator::ExtractProngsAndSplits(const CollectionMaps& c
                     for (unsigned int iTrack = 0, nTracks = pReconstructedParticle.tracks_size(); iTrack < nTracks; ++iTrack)
                     {
                         edm4hep::Track pTrack = pReconstructedParticle.getTracks(iTrack);
-                        (0 == iTrack) ? m_parentTrackList.insert(pTrack.id()) : m_daughterTrackList.insert(pTrack.id());
+                        (0 == iTrack) ? m_parentTrackList.insert(pTrack.id().index) : m_daughterTrackList.insert(pTrack.id().index);
 
                         if (0 == m_settings.m_shouldFormTrackRelationships) continue;
 
@@ -490,7 +490,7 @@ pandora::StatusCode TrackCreator::ExtractV0s(const CollectionMaps& collectionMap
                     for (unsigned int iTrack = 0, nTracks = pReconstructedParticle.tracks_size(); iTrack < nTracks; ++iTrack)
                     {
                         edm4hep::Track pTrack = pReconstructedParticle.getTracks(iTrack);
-                        m_v0TrackList.insert(pTrack.id());
+                        m_v0TrackList.insert(pTrack.id().index);
 
                         int trackPdgCode = pandora::UNKNOWN_PARTICLE_TYPE;
 
@@ -546,7 +546,7 @@ bool TrackCreator::IsConflictingRelationship(const edm4hep::ReconstructedParticl
     for (unsigned int iTrack = 0, nTracks = Particle.tracks_size(); iTrack < nTracks; ++iTrack)
     {
         edm4hep::Track pTrack = Particle.getTracks(iTrack) ;
-        unsigned int pTrack_id = pTrack.id() ;
+        unsigned int pTrack_id = pTrack.id().index ;
 
         if (this->IsDaughter(pTrack_id) || this->IsParent(pTrack_id) || this->IsV0(pTrack_id))
             return true;
@@ -859,7 +859,7 @@ void TrackCreator::DefineTrackPfoUsage(const edm4hep::Track *const pTrack, Pando
     bool canFormPfo(false);
     bool canFormClusterlessPfo(false);
 
-    if (trackParameters.m_reachesCalorimeter.Get() && !this->IsParent(pTrack->id()))
+    if (trackParameters.m_reachesCalorimeter.Get() && !this->IsParent(pTrack->id().index))
     {
         const float d0(std::fabs(pTrack->getTrackStates(0).D0)), z0(std::fabs(pTrack->getTrackStates(0).Z0));
 
@@ -888,8 +888,8 @@ void TrackCreator::DefineTrackPfoUsage(const edm4hep::Track *const pTrack, Pando
             const float zCutForNonVertexTracks(m_tpcInnerR * std::fabs(pZ / pT) + m_settings.m_zCutForNonVertexTracks);
             const bool passRzQualityCuts((zMin < zCutForNonVertexTracks) && (rInner < m_tpcInnerR + m_settings.m_maxTpcInnerRDistance));
 
-            const bool isV0(this->IsV0(pTrack->id()));
-            const bool isDaughter(this->IsDaughter(pTrack->id()));
+            const bool isV0(this->IsV0(pTrack->id().index));
+            const bool isDaughter(this->IsDaughter(pTrack->id().index));
 
             // Decide whether track can be associated with a pandora cluster and used to form a charged PFO
             if ((d0 < m_settings.m_d0TrackCut) && (z0 < m_settings.m_z0TrackCut) && (rInner < m_tpcInnerR + m_settings.m_maxTpcInnerRDistance))
@@ -926,7 +926,7 @@ void TrackCreator::DefineTrackPfoUsage(const edm4hep::Track *const pTrack, Pando
                 }
             }
         }
-        else if (this->IsDaughter(pTrack->id()) || this->IsV0(pTrack->id()))
+        else if (this->IsDaughter(pTrack->id().index) || this->IsV0(pTrack->id().index))
         {
             std::cout<<"WARNING Recovering daughter or v0 track " << trackParameters.m_momentumAtDca.Get().GetMagnitude() << std::endl;
             canFormPfo = true;

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/MCParticleCreator.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/MCParticleCreator.cpp
@@ -57,7 +57,7 @@ pandora::StatusCode MCParticleCreator::CreateMCParticles(const CollectionMaps& c
                     mcParticleParameters.m_particleId = pMcParticle.getPDG();
                     mcParticleParameters.m_mcParticleType = pandora::MC_3D;
                     mcParticleParameters.m_pParentAddress = &pMcParticle;
-                    unsigned int p_id = pMcParticle.id();
+                    unsigned int p_id = pMcParticle.id().index;
                     auto p_mc = &pMcParticle;
                     (*m_id_pMC_map) [p_id]   = p_mc;
                     mcParticleParameters.m_momentum = pandora::CartesianVector(pMcParticle.getMomentum()[0], pMcParticle.getMomentum()[1],
@@ -271,8 +271,8 @@ pandora::StatusCode MCParticleCreator::CreateCaloHitToMCParticleRelationships(co
                             edm4hep::CaloHitContribution conb = pSimHit.getContributions(iCont);
                             auto ipa = conb.getParticle();
                             float  ien = conb.getEnergy();
-                            if( m_id_pMC_map->find(ipa.id()) == m_id_pMC_map->end() ) continue;
-                            auto p_tmp = (*m_id_pMC_map)[ipa.id()]; 
+                            if( m_id_pMC_map->find(ipa.id().index) == m_id_pMC_map->end() ) continue;
+                            auto p_tmp = (*m_id_pMC_map)[ipa.id().index];
                             mcParticleToEnergyWeightMap[p_tmp] += ien;
                         }
                         
@@ -331,12 +331,12 @@ pandora::StatusCode MCParticleCreator::CreateTrackToMCParticleRelationships(cons
                         if( pMCRecoTrackerAssociationCollection.at(ic).getRec().id() != pTrack->getTrackerHits(ith).id() ) continue;
                         auto pSimHit = pMCRecoTrackerAssociationCollection.at(ic).getSim();
                         auto ipa = pSimHit.getMCParticle();
-                        if( m_id_pMC_map->find(ipa.id()) == m_id_pMC_map->end() ) continue;
+                        if( m_id_pMC_map->find(ipa.id().index) == m_id_pMC_map->end() ) continue;
                         const float trueMomentum(pandora::CartesianVector(ipa.getMomentum()[0], ipa.getMomentum()[1], ipa.getMomentum()[2]).GetMagnitude());
                         const float deltaMomentum(std::fabs(recoMomentum - trueMomentum));
                         if (deltaMomentum < bestDeltaMomentum)
                         {
-                            pBestMCParticle = ((*m_id_pMC_map)[ipa.id()]);
+                            pBestMCParticle = ((*m_id_pMC_map)[ipa.id().index]);
                             bestDeltaMomentum = deltaMomentum;
                         }
                     }

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/PandoraMatrixAlg.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/PandoraMatrixAlg.cpp
@@ -591,7 +591,7 @@ StatusCode PandoraMatrixAlg::Ana()
         {
             if(reco_associa_col->at(j).getRec().id() != pReco.id() ) continue;
             std::cout<<"MC pid ="<<reco_associa_col->at(j).getSim().getPDG()<<",weight="<<reco_associa_col->at(j).getWeight()<<", px="<<reco_associa_col->at(j).getSim().getMomentum()[0]<<", py="<<reco_associa_col->at(j).getSim().getMomentum()[1]<<",pz="<<reco_associa_col->at(j).getSim().getMomentum()[2]<<std::endl;
-            tmp_mc_id    .push_back(reco_associa_col->at(j).getSim().id());
+            tmp_mc_id    .push_back(reco_associa_col->at(j).getSim().id().index);
             tmp_mc_weight.push_back(reco_associa_col->at(j).getWeight());
         }
         m_pReco_mc_id    .push_back(tmp_mc_id);
@@ -604,7 +604,7 @@ StatusCode PandoraMatrixAlg::Ana()
     { 
         for(unsigned int i=0 ; i< MCParticle->size(); i++)
         {
-            m_mc_id    .push_back(MCParticle->at(i).id());
+            m_mc_id    .push_back(MCParticle->at(i).id().index);
             m_mc_p_size.push_back(MCParticle->at(i).parents_size());
             m_mc_pid   .push_back(MCParticle->at(i).getPDG());
             m_mc_mass  .push_back(MCParticle->at(i).getMass());
@@ -655,9 +655,9 @@ StatusCode PandoraMatrixAlg::CreateMCRecoParticleAssociation()
                         if(it->getRec().id() != hit.id()) continue;
                         for(auto itc = it->getSim().contributions_begin(); itc != it->getSim().contributions_end(); itc++)
                         {
-                            if(mc_map.find(itc->getParticle().id()) == mc_map.end()) mc_map[itc->getParticle().id()] = itc->getParticle() ;
-                            if(id_edep_map.find(itc->getParticle().id()) != id_edep_map.end()) id_edep_map[itc->getParticle().id()] = id_edep_map[itc->getParticle().id()] + itc->getEnergy() ;
-                            else                                                               id_edep_map[itc->getParticle().id()] = itc->getEnergy() ;
+                            if(mc_map.find(itc->getParticle().id().index) == mc_map.end()) mc_map[itc->getParticle().id().index] = itc->getParticle() ;
+                            if(id_edep_map.find(itc->getParticle().id().index) != id_edep_map.end()) id_edep_map[itc->getParticle().id().index] = id_edep_map[itc->getParticle().id().index] + itc->getEnergy() ;
+                            else                                                               id_edep_map[itc->getParticle().id().index] = itc->getEnergy() ;
                             tot_en += itc->getEnergy() ;
                         }
                     }

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/TrackCreator.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/TrackCreator.cpp
@@ -185,7 +185,7 @@ pandora::StatusCode TrackCreator::ExtractKinks(const CollectionMaps& collectionM
                     for (unsigned int iTrack = 0, nTracks = pReconstructedParticle.tracks_size(); iTrack < nTracks; ++iTrack)
                     {
                         auto pTrack = pReconstructedParticle.getTracks(iTrack);
-                        (0 == iTrack) ? m_parentTrackList.insert(pTrack.id()) : m_daughterTrackList.insert(pTrack.id());
+                        (0 == iTrack) ? m_parentTrackList.insert(pTrack.id().index) : m_daughterTrackList.insert(pTrack.id().index);
 
                         int trackPdgCode = pandora::UNKNOWN_PARTICLE_TYPE;
 
@@ -285,7 +285,7 @@ pandora::StatusCode TrackCreator::ExtractProngsAndSplits(const CollectionMaps& c
                     for (unsigned int iTrack = 0, nTracks = pReconstructedParticle.tracks_size(); iTrack < nTracks; ++iTrack)
                     {
                         auto pTrack = pReconstructedParticle.getTracks(iTrack);
-                        (0 == iTrack) ? m_parentTrackList.insert(pTrack.id()) : m_daughterTrackList.insert(pTrack.id());
+                        (0 == iTrack) ? m_parentTrackList.insert(pTrack.id().index) : m_daughterTrackList.insert(pTrack.id().index);
 
                         if (0 == m_settings.m_shouldFormTrackRelationships) continue;
 
@@ -354,7 +354,7 @@ pandora::StatusCode TrackCreator::ExtractV0s(const CollectionMaps& collectionMap
                     for (unsigned int iTrack = 0, nTracks = pReconstructedParticle.tracks_size(); iTrack < nTracks; ++iTrack)
                     {
                         auto pTrack = pReconstructedParticle.getTracks(iTrack);
-                        m_v0TrackList.insert(pTrack.id());
+                        m_v0TrackList.insert(pTrack.id().index);
 
                         int trackPdgCode = pandora::UNKNOWN_PARTICLE_TYPE;
 
@@ -409,7 +409,7 @@ bool TrackCreator::IsConflictingRelationship(const edm4hep::ReconstructedParticl
     for (unsigned int iTrack = 0, nTracks = Particle.tracks_size(); iTrack < nTracks; ++iTrack)
     {
         edm4hep::Track pTrack = Particle.getTracks(iTrack) ;
-        unsigned int pTrack_id = pTrack.id() ;
+        unsigned int pTrack_id = pTrack.id().index ;
 
         if (this->IsDaughter(pTrack_id) || this->IsParent(pTrack_id) || this->IsV0(pTrack_id))
             return true;
@@ -720,7 +720,7 @@ void TrackCreator::DefineTrackPfoUsage(edm4hep::Track *const pTrack, PandoraApi:
     bool canFormPfo(false);
     bool canFormClusterlessPfo(false);
 
-    if (trackParameters.m_reachesCalorimeter.Get() && !this->IsParent(pTrack->id()))
+    if (trackParameters.m_reachesCalorimeter.Get() && !this->IsParent(pTrack->id().index))
     {
         const float d0(std::fabs(pTrack->getTrackStates(0).D0)), z0(std::fabs(pTrack->getTrackStates(0).Z0));
 
@@ -748,8 +748,8 @@ void TrackCreator::DefineTrackPfoUsage(edm4hep::Track *const pTrack, PandoraApi:
             const float zCutForNonVertexTracks(m_tpcInnerR * std::fabs(pZ / pT) + m_settings.m_zCutForNonVertexTracks);
             const bool passRzQualityCuts((zMin < zCutForNonVertexTracks) && (rInner < m_tpcInnerR + m_settings.m_maxTpcInnerRDistance));
 
-            const bool isV0(this->IsV0(pTrack->id()));
-            const bool isDaughter(this->IsDaughter(pTrack->id()));
+            const bool isV0(this->IsV0(pTrack->id().index));
+            const bool isDaughter(this->IsDaughter(pTrack->id().index));
 
             // Decide whether track can be associated with a pandora cluster and used to form a charged PFO
             if ((d0 < m_settings.m_d0TrackCut) && (z0 < m_settings.m_z0TrackCut) && (rInner < m_tpcInnerR + m_settings.m_maxTpcInnerRDistance))
@@ -786,7 +786,7 @@ void TrackCreator::DefineTrackPfoUsage(edm4hep::Track *const pTrack, PandoraApi:
                 }
             }
         }
-        else if (this->IsDaughter(pTrack->id()) || this->IsV0(pTrack->id()))
+        else if (this->IsDaughter(pTrack->id().index) || this->IsV0(pTrack->id().index))
         {
             std::cout<<"WARNING Recovering daughter or v0 track " << trackParameters.m_momentumAtDca.Get().GetMagnitude() << std::endl;
             canFormPfo = true;


### PR DESCRIPTION
After https://github.com/AIDASoft/podio/pull/493, `id()` returns a `podio::ObjectID` which breaks in a few places. I have made the changes so that compiling works by using the `index` member variable but I'm not sure if everything keeps working, it would be great if someone can have a look.