### PR TITLE
Remove explicit mentionings of MCParticle momentum type

### DIFF
--- a/Analysis/DumpEvent/src/DumpMCParticleAlg.cpp
+++ b/Analysis/DumpEvent/src/DumpMCParticleAlg.cpp
@@ -93,11 +93,11 @@ StatusCode DumpMCParticleAlg::execute(){
       m_charge[m_nParticles] = particle.getCharge();
       m_time[m_nParticles] = particle.getTime();
       m_mass[m_nParticles] = particle.getMass();
-      const edm4hep::Vector3d& vertex = particle.getVertex();
+      const auto& vertex = particle.getVertex();
       m_vx[m_nParticles] = vertex.x;
       m_vy[m_nParticles] = vertex.y;
       m_vz[m_nParticles] = vertex.z;
-      const edm4hep::Vector3f& momentum = particle.getMomentum();
+      const auto& momentum = particle.getMomentum();
       m_px[m_nParticles] = momentum.x;
       m_py[m_nParticles] = momentum.y;
       m_pz[m_nParticles] = momentum.z;

--- a/Digitisers/SimpleDigi/src/TPCDigiAlg.cpp
+++ b/Digitisers/SimpleDigi/src/TPCDigiAlg.cpp
@@ -590,7 +590,7 @@ StatusCode TPCDigiAlg::execute()
       if(mcp.isAvailable()){
 
         // get the pt of the MCParticle, this will used later to uses nominal smearing for low momentum rubish
-        const edm4hep::Vector3f momentumMC= mcp.getMomentum() ;
+        const auto& momentumMC= mcp.getMomentum() ;
         ptSqrdMC = momentumMC[0]*momentumMC[0]+momentumMC[1]*momentumMC[1] ;
         
         debug() << " mcp id = " << mcp.id() 
@@ -1057,7 +1057,7 @@ StatusCode TPCDigiAlg::execute()
         auto mcp = (_tpcHitMap[ seed_hit ]).getMCParticle() ;
         if(mcp.isAvailable()) {
           ++_NLostPhysicsTPCHits;
-          const edm4hep::Vector3f mom= mcp.getMomentum() ;
+          const auto& mom= mcp.getMomentum() ;
           double ptSQRD = mom[0]*mom[0]+mom[1]*mom[1] ;
           if( ptSQRD > (0.2*0.2) ) ++_NLostPhysicsAbove02GeVPtTPCHits ;
           if( ptSQRD > 1.0 )  ++_NLostPhysicsAbove1GeVPtTPCHits ;

--- a/Reconstruction/RecGenfitAlg/src/GenfitTrack.cpp
+++ b/Reconstruction/RecGenfitAlg/src/GenfitTrack.cpp
@@ -40,6 +40,7 @@
 
 //cpp
 #include <cfloat>
+#include <type_traits>
 
 const int GenfitTrack::s_PDG[2][5]
 ={{-11,-13,211,321,2212},{11,13,-211,-321,-2212}};
@@ -123,8 +124,8 @@ bool GenfitTrack::createGenfitTrackFromMCParticle(int pidType,
         const edm4hep::MCParticle& mcParticle, double eventStartTime)
 {
     ///get track parameters from McParticle
-    edm4hep::Vector3d mcPocaPos = mcParticle.getVertex();//mm
-    edm4hep::Vector3f mcPocaMom = mcParticle.getMomentum();//GeV
+    const auto& mcPocaPos = mcParticle.getVertex();//mm
+    const auto& mcPocaMom = mcParticle.getMomentum();//GeV
     if(m_debug>=2)std::cout<<"seedPos poca "<< mcPocaPos.x
         <<" "<<mcPocaPos.y<<" "<<mcPocaPos.z<<" mm "<<std::endl;
     if(m_debug>=2)std::cout<<"seedMom poca "<< mcPocaMom.x
@@ -132,7 +133,8 @@ bool GenfitTrack::createGenfitTrackFromMCParticle(int pidType,
 
     ///Pivot to first layer to avoid correction of beam pipe
     edm4hep::Vector3d firstLayerPos(1e9,1e9,1e9);
-    edm4hep::Vector3f firstLayerMom(1e9,1e9,1e9);
+    using MomentumT = std::remove_cv_t<std::remove_reference_t<decltype(mcPocaMom)>>;
+    MomentumT firstLayerMom{1e9,1e9,1e9};
     pivotToFirstLayer(mcPocaPos,mcPocaMom,firstLayerPos,firstLayerMom);
 
     //TODO convert unit
@@ -827,13 +829,3 @@ bool GenfitTrack::storeTrack(edm4hep::MutableReconstructedParticle& recParticle,
 
     return true;
 }
-
-void GenfitTrack::pivotToFirstLayer(edm4hep::Vector3d& pos,
-        edm4hep::Vector3f& mom, edm4hep::Vector3d& firstPos,
-        edm4hep::Vector3f& firstMom)
-{
-    //FIXME, TODO
-    firstPos=pos;
-    firstMom=mom;
-}
-

--- a/Reconstruction/RecGenfitAlg/src/GenfitTrack.h
+++ b/Reconstruction/RecGenfitAlg/src/GenfitTrack.h
@@ -124,8 +124,13 @@ class GenfitTrack {
             int ndfCut=1e9, double chi2Cut=1.e9);
 
     ///A tool to convert track to the first layer of DC
-    void pivotToFirstLayer(edm4hep::Vector3d& pos,edm4hep::Vector3f& mom,
-            edm4hep::Vector3d& firstPos, edm4hep::Vector3f& firstMom);
+    template<typename MomT>
+    void pivotToFirstLayer(const edm4hep::Vector3d& pos, const MomT& mom,
+                           edm4hep::Vector3d& firstPos, MomT& firstMom) {
+        //FIXME, TODO
+        firstPos=pos;
+        firstMom=mom;
+    }
 
     /// Copy a track to event
     //void CopyATrack()const;

--- a/Reconstruction/RecGenfitAlg/src/RecGenfitAlgDC.cpp
+++ b/Reconstruction/RecGenfitAlg/src/RecGenfitAlgDC.cpp
@@ -397,7 +397,7 @@ void RecGenfitAlgDC::debugEvent()
     m_mcIndex=iHit;
     int iMcParticle=0;
     for(auto mcParticle : *mcParticleCol){
-        edm4hep::Vector3f mcPocaMom = mcParticle.getMomentum();//GeV
+        const auto& mcPocaMom = mcParticle.getMomentum();//GeV
         float px=mcPocaMom.x;
         float py=mcPocaMom.y;
         float pz=mcPocaMom.z;

--- a/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.cpp
+++ b/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.cpp
@@ -169,7 +169,7 @@ StatusCode TruthTrackerAlg::execute()
         mcParticleVertexSmeared.z=
             CLHEP::RandGauss::shoot(mcParticleVertex.z,m_resVertexZ);
         ///Momentum
-        edm4hep::Vector3f mcParticleMom=mcParticle.getMomentum();//GeV
+        const auto& mcParticleMom=mcParticle.getMomentum();//GeV
         double mcParticlePt=sqrt(mcParticleMom.x*mcParticleMom.x+
                 mcParticleMom.y*mcParticleMom.y);
         //double mcParticlePtSmeared=

--- a/Simulation/DetSimCore/src/G4PrimaryCnvTool.cpp
+++ b/Simulation/DetSimCore/src/G4PrimaryCnvTool.cpp
@@ -72,7 +72,7 @@ bool G4PrimaryCnvTool::mutate(G4Event* anEvent) {
             particle_def = particletbl->FindParticle(pdgcode);
         }
         // momentum
-        const edm4hep::Vector3f& momentum = p.getMomentum();
+        const auto& momentum = p.getMomentum();
         G4PrimaryParticle* g4prim = new G4PrimaryParticle(particle_def,
                                                           momentum.x*CLHEP::GeV,
                                                           momentum.y*CLHEP::GeV,


### PR DESCRIPTION
Remove the explicit mentionings of `edm4hep::Vector3f` for cases where an `auto` does the trick. This makes it easier to switch representations while being backwards compatible. This is necessary for key4hep/EDM4hep#237