### PR TITLE
Handling the CI related to KEYHEP_STACK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,12 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        # LCG_RELEASE: [LCG_EXTERNAL, KEY4HEP_STACK]
-        LCG_RELEASE: [LCG_EXTERNAL]
-        # CEPCSW_BLDTOOL: [make, ninja]
-        CEPCSW_BLDTOOL: [ninja]
+        LCG_RELEASE: 
+          - LCG_EXTERNAL
+          - KEY4HEP_STACK
+        CEPCSW_BLDTOOL:
+          - ninja
+        # - make
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,8 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        LCG_RELEASE: [LCG_EXTERNAL, KEY4HEP_STACK]
+        # LCG_RELEASE: [LCG_EXTERNAL, KEY4HEP_STACK]
+        LCG_RELEASE: [LCG_EXTERNAL]
         # CEPCSW_BLDTOOL: [make, ninja]
         CEPCSW_BLDTOOL: [ninja]
 

--- a/build-k4.sh
+++ b/build-k4.sh
@@ -20,8 +20,12 @@ function error:() {
 }
 
 function check-cepcsw-envvar() {
-    # source /cvmfs/sw.hsf.org/key4hep/setup.sh
-    source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
+    if [ "${k4_version}" = "nightlies" ]; then
+        source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
+    else
+        source /cvmfs/sw.hsf.org/key4hep/setup.sh -r ${k4_version}
+    fi
+
     # fix the order of compiler
     local ccdir=$(dirname $CC)
     export PATH=$ccdir:$PATH
@@ -113,8 +117,8 @@ function run-install() {
 ##############################################################################
 
 # The current default platform
-k4_platform=x86_64-linux-gcc11-opt
-k4_version=master
+k4_platform=${K4_PLATFORM:-x86_64-linux-gcc11-opt}
+k4_version=${K4_VERSION:-2024-03-10} # or nightlies
 bldtool=${CEPCSW_BLDTOOL} # make, ninja # set in env var
 
 check-cepcsw-envvar || exit -1


### PR DESCRIPTION
Due to the API change in EDM4hep, the CEPCSW is not built with the latest Key4hep stack. Some dependencies are not built. 