### PR TITLE
REC: Tracking bug fix

### DIFF
--- a/Digitisers/SimpleDigi/src/PlanarDigiAlg.cpp
+++ b/Digitisers/SimpleDigi/src/PlanarDigiAlg.cpp
@@ -259,7 +259,7 @@ StatusCode PlanarDigiAlg::execute()
       localPointSmeared.setY( localPoint.y() + dy );
 
       //check if hit is in boundaries
-      if ( ms->isLocalInBoundary( localPointSmeared ) && fabs(dx)<_maxPull*resU && fabs(dy)<_maxPull*resV ) {
+      if ( ms->isLocalInBoundary( localPointSmeared ) && fabs(dx)<=_maxPull*resU && fabs(dy)<=_maxPull*resV ) {
       //if ( ms->isLocalInBoundary( localPointSmeared ) ) {
         accept_hit = true;
         break;

--- a/Examples/options/sim-rec-trackerecal.py
+++ b/Examples/options/sim-rec-trackerecal.py
@@ -79,7 +79,7 @@ tpc_sensdettool.TypeOption = 1
 
 from Configurables import GearSvc
 gearsvc = GearSvc("GearSvc")
-gearsvc.GearXMLFile = "Detector/DetCEPCv4/compact/FullDetGear.xml"
+#gearsvc.GearXMLFile = "Detector/DetCEPCv4/compact/FullDetGear.xml"
 
 from Configurables import TrackSystemSvc
 tracksystemsvc = TrackSystemSvc("TrackSystemSvc")
@@ -148,7 +148,7 @@ digiTPC.TPCTrackerHitsCol = tpchitname
 from Configurables import ClupatraAlg
 clupatra = ClupatraAlg("Clupatra")
 clupatra.TPCHitCollection = tpchitname
-#clupatra.OutputLevel = DEBUG
+clupatra.OutputLevel = DEBUG
 
 from Configurables import SiliconTrackingAlg
 tracking = SiliconTrackingAlg("SiliconTracking")
@@ -331,7 +331,7 @@ ApplicationMgr(
     TopAlg = [genalg, detsimalg, digiVXD, digiSIT, digiSET, digiFTD, spSIT, spFTD, digiTPC, clupatra, tracking, forward, subset, full, simHitMerge, caloDigi, pandoralg, write],
     EvtSel = 'NONE',
     EvtMax = 10,
-    ExtSvc = [rndmengine, dsvc, evtseeder, gearsvc, geosvc, tracksystemsvc],
+    ExtSvc = [rndmengine, dsvc, evtseeder, geosvc, gearsvc, tracksystemsvc],
     HistogramPersistency='ROOT',
     OutputLevel=INFO
 )

--- a/Examples/options/sim-rec-trackerecal.py
+++ b/Examples/options/sim-rec-trackerecal.py
@@ -148,7 +148,7 @@ digiTPC.TPCTrackerHitsCol = tpchitname
 from Configurables import ClupatraAlg
 clupatra = ClupatraAlg("Clupatra")
 clupatra.TPCHitCollection = tpchitname
-clupatra.OutputLevel = DEBUG
+#clupatra.OutputLevel = DEBUG
 
 from Configurables import SiliconTrackingAlg
 tracking = SiliconTrackingAlg("SiliconTracking")

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
@@ -287,7 +287,8 @@ namespace clupatra_new{
 		UTIL::BitField64 encoder( UTIL::ILDCellID0::encoder_string ) ;
 		encoder[UTIL::ILDCellID0::subdet] = UTIL::ILDDetID::TPC ;
 
-		edm4hep::TrackerHit firstHit; // =  0 ;
+		edm4hep::TrackerHit firstHit = 0;
+		// = 0 equal to unlink() 
                 //firstHit.unlink();
 
 		IMarlinTrack* bwTrk = 0 ;

--- a/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp
+++ b/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.cpp
@@ -1166,13 +1166,18 @@ void FullLDCTrackingAlg::prepareVectors() {
       trackExt->setNDF(tpcTrack.getNdf());
       trackExt->setChi2(tpcTrack.getChi2());
       for (int iHit=0;iHit<nHits;++iHit) {
-	edm4hep::TrackerHit hit = tpcTrack.getTrackerHits(iHit);//hitVec[iHit];
-	if(!hit.isAvailable()) error() << "Tracker hit not available" << endmsg;
+	edm4hep::TrackerHit hit = tpcTrack.getTrackerHits(iHit);
+	if (!hit.isAvailable()) {
+	  error() << "Tracker hit not available" << endmsg;
+	  continue;
+	}
 	//info() << "hit " << hit.id() << " " << hit.getCellID() << " " << hit.getPosition()[0] << " " << hit.getPosition()[1] << " " << hit.getPosition()[2] << endmsg;
 	auto it = mapTrackerHits.find(hit);
-	if(it==mapTrackerHits.end()) error() << "Cannot find hit " << hit.id() << " in map" << endmsg;
-	else continue;
-        TrackerHitExtended * hitExt = it->second;
+	if (it==mapTrackerHits.end()) {
+	  error() << "Cannot find hit " << hit.id() << " in map" << endmsg;
+	  continue;
+	}
+        TrackerHitExtended* hitExt = it->second;
 	//info() << hit.id() << " " << hitExt << endmsg;
         hitExt->setTrackExtended( trackExt );
         trackExt->addTrackerHitExtended( hitExt );
@@ -1231,8 +1236,17 @@ void FullLDCTrackingAlg::prepareVectors() {
       char strg[200];
       HelixClass helixSi;
       for (int iHit=0;iHit<nHits;++iHit) {
-	edm4hep::TrackerHit hit = siTrack.getTrackerHits(iHit);//hitVec[iHit];
-        TrackerHitExtended * hitExt = mapTrackerHits[hit];
+	edm4hep::TrackerHit hit = siTrack.getTrackerHits(iHit);
+	if (!hit.isAvailable()) {
+	  error() << "Tracker hit not available" << endmsg;
+	  continue;
+	}
+	auto it = mapTrackerHits.find(hit);
+        if (it==mapTrackerHits.end()) {
+	  error() << "Cannot find hit " << hit.id() << " in map" << endmsg;
+	  continue;
+	}
+        TrackerHitExtended* hitExt = it->second;
         hitExt->setTrackExtended( trackExt );
         
         trackExt->addTrackerHitExtended( hitExt );
@@ -1534,8 +1548,8 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
   int nTPCHits = int(tpcHitVec.size());
   int nHits = nTPCHits + nSiHits;
   
-  //std::cout << "FullLDCTrackingAlg::CombineTracks nSiHits = " << nSiHits << endmsg;
-  //std::cout << "FullLDCTrackingAlg::CombineTracks nTPCHits = " << nTPCHits << endmsg;
+  //debug() << "FullLDCTrackingAlg::CombineTracks nSiHits = " << nSiHits << endmsg;
+  //debug() << "FullLDCTrackingAlg::CombineTracks nTPCHits = " << nTPCHits << endmsg;
   
   TrackerHitVec trkHits;
   trkHits.reserve(nHits);
@@ -1748,7 +1762,7 @@ TrackExtended * FullLDCTrackingAlg::CombineTracks(TrackExtended * tpcTrack, Trac
       tpcHitInFit.push_back(tpcHitVec[i]);
     }
   }
-  
+
   debug() << "FullLDCTrackingAlg::CombineTracks: Check for Silicon Hit rejections ... " << endmsg;
   
   if ( (int)siOutliers.size() > _maxAllowedSiHitRejectionsForTrackCombination ) {


### PR DESCRIPTION
* Digitization for silicon
  * accept condition cannot not statify if resV=0 for strip case, fixed let 0=0
* Clupatra
  * edm4hep::TrackerHit firstHit will not let object pointer = 0, but edm4hep::TrackerHit firstHit = 0 equal to call unlink()
* FullLDCTrackingAlg
  * wrong to continue while find hit in map, fixed to next step
* Examples
  * fix run error, GeomSvc should always load before GearSvc     