### PR TITLE
edm4hep version control for ObjectID

### DIFF
--- a/Utilities/DataHelper/include/DataHelper/Navigation.h
+++ b/Utilities/DataHelper/include/DataHelper/Navigation.h
@@ -5,6 +5,15 @@
 #include "edm4hep/TrackerHitCollection.h"
 #include <map>
 
+#if __has_include("edm4hep/EDM4hepVersion.h")
+#include "edm4hep/EDM4hepVersion.h"
+#else
+// Copy the necessary parts from  the header above to make whatever we need to work here
+#define EDM4HEP_VERSION(major, minor, patch) ((UINT64_C(major) << 32) | (UINT64_C(minor) << 16) | (UINT64_C(patch)))
+// v00-09 is the last version without the capitalization change of the track vector members
+#define EDM4HEP_BUILD_VERSION EDM4HEP_VERSION(0, 9, 0)
+#endif
+
 class Navigation{
  public:
   static Navigation* Instance();
@@ -17,9 +26,15 @@ class Navigation{
   void AddTrackerHitCollection(const edm4hep::TrackerHitCollection* col){m_hitColVec.push_back(col);};
   void AddTrackerAssociationCollection(const edm4hep::MCRecoTrackerAssociationCollection* col){m_assColVec.push_back(col);};
 
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 2)
   edm4hep::TrackerHit GetTrackerHit(const edm4hep::ObjectID& id, bool delete_by_caller=true);
   std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::ObjectID& id);
+#else
+  edm4hep::TrackerHit GetTrackerHit(const podio::ObjectID& id, bool delete_by_caller=true);
+  std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const podio::ObjectID& id);
+#endif
   std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::TrackerHit& hit);
+  std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::TrackerHit& hit, const edm4hep::MCRecoTrackerAssociationCollection* col);
   
   //static Navigation* m_fNavigation;
  private:

--- a/Utilities/DataHelper/include/DataHelper/Navigation.h
+++ b/Utilities/DataHelper/include/DataHelper/Navigation.h
@@ -26,7 +26,7 @@ class Navigation{
   void AddTrackerHitCollection(const edm4hep::TrackerHitCollection* col){m_hitColVec.push_back(col);};
   void AddTrackerAssociationCollection(const edm4hep::MCRecoTrackerAssociationCollection* col){m_assColVec.push_back(col);};
 
-#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 2)
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 4)
   edm4hep::TrackerHit GetTrackerHit(const edm4hep::ObjectID& id, bool delete_by_caller=true);
   std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::ObjectID& id);
 #else

--- a/Utilities/DataHelper/src/Navigation.cpp
+++ b/Utilities/DataHelper/src/Navigation.cpp
@@ -25,7 +25,7 @@ void Navigation::Initialize(){
   m_trkHits.clear();
 }
 
-#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 2)
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 4)
 edm4hep::TrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_id, bool delete_by_caller){
 #else
 edm4hep::TrackerHit Navigation::GetTrackerHit(const podio::ObjectID& obj_id, bool delete_by_caller){
@@ -61,7 +61,7 @@ edm4hep::TrackerHit Navigation::GetTrackerHit(const podio::ObjectID& obj_id, boo
   throw std::runtime_error("Not found TrackerHit");
 }
 
-#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 2)
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 4)
 std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::ObjectID& id){
 #else
 std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const podio::ObjectID& id){

--- a/Utilities/DataHelper/src/Navigation.cpp
+++ b/Utilities/DataHelper/src/Navigation.cpp
@@ -25,7 +25,11 @@ void Navigation::Initialize(){
   m_trkHits.clear();
 }
 
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 2)
 edm4hep::TrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_id, bool delete_by_caller){
+#else
+edm4hep::TrackerHit Navigation::GetTrackerHit(const podio::ObjectID& obj_id, bool delete_by_caller){
+#endif
   int id = obj_id.collectionID * 10000000 + obj_id.index;
   if(!delete_by_caller){
     if(m_trkHits.find(id)!=m_trkHits.end()) return m_trkHits[id];
@@ -33,7 +37,7 @@ edm4hep::TrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_id, b
   /*
   for(int i=0;i<m_assColVec.size();i++){
     for(auto ass : *m_assColVec[i]){
-      edm4hep::ObjectID rec_id = ass.getRec().getObjectID();
+      auto rec_id = ass.getRec().getObjectID();
       if(rec_id.collectionID!=id.collectionID)break;
       else if(rec_id.index==id.index){
 	m_trkHits.push_back(ass.getRec());
@@ -44,7 +48,7 @@ edm4hep::TrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_id, b
   */
   for(int i=0;i<m_hitColVec.size();i++){
     for(auto hit : *m_hitColVec[i]){
-      edm4hep::ObjectID this_id = hit.getObjectID();
+      auto this_id = hit.getObjectID();
       if(this_id.collectionID!=obj_id.collectionID)break;
       else if(this_id.index==obj_id.index){
 	edm4hep::TrackerHit hit_copy = edm4hep::TrackerHit(hit);
@@ -57,11 +61,15 @@ edm4hep::TrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_id, b
   throw std::runtime_error("Not found TrackerHit");
 }
 
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 2)
 std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::ObjectID& id){
+#else
+std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const podio::ObjectID& id){
+#endif
   std::vector<edm4hep::SimTrackerHit> hits;
   for(int i=0;i<m_assColVec.size();i++){
     for(auto ass : *m_assColVec[i]){
-      edm4hep::ObjectID this_id = ass.getRec().getObjectID();
+      auto this_id = ass.getRec().getObjectID();
       if(this_id.collectionID!=id.collectionID)break;
       else if(this_id.index==id.index) hits.push_back(ass.getSim()); 
     }
@@ -76,6 +84,15 @@ std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4h
       if(ass.getRec().getObjectID().collectionID != hit.getObjectID().collectionID) break;
       else if(ass.getRec()==hit) hits.push_back(ass.getSim());
     }
+  }
+  return hits;
+}
+
+std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::TrackerHit& hit, const edm4hep::MCRecoTrackerAssociationCollection* col){
+  std::vector<edm4hep::SimTrackerHit> hits;
+  for(auto ass : *col){
+    if(ass.getRec().getObjectID().collectionID != hit.getObjectID().collectionID) break;
+    else if(ass.getRec()==hit) hits.push_back(ass.getSim());
   }
   return hits;
 }


### PR DESCRIPTION
EDM4hep plan to switch edm4hep::ObjectID to podio::ObjectID as https://github.com/key4hep/EDM4hep/pull/260
Switch in code according to EDM4HEP_VERSION.
EDM4HEP_VERSION(0, 10, 2) maybe is not the last version has edm4hep::ObjectID, if not, and then it should be updated also.