### PR TITLE
Remove k4LCIOReader

### DIFF
--- a/cmake/CEPCSWConfig.cmake
+++ b/cmake/CEPCSWConfig.cmake
@@ -2,7 +2,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(podio REQUIRED)
 find_dependency(Gaudi REQUIRED)
 find_dependency(k4FWCore REQUIRED)
-find_dependency(k4LCIOReader REQUIRED)
 find_dependency(EDM4HEP REQUIRED)
 find_dependency(ROOT REQUIRED)
 


### PR DESCRIPTION
I think it isn't being used in any place and then we can remove it from the key4hep stack since now conversions in both ways are provided in https://github.com/key4hep/k4EDM4hep2LcioConv