### PR TITLE
Move to makeEmpty factory methods for initializing empty edm4hep objects

### DIFF
--- a/Analysis/TrackInspect/src/TrackInspectAlg.cpp
+++ b/Analysis/TrackInspect/src/TrackInspectAlg.cpp
@@ -39,6 +39,8 @@
 
 #include "DataHelper/HelixClass.h"
 
+#include "podio/podioVersion.h"
+
 #include "CLHEP/Units/SystemOfUnits.h"
 #include <math.h>
 #include <TTree.h>
@@ -179,7 +181,11 @@ StatusCode TrackInspectAlg::execute(){
             if (theTracks.size() == 0) {
                 totalCandidates[m_nParticles] = 0;
                 nCandidate[m_nParticles] = -1;
+#if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
                 Fill(particle, edm4hep::Track(nullptr));
+#else
+                Fill(particle, edm4hep::Track::makeEmpty());
+#endif
                 m_nParticles++;
             }
             else {

--- a/Reconstruction/PFA/Arbor/src/ArborToolLCIO.cc
+++ b/Reconstruction/PFA/Arbor/src/ArborToolLCIO.cc
@@ -35,6 +35,8 @@
 #include <DDRec/CellIDPositionConverter.h>
 #include "DetInterface/IGeomSvc.h"
 
+#include "podio/podioVersion.h"
+
 using namespace std;
 /* 
 void ClusterBuilding( LCEvent * evtPP, std::string Name, std::vector<CalorimeterHit*> Hits, std::vector< std::vector<int> > BranchOrder, int DHCALFlag )
@@ -859,7 +861,12 @@ edm4hep::ClusterCollection* ArborToolLCIO::ClusterVecMerge( std::vector<edm4hep:
 	edm4hep::Cluster Mergebranch_A;
 	edm4hep::Cluster Mergebranch_B;
 	edm4hep::Cluster tmpMergebranch;
+#if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
 	edm4hep::Cluster Mainbranch (0);
+#else
+	auto Mainbranch = edm4hep::Cluster::makeEmpty();
+#endif
+
 
 	TVector3 tmpClusterSeedPos, MBSeedPos;	
 

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
@@ -19,6 +19,9 @@
 #include "k4FWCore/DataHandle.h"
 #include "GaudiAlg/GaudiAlgorithm.h"
 #include "GearSvc/IGearSvc.h"
+
+#include "podio/podioVersion.h"
+
 using namespace MarlinTrk ;
 
 namespace lcio{
@@ -287,8 +290,12 @@ namespace clupatra_new{
 		UTIL::BitField64 encoder( UTIL::ILDCellID0::encoder_string ) ;
 		encoder[UTIL::ILDCellID0::subdet] = UTIL::ILDDetID::TPC ;
 
+#if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
 		edm4hep::TrackerHit firstHit = 0;
-		// = 0 equal to unlink() 
+#else
+		auto firstHit = edm4hep::TrackerHit::makeEmpty();
+#endif
+		// = 0 equal to unlink()
                 //firstHit.unlink();
 
 		IMarlinTrack* bwTrk = 0 ;
@@ -1410,7 +1417,11 @@ start:
 #if use_fit_at_last_hit
 				code = mtrk->getTrackState( lHit, tsLH, chi2, ndf ) ;
 #else     // get the track state at the last hit by propagating from the last(first) constrained fit position (a la MarlinTrkUtils)
+#if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
 				edm4hep::TrackerHit last_constrained_hit(0);
+#else
+				auto last_constrained_hit = edm4hep::TrackerHit::makeEmpty();
+#endif
 				code = mtrk->getTrackerHitAtPositiveNDF( last_constrained_hit );
 				//code = mtrk->smooth() ;
 				if( code != MarlinTrk::IMarlinTrack::success ){

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.h
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.h
@@ -30,6 +30,8 @@
 #include "TrackSystemSvc/IMarlinTrack.h"
 #include "TrackSystemSvc/IMarlinTrkSystem.h"
 
+#include "podio/podioVersion.h"
+
 // ----- include for verbosity dependend logging ---------
 // #include "marlin/VerbosityLevels.h"
 
@@ -57,7 +59,11 @@ namespace clupatra_new{
 		ClupaHit() :layer(-1),
 		zIndex(-1),
 		phiIndex(-1),
+#if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
 		edm4hepHit(0),
+#else
+		edm4hepHit(edm4hep::TrackerHit::makeEmpty()),
+#endif
 		pos(0.,0.,0.) {}
 		int layer ;
 		int zIndex ;

--- a/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
+++ b/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
@@ -26,6 +26,8 @@
 #include "gear/GEAR.h"
 #include "gear/BField.h"
 
+#include "podio/podioVersion.h"
+
 //#include "streamlog/streamlog.h"
 
 
@@ -76,8 +78,12 @@ namespace MarlinTrk {
   
   
   MarlinKalTestTrack::MarlinKalTestTrack(MarlinKalTest* ktest) 
-    : _ktest(ktest), _trackHitAtPositiveNDF(edm4hep::TrackerHit(0)) {
-    
+    : _ktest(ktest),
+#if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
+      _trackHitAtPositiveNDF(edm4hep::TrackerHit(0)) {
+#else
+      _trackHitAtPositiveNDF(edm4hep::TrackerHit::makeEmpty()) {
+#endif
     _kaltrack = new TKalTrack() ;
     _kaltrack->SetOwner() ;
     

--- a/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
+++ b/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
@@ -33,6 +33,8 @@
 
 #include "TMatrixD.h"
 
+#include "podio/podioVersion.h"
+
 #define MIN_NDF 6
 
 namespace MarlinTrk {
@@ -492,9 +494,14 @@ namespace MarlinTrk {
     ///////////////////////////////////////////////////////
     
     edm4hep::TrackState* trkStateAtLastHit = new edm4hep::TrackState() ;
+
     edm4hep::TrackerHit lastHit = hits_in_fit.front().first;
           
+#if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
     edm4hep::TrackerHit last_constrained_hit(0);// = 0 ;
+#else
+		auto last_constrained_hit = edm4hep::TrackerHit::makeEmpty();
+#endif
     marlintrk->getTrackerHitAtPositiveNDF(last_constrained_hit);
 
     return_error = marlintrk->smooth(lastHit);

--- a/Utilities/DataHelper/src/TrackExtended.cc
+++ b/Utilities/DataHelper/src/TrackExtended.cc
@@ -1,11 +1,18 @@
 #include "DataHelper/ClusterExtended.h"
 #include "DataHelper/TrackerHitExtended.h"
 #include "DataHelper/TrackExtended.h"
+
+#include "podio/podioVersion.h"
+
 #include <math.h>
 #include <iostream>
 
 TrackExtended::TrackExtended( ) {
+#if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
     _track = NULL;
+#else
+    _track = edm4hep::Track::makeEmpty();
+#endif
     _superCluster = NULL;
     _trackerHitVector.clear();
     _clusterVec.clear();
@@ -24,7 +31,11 @@ TrackExtended::TrackExtended(Track track) {
 TrackExtended::TrackExtended( TrackerHitExtended * trackerhit) {
     _trackerHitVector.clear();
     _trackerHitVector.push_back(trackerhit);
+#if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
     _track = NULL;
+#else
+    _track = edm4hep::Track::makeEmpty();
+#endif
     _superCluster = NULL;
     _clusterVec.clear();
     _group = NULL;

--- a/Utilities/DataHelper/src/TrackExtended.cc
+++ b/Utilities/DataHelper/src/TrackExtended.cc
@@ -2,6 +2,7 @@
 #include "DataHelper/TrackerHitExtended.h"
 #include "DataHelper/TrackExtended.h"
 #include <math.h>
+#include <iostream>
 
 TrackExtended::TrackExtended( ) {
     _track = NULL;


### PR DESCRIPTION
The public object constructor from an `Obj*` is removed with AIDASoft/podio#514 and instead replaced with the `makeEmpty` factory method that has the same result. This PR introduces the necessary changes in a backwards compatible manner, so that things should keep working after the podio PR has been merged. 

If a sort of "clean cut" is desired I can also remove the pre-processor checks and instead bump the required podio version in the CMake configuration to keep things working. In that case we would have to wait until AIDASoft/podio#514 is merged and there is a new podio tag after that.