### PR TITLE
[WIP] Fix compilation with EDM4hep

### DIFF
--- a/Analysis/TrackInspect/src/TrackInspectAlg.cpp
+++ b/Analysis/TrackInspect/src/TrackInspectAlg.cpp
@@ -136,7 +136,7 @@ StatusCode TrackInspectAlg::execute(){
     for (auto relCol: relCols) {
     	if (relCol){
 	    for (auto rel: *relCol){
-		    std::pair<edm4hep::TrackerHit, edm4hep::MCParticle> p = std::make_pair(rel.getRec(), rel.getSim().getMCParticle());
+		    std::pair<edm4hep::TrackerHit3D, edm4hep::MCParticle> p = std::make_pair(rel.getRec(), rel.getSim().getMCParticle());
 		    if (hitmap.find(p) == hitmap.end()) hitmap[p] = 0.;
 		    hitmap[p] += rel.getWeight();
 	    }
@@ -212,9 +212,9 @@ double TrackInspectAlg::match(edm4hep::MCParticle particle, edm4hep::Track track
     double matchedHits = 0;
     double usedHits = 0;
     for (int i = 0; i < NHits; i++) {
-        edm4hep::TrackerHit hit = track.getTrackerHits(i);
+        edm4hep::TrackerHit3D hit = track.getTrackerHits(i);
         usedHits++;
-        std::pair<edm4hep::TrackerHit, edm4hep::MCParticle> ele = std::make_pair(hit, particle);
+        std::pair<edm4hep::TrackerHit3D, edm4hep::MCParticle> ele = std::make_pair(hit, particle);
         //std::cout << "lookup --> " << ele.first << std::endl;
         //if (hitmap.find(ele) != hitmap.end() ) {
         //std::cout << "find --> " << hitmap[ele] << std::endl;

--- a/Analysis/TrackInspect/src/TrackInspectAlg.h
+++ b/Analysis/TrackInspect/src/TrackInspectAlg.h
@@ -5,11 +5,25 @@
 #include "GaudiKernel/Algorithm.h"
 
 #include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "edm4hep/MCParticle.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 
 #include "GaudiKernel/NTuple.h"
@@ -42,7 +56,7 @@ class TrackInspectAlg : public Algorithm {
         Gaudi::Property<bool> _useSET{this, "useSET", true};
         Gaudi::Property<bool> _useFTD{this, "useFTD", true};
 
-        std::map<std::pair<edm4hep::TrackerHit, edm4hep::MCParticle>, double> hitmap;
+        std::map<std::pair<edm4hep::TrackerHit3D, edm4hep::MCParticle>, double> hitmap;
         std::vector<std::tuple<edm4hep::MCParticle, edm4hep::Track, double>> matchvec;
         double match(edm4hep::MCParticle, edm4hep::Track);
 

--- a/Digitisers/DCHDigi/src/DCHDigiAlg.cpp
+++ b/Digitisers/DCHDigi/src/DCHDigiAlg.cpp
@@ -107,7 +107,7 @@ StatusCode DCHDigiAlg::execute()
 
   info() << "Processing " << _nEvt << " events " << endmsg;
   if(m_WriteAna) m_evt = _nEvt;
-  edm4hep::TrackerHitCollection* Vec   = w_DigiDCHCol.createAndPut();
+  edm4hep::TrackerHit3DCollection* Vec   = w_DigiDCHCol.createAndPut();
   edm4hep::MCRecoTrackerAssociationCollection* AssoVec   = w_AssociationCol.createAndPut();
   const edm4hep::SimTrackerHitCollection* SimHitCol =  r_SimDCHCol.get();
   if (SimHitCol->size() == 0) {

--- a/Digitisers/DCHDigi/src/DCHDigiAlg.h
+++ b/Digitisers/DCHDigi/src/DCHDigiAlg.h
@@ -5,7 +5,14 @@
 #include "GaudiKernel/NTuple.h"
 #include "GaudiAlg/GaudiAlgorithm.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 #include "edm4hep/MCParticle.h"
 
@@ -102,7 +109,7 @@ protected:
   // Input collections
   DataHandle<edm4hep::SimTrackerHitCollection> r_SimDCHCol{"DriftChamberHitsCollection", Gaudi::DataHandle::Reader, this};
   // Output collections
-  DataHandle<edm4hep::TrackerHitCollection>    w_DigiDCHCol{"DigiDCHitCollection", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::TrackerHit3DCollection>    w_DigiDCHCol{"DigiDCHitCollection", Gaudi::DataHandle::Writer, this};
   DataHandle<edm4hep::MCRecoTrackerAssociationCollection>    w_AssociationCol{"DCHitAssociationCollection", Gaudi::DataHandle::Writer, this};
 };
 

--- a/Digitisers/SimpleDigi/src/CylinderDigiAlg.h
+++ b/Digitisers/SimpleDigi/src/CylinderDigiAlg.h
@@ -5,7 +5,14 @@
 #include "GaudiKernel/NTuple.h"
 #include "GaudiAlg/GaudiAlgorithm.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 
 #include <DDRec/DetectorData.h>
@@ -28,7 +35,7 @@ protected:
   // Input collections
   DataHandle<edm4hep::SimTrackerHitCollection>            m_inputColHdls{"DriftChamberHitsCollection", Gaudi::DataHandle::Reader, this};
   // Output collections
-  DataHandle<edm4hep::TrackerHitCollection>               m_outputColHdls{"DCTrackerHits", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::TrackerHit3DCollection>               m_outputColHdls{"DCTrackerHits", Gaudi::DataHandle::Writer, this};
   DataHandle<edm4hep::MCRecoTrackerAssociationCollection> m_assColHdls{"DCTrackerHitAssociationCollection", Gaudi::DataHandle::Writer, this};
 
   Gaudi::Property<float> m_resRPhi{this, "ResRPhi", 0.1};

--- a/Digitisers/SimpleDigi/src/PlanarDigiAlg.h
+++ b/Digitisers/SimpleDigi/src/PlanarDigiAlg.h
@@ -6,7 +6,14 @@
 #include <gsl/gsl_rng.h>
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 
 /** ======= PlanarDigiProcessor / PlanarDigiAlg ========== <br>
@@ -92,7 +99,7 @@ protected:
   DataHandle<edm4hep::EventHeaderCollection> _headerCol{"EventHeaderCol", Gaudi::DataHandle::Reader, this};
   DataHandle<edm4hep::SimTrackerHitCollection> _inColHdl{"VXDCollection", Gaudi::DataHandle::Reader, this};
   // Output collections
-  DataHandle<edm4hep::TrackerHitCollection> _outColHdl{"VXDTrackerHits", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _outColHdl{"VXDTrackerHits", Gaudi::DataHandle::Writer, this};
   DataHandle<edm4hep::MCRecoTrackerAssociationCollection> _outRelColHdl{"VXDTrackerHitRelations", Gaudi::DataHandle::Writer, this};
 };
 

--- a/Digitisers/SimpleDigi/src/TPCDigiAlg.h
+++ b/Digitisers/SimpleDigi/src/TPCDigiAlg.h
@@ -23,7 +23,14 @@ Steve Aplin 26 June 2009 (DESY)
 #include "k4FWCore/DataHandle.h"
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 
@@ -164,9 +171,9 @@ protected:
 
   /** Output collection name.
    */
-  DataHandle<edm4hep::TrackerHitCollection> _TPCTrackerHitsColHdl{"TPCTrackerHits", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _TPCTrackerHitsColHdl{"TPCTrackerHits", Gaudi::DataHandle::Writer, this};
   DataHandle<edm4hep::MCRecoTrackerAssociationCollection> _TPCAssColHdl{"TPCTrackerHitAss", Gaudi::DataHandle::Writer, this};
-  edm4hep::TrackerHitCollection* _trkhitVec;
+  edm4hep::TrackerHit3DCollection* _trkhitVec;
   edm4hep::MCRecoTrackerAssociationCollection* _relCol;
 
   bool _use_raw_hits_to_store_simhit_pointer;

--- a/Reconstruction/DCHDedx/src/RecDCHDedxAlg.cpp
+++ b/Reconstruction/DCHDedx/src/RecDCHDedxAlg.cpp
@@ -2,7 +2,14 @@
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 #include "edm4hep/MCRecoParticleAssociationCollection.h"

--- a/Reconstruction/PFA/Arbor/src/ArborToolLCIO.hh
+++ b/Reconstruction/PFA/Arbor/src/ArborToolLCIO.hh
@@ -8,7 +8,14 @@
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/VertexCollection.h"
 #include "edm4hep/TrackCollection.h"

--- a/Reconstruction/PFA/Pandora/GaudiPandora/include/PandoraPFAlg.h
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/include/PandoraPFAlg.h
@@ -7,7 +7,14 @@
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/VertexCollection.h"
 #include "edm4hep/TrackCollection.h"

--- a/Reconstruction/PFA/Pandora/GaudiPandora/src/TrackCreator.cpp
+++ b/Reconstruction/PFA/Pandora/GaudiPandora/src/TrackCreator.cpp
@@ -786,7 +786,7 @@ void TrackCreator::TrackReachesECAL(const edm4hep::Track *const pTrack, PandoraA
     for (unsigned int i = 0; i < nTrackHits; ++i)
     {
         
-        const edm4hep::TrackerHit Hit ( pTrack->getTrackerHits(i) );
+        const edm4hep::TrackerHit3D Hit ( pTrack->getTrackerHits(i) );
         const edm4hep::Vector3d pos = Hit.getPosition();
         
         float x = float(pos[0]);

--- a/Reconstruction/PFA/Pandora/MatrixPandora/include/PandoraMatrixAlg.h
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/include/PandoraMatrixAlg.h
@@ -8,7 +8,14 @@
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/VertexCollection.h"
 #include "edm4hep/TrackCollection.h"

--- a/Reconstruction/PFA/Pandora/MatrixPandora/src/TrackCreator.cpp
+++ b/Reconstruction/PFA/Pandora/MatrixPandora/src/TrackCreator.cpp
@@ -647,7 +647,7 @@ void TrackCreator::TrackReachesECAL(edm4hep::Track *const pTrack, PandoraApi::Tr
     for (unsigned int i = 0; i < nTrackHits; ++i)
     {
         
-        const edm4hep::TrackerHit Hit ( pTrack->getTrackerHits(i) );
+        const edm4hep::TrackerHit3D Hit ( pTrack->getTrackerHits(i) );
         const edm4hep::Vector3d pos = Hit.getPosition();
         
         float x = float(pos[0]);

--- a/Reconstruction/RecAssociationMaker/src/TrackParticleRelationAlg.cpp
+++ b/Reconstruction/RecAssociationMaker/src/TrackParticleRelationAlg.cpp
@@ -55,7 +55,7 @@ StatusCode TrackParticleRelationAlg::execute() {
   }
 
   // Prepare map from hit to MCParticle
-  std::map<edm4hep::TrackerHit, edm4hep::MCParticle> mapHitParticle;
+  std::map<edm4hep::TrackerHit3D, edm4hep::MCParticle> mapHitParticle;
   debug() << "reading Association" << endmsg;
   for (auto hdl : m_inAssociationColHdls) {
     const edm4hep::MCRecoTrackerAssociationCollection* assCol = nullptr;
@@ -92,7 +92,7 @@ StatusCode TrackParticleRelationAlg::execute() {
     }
     
     if(trkCol) {
-      std::map<edm4hep::MCParticle, std::vector<edm4hep::TrackerHit> > mapParticleHits;
+      std::map<edm4hep::MCParticle, std::vector<edm4hep::TrackerHit3D> > mapParticleHits;
 
       for (auto track: *trkCol) {
 	std::map<edm4hep::MCParticle, int> mapParticleNHits;
@@ -128,7 +128,7 @@ StatusCode TrackParticleRelationAlg::execute() {
       }
       
       if (msgLevel(MSG::DEBUG)) {
-	for (std::map<edm4hep::MCParticle, std::vector<edm4hep::TrackerHit> >::iterator it=mapParticleHits.begin(); it!=mapParticleHits.end(); it++) {
+	for (std::map<edm4hep::MCParticle, std::vector<edm4hep::TrackerHit3D> >::iterator it=mapParticleHits.begin(); it!=mapParticleHits.end(); it++) {
 	  auto particle = it->first;
 	  auto hits     = it->second;
 	  debug() << "=== MCPaticle ===" << particle << endmsg;

--- a/Reconstruction/RecGenfitAlg/src/GenfitHit.cpp
+++ b/Reconstruction/RecGenfitAlg/src/GenfitHit.cpp
@@ -7,13 +7,20 @@
 #include "DD4hep/DetElement.h"
 #include "DD4hep/Segmentations.h"
 #include "DD4hep/DD4hepUnits.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "edm4hep/SimTrackerHit.h"
 #include "TRandom.h"
 
 #include <iostream>
 
-GenfitHit::GenfitHit(const edm4hep::TrackerHit* trackerHit,
+GenfitHit::GenfitHit(const edm4hep::TrackerHit3D* trackerHit,
         const edm4hep::SimTrackerHit* simTrackerHit,
         const dd4hep::DDSegmentation::BitFieldCoder* decoder,
         const dd4hep::DDSegmentation::GridDriftChamber* gridDriftChamber,

--- a/Reconstruction/RecGenfitAlg/src/GenfitHit.h
+++ b/Reconstruction/RecGenfitAlg/src/GenfitHit.h
@@ -25,7 +25,7 @@ namespace dd4hep {
 
 class GenfitHit{
     public:
-        GenfitHit(const edm4hep::TrackerHit* trackerHit,
+        GenfitHit(const edm4hep::TrackerHit3D* trackerHit,
                 const edm4hep::SimTrackerHit* simTrackerHit,
                 const dd4hep::DDSegmentation::BitFieldCoder* decoder,
                 const dd4hep::DDSegmentation::GridDriftChamber* gridDriftChamber,
@@ -38,7 +38,7 @@ class GenfitHit{
         double getDriftDistanceErr()const{return m_driftDistanceErr;}
         double getDriftDistanceTruth()const{return m_driftDistanceTruth;}
         const edm4hep::SimTrackerHit* getSimTrackerHit()const{return m_simTrackerHit;}
-        const edm4hep::TrackerHit* getTrackerHit()const{return m_trackerHit;}
+        const edm4hep::TrackerHit3D* getTrackerHit()const{return m_trackerHit;}
         TVector3 getEnd0()const;
         TVector3 getEnd1()const;
         TVector3 getTruthPos()const;
@@ -54,7 +54,7 @@ class GenfitHit{
     private:
         const dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
         const dd4hep::DDSegmentation::GridDriftChamber* m_gridDriftChamber;
-        const edm4hep::TrackerHit* m_trackerHit;
+        const edm4hep::TrackerHit3D* m_trackerHit;
         const edm4hep::SimTrackerHit* m_simTrackerHit;
         double m_driftDistance;
         double m_driftDistanceErr;

--- a/Reconstruction/RecGenfitAlg/src/GenfitTrack.h
+++ b/Reconstruction/RecGenfitAlg/src/GenfitTrack.h
@@ -108,22 +108,22 @@ class GenfitTrack {
             int sortMethod,bool truthAmbig,float skipCorner, float skipNear);
 
     ///Add WireMeasurements of hits on track from hit selection
-    virtual int addWireMeasurementsFromList(std::vector<edm4hep::TrackerHit*>& hits,float sigma,
+    virtual int addWireMeasurementsFromList(std::vector<edm4hep::TrackerHit3D*>& hits,float sigma,
             const edm4hep::MCRecoTrackerAssociationCollection* assoHits,
             int sortMethod,bool truthAmbig,float skipCorner, float skipNear);
 
-    virtual int addWireMeasurementsFromListTrF(const edm4hep::TrackerHitCollection* trkHits,
+    virtual int addWireMeasurementsFromListTrF(const edm4hep::TrackerHit3DCollection* trkHits,
             float sigma,int sortMethod);
 
     ///Add one silicon hits
-    bool addSiliconMeasurement(edm4hep::TrackerHit* hit,
+    bool addSiliconMeasurement(edm4hep::TrackerHit3D* hit,
             float sigmaU,float sigmaV,int cellID,int hitID);
 
     ///Add silicon measurements, return number of hits on track
     int addSiliconMeasurements(edm4hep::Track& track,
             std::vector<float> sigmaU,std::vector<float> sigmaV);
 
-    bool debugDistance(const edm4hep::TrackerHitCollection* dCDigiCol,
+    bool debugDistance(const edm4hep::TrackerHit3DCollection* dCDigiCol,
             int& nFittedDC,int& nFittedSDT,int& ngenfitHit,
             std::vector<double>& smearDistance,
             std::vector<double>& truthDistance,double driftVelocity);
@@ -243,11 +243,11 @@ class GenfitTrack {
     genfit::AbsTrackRep* getRep(int id=0) const;
     bool getMOP(int hitID, genfit::MeasuredStateOnPlane& mop,
             genfit::AbsTrackRep* trackRep=nullptr) const;
-    const dd4hep::rec::ISurface* getISurface(edm4hep::TrackerHit* hit);
+    const dd4hep::rec::ISurface* getISurface(edm4hep::TrackerHit3D* hit);
     void getSeedCov(TMatrixDSym& cov);
     void getAssoSimTrackerHit(
             const edm4hep::MCRecoTrackerAssociationCollection*& assoHits,
-            edm4hep::TrackerHit* trackerHit,
+            edm4hep::TrackerHit3D* trackerHit,
             edm4hep::SimTrackerHit& simTrackerHit) const;
     void getEndPointsOfWire(int cellID,TVector3& end0,TVector3& end1)const;
     void getTrackFromEDMTrack(const edm4hep::Track& edm4HepTrack,
@@ -259,19 +259,19 @@ class GenfitTrack {
     void clearGenfitHitVec();
     void getISurfaceOUV(const dd4hep::rec::ISurface* iSurface,TVector3& o,
             TVector3& u,TVector3& v,double& lengthU,double& lengthV);
-    void getMeasurementAndCov(edm4hep::TrackerHit* hit,TVector3& pos,TMatrixDSym& cov);
+    void getMeasurementAndCov(edm4hep::TrackerHit3D* hit,TVector3& pos,TMatrixDSym& cov);
     int getSigmas(int cellID,std::vector<float> sigmaUVec,
         std::vector<float> sigmaVVec,float& sigmaU,float& sigmaV)const;
-    bool isCDCHit(edm4hep::TrackerHit* hit);
-    GenfitHit* makeAGenfitHit(edm4hep::TrackerHit* trackerHit,
+    bool isCDCHit(edm4hep::TrackerHit3D* hit);
+    GenfitHit* makeAGenfitHit(edm4hep::TrackerHit3D* trackerHit,
             edm4hep::SimTrackerHit* simTrackerHitAsso,
             double sigma,bool truthAmbig,double skipCorner,double skipNear);
-    void getSortedTrackerHits(std::vector<edm4hep::TrackerHit*>& hits,
+    void getSortedTrackerHits(std::vector<edm4hep::TrackerHit3D*>& hits,
             const edm4hep::MCRecoTrackerAssociationCollection* assoHits,
-            std::vector<edm4hep::TrackerHit*>& sortedDCTrackerHits,
+            std::vector<edm4hep::TrackerHit3D*>& sortedDCTrackerHits,
             int sortMethod);
-    void getSortedTrackerHitsTrF(std::vector<edm4hep::TrackerHit*> trackerHits,
-            std::vector<edm4hep::TrackerHit*>& sortedDCTrackerHits,
+    void getSortedTrackerHitsTrF(std::vector<edm4hep::TrackerHit3D*> trackerHits,
+            std::vector<edm4hep::TrackerHit3D*>& sortedDCTrackerHits,
             int sortMethod=1);
 
     genfit::Track* m_track;/// track

--- a/Reconstruction/RecGenfitAlg/src/PlanarMeasurementSDT.h
+++ b/Reconstruction/RecGenfitAlg/src/PlanarMeasurementSDT.h
@@ -73,15 +73,15 @@ class PlanarMeasurementSDT : public AbsMeasurement {
    */
   void setStripV(bool v = true) {stripV_ = v;}
 
-  void setTrackerHit(const edm4hep::TrackerHit* hit){trackerHit_=hit;}
-  const edm4hep::TrackerHit* getTrackerHit(){return trackerHit_;}
+  void setTrackerHit(const edm4hep::TrackerHit3D* hit){trackerHit_=hit;}
+  const edm4hep::TrackerHit3D* getTrackerHit(){return trackerHit_;}
 
  protected:
   SharedPlanePtr physicalPlane_;   //! This is persistent, but '!' makes ROOT shut up.
   int planeId_; // planeId id is -1 per default
   bool stripV_;
   const edm4hep::SimTrackerHit* simTrackerHit_;
-  const edm4hep::TrackerHit* trackerHit_;
+  const edm4hep::TrackerHit3D* trackerHit_;
 
  public:
 

--- a/Reconstruction/RecGenfitAlg/src/RecGenfitAlgDC.cpp
+++ b/Reconstruction/RecGenfitAlg/src/RecGenfitAlgDC.cpp
@@ -16,7 +16,14 @@
 #include "edm4hep/MCParticle.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 #include "edm4hep/ReconstructedParticle.h"
@@ -213,7 +220,7 @@ StatusCode RecGenfitAlgDC::execute()
         debug()<<"TrackCollection not found"<<endmsg;
         return StatusCode::SUCCESS;
     }
-    const edm4hep::TrackerHitCollection* didiDCHitsCol=nullptr;
+    const edm4hep::TrackerHit3DCollection* didiDCHitsCol=nullptr;
     didiDCHitsCol=m_digiDCHitsCol.get();
     if(nullptr==didiDCHitsCol) {
         debug()<<"DigiDCHitCollection not found"<<endmsg;

--- a/Reconstruction/RecGenfitAlg/src/RecGenfitAlgDC.h
+++ b/Reconstruction/RecGenfitAlg/src/RecGenfitAlgDC.h
@@ -67,7 +67,7 @@ class RecGenfitAlgDC:public GaudiAlgorithm {
         DataHandle<edm4hep::EventHeaderCollection> _headerCol{
             "EventHeaderCol", Gaudi::DataHandle::Reader, this};
         //Drift chamber rec hit and trac
-        DataHandle<edm4hep::TrackerHitCollection> m_digiDCHitsCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_digiDCHitsCol{
             "DigiDCHitCollection", Gaudi::DataHandle::Reader, this};
         DataHandle<edm4hep::TrackCollection> m_dcTrackCol{
             "DCTrackCollection", Gaudi::DataHandle::Reader, this};
@@ -81,7 +81,7 @@ class RecGenfitAlgDC:public GaudiAlgorithm {
             m_dcHitAssociationCol{"DCHitAssociationCollection",
                 Gaudi::DataHandle::Reader, this};
         //output hits and particles
-        DataHandle<edm4hep::TrackerHitCollection> m_dcFitRecHitCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_dcFitRecHitCol{
             "DCFitRecHitsCollection", Gaudi::DataHandle::Writer, this};
         DataHandle<edm4hep::ReconstructedParticleCollection> m_dcRecParticleCol{
             "DCRecParticleCollection", Gaudi::DataHandle::Writer, this};

--- a/Reconstruction/RecGenfitAlg/src/RecGenfitAlgSDT.cpp
+++ b/Reconstruction/RecGenfitAlg/src/RecGenfitAlgSDT.cpp
@@ -21,7 +21,14 @@
 #include "edm4hep/MCParticle.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 #include "edm4hep/ReconstructedParticle.h"
@@ -376,7 +383,7 @@ StatusCode RecGenfitAlgSDT::execute()
     auto assoDCHitsCol=m_DCHitAssociationCol.get();
     double eventStartTime=0;
 
-    const edm4hep::TrackerHitCollection* dCDigiCol=nullptr;
+    const edm4hep::TrackerHit3DCollection* dCDigiCol=nullptr;
     dCDigiCol=m_DCDigiCol.get();
 
     const edm4hep::TrackCollection* dcTrackCol=nullptr;
@@ -452,12 +459,12 @@ StatusCode RecGenfitAlgSDT::execute()
                         assoDCHitsCol,m_sigmaHitU,m_sigmaHitV);
             }else if(1==m_measurementTypeDC.value()){
                 if(m_selectDCHit){
-                    std::vector<edm4hep::TrackerHit*> selectedHits;
+                    std::vector<edm4hep::TrackerHit3D*> selectedHits;
                     selectHits(sdtTrack,selectedHits);
                     nHitAdded+=genfitTrack->addWireMeasurementsFromList(selectedHits,
                             m_sigmaHitU[0],assoDCHitsCol,m_sortMethod,m_truthAmbig,
                             m_skipCorner,m_skipNear);//mm
-                    std::vector<edm4hep::TrackerHit*> tmp;
+                    std::vector<edm4hep::TrackerHit3D*> tmp;
                     selectedHits.swap(tmp);
                 }else{
                     if(m_useNoiseDCHit){
@@ -716,7 +723,7 @@ void RecGenfitAlgSDT::debugEvent(const edm4hep::TrackCollection* sdtTrackCol,
         m_nSdtTrackHit = sdtTrack.trackerHits_size();
         if(sdtTrack.trackerHits_size()<1e-9) continue;
         for(int ihit=0;ihit<sdtTrack.trackerHits_size();ihit++){
-            edm4hep::TrackerHit sdtTrackHit = sdtTrack.getTrackerHits(ihit);
+            edm4hep::TrackerHit3D sdtTrackHit = sdtTrack.getTrackerHits(ihit);
         }
 
         //if(iSdtTrack>0) break;//TODO debug for some track only
@@ -822,7 +829,7 @@ void RecGenfitAlgSDT::debugEvent(const edm4hep::TrackCollection* sdtTrackCol,
     for(auto sdtRecTrack: *sdtRecTrackCol){
         for(int iHit=0;iHit<sdtRecTrack.trackerHits_size();iHit++)
         {
-            edm4hep::TrackerHit sdtRecTrackHit = sdtRecTrack.getTrackerHits(iHit);
+            edm4hep::TrackerHit3D sdtRecTrackHit = sdtRecTrack.getTrackerHits(iHit);
         }
         for(unsigned int i=0; i<sdtRecTrack.trackStates_size(); i++) {
             edm4hep::TrackState trackStat=sdtRecTrack.getTrackStates(i);
@@ -842,7 +849,7 @@ void RecGenfitAlgSDT::debugEvent(const edm4hep::TrackCollection* sdtTrackCol,
     }
 
     //debug digi
-    const edm4hep::TrackerHitCollection* dCDigiCol=nullptr;
+    const edm4hep::TrackerHit3DCollection* dCDigiCol=nullptr;
     dCDigiCol=m_DCDigiCol.get();
     if(nullptr!=dCDigiCol){ m_nDCDigi=dCDigiCol->size(); }
     int iDCDigi=0;
@@ -910,7 +917,7 @@ void RecGenfitAlgSDT::debugEvent(const edm4hep::TrackCollection* sdtTrackCol,
 }
 
 void RecGenfitAlgSDT::selectHits(const edm4hep::Track&,
-        std::vector<edm4hep::TrackerHit*>& dcDigiSelected)
+        std::vector<edm4hep::TrackerHit3D*>& dcDigiSelected)
 {
     //for single track only, FIXME
     double eventStartTime=0;
@@ -923,7 +930,7 @@ void RecGenfitAlgSDT::selectHits(const edm4hep::Track&,
     if(genfitTrack->createGenfitTrackFromMCParticle(
                 pidType,*(mcParticleCol->begin()),
                 eventStartTime)){
-        const edm4hep::TrackerHitCollection* dCDigiCol=nullptr;
+        const edm4hep::TrackerHit3DCollection* dCDigiCol=nullptr;
         dCDigiCol=m_DCDigiCol.get();
         int iDCDigi=0;
         for(auto dcDigi:*dCDigiCol){
@@ -959,7 +966,7 @@ void RecGenfitAlgSDT::selectHits(const edm4hep::Track&,
                 debug()<<"Skip hit delta doca "<<fabs(docaExt-docaMC)<<endmsg;
                 continue;
             }
-            edm4hep::TrackerHit* thisDigi = new edm4hep::TrackerHit(dcDigi);
+            edm4hep::TrackerHit3D* thisDigi = new edm4hep::TrackerHit3D(dcDigi);
             dcDigiSelected.push_back(thisDigi);
             iDCDigi++;
         }//end loop over digi

--- a/Reconstruction/RecGenfitAlg/src/RecGenfitAlgSDT.h
+++ b/Reconstruction/RecGenfitAlg/src/RecGenfitAlgSDT.h
@@ -73,11 +73,11 @@ class RecGenfitAlgSDT:public GaudiAlgorithm {
                 const edm4hep::TrackCollection* sdtRecTrackCol,
                 double eventStartTime,int nFittedSDT);
 
-        void selectHits(const edm4hep::Track&, std::vector<edm4hep::TrackerHit*>& dcDigiSelected);
+        void selectHits(const edm4hep::Track&, std::vector<edm4hep::TrackerHit3D*>& dcDigiSelected);
 
         DataHandle<edm4hep::EventHeaderCollection> m_headerCol{
             "EventHeaderCol", Gaudi::DataHandle::Reader, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_DCDigiCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_DCDigiCol{
             "DigiDCHitCollection", Gaudi::DataHandle::Reader, this};
         //Mc truth
         DataHandle<edm4hep::SimTrackerHitCollection> m_simVXDHitCol{
@@ -128,7 +128,7 @@ class RecGenfitAlgSDT:public GaudiAlgorithm {
             "NoiseDCHitAssociationCollection", Gaudi::DataHandle::Reader, this};
 
         //Track Finding
-        DataHandle<edm4hep::TrackerHitCollection> m_DCTrackFindingCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_DCTrackFindingCol{
             "DCTrackFindingHitCollection",Gaudi::DataHandle::Reader, this};
 
         //Output hits and particles

--- a/Reconstruction/RecGenfitAlg/src/WireMeasurementDC.cpp
+++ b/Reconstruction/RecGenfitAlg/src/WireMeasurementDC.cpp
@@ -23,7 +23,14 @@
 
 #include "WireMeasurementDC.h"
 #include "edm4hep/SimTrackerHit.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 #include <iostream>
 #include <algorithm>

--- a/Reconstruction/RecGenfitAlg/src/WireMeasurementDC.h
+++ b/Reconstruction/RecGenfitAlg/src/WireMeasurementDC.h
@@ -109,7 +109,7 @@ class WireMeasurementDC : public genfit::AbsMeasurement{
   virtual bool isLeftRigthMeasurement() const {return true;}
   double getMaxDistance(){return maxDistance_;}
   int getLeftRightResolution() const override {return leftRight_;}
-  void setTrackerHit(const edm4hep::TrackerHit& trackerHit,int l,int c){
+  void setTrackerHit(const edm4hep::TrackerHit3D& trackerHit,int l,int c){
       trackerHit_=&trackerHit;
       layer_=l;
       cell_=c;
@@ -119,7 +119,7 @@ class WireMeasurementDC : public genfit::AbsMeasurement{
   }
   void print();
 
-  const edm4hep::TrackerHit* getTrackerHit(){return trackerHit_;}
+  const edm4hep::TrackerHit3D* getTrackerHit(){return trackerHit_;}
 
  protected:
 
@@ -131,7 +131,7 @@ class WireMeasurementDC : public genfit::AbsMeasurement{
   int layer_;
   int cell_;
   const edm4hep::SimTrackerHit* simTrackerHit_;
-  const edm4hep::TrackerHit* trackerHit_;
+  const edm4hep::TrackerHit3D* trackerHit_;
 
  public:
 

--- a/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.cpp
@@ -3,7 +3,14 @@
 #include "TrackSystemSvc/ITrackSystemSvc.h"
 #include "DataHelper/Navigation.h"
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackerHitPlane.h"
 #include "edm4hep/Track.h"
 #if __has_include("edm4hep/EDM4hepVersion.h")
@@ -248,7 +255,7 @@ StatusCode ForwardTrackingAlg::execute(){
   
   debug() << "\t\t---Reading in Collections---" << endmsg;
   Navigation::Instance()->Initialize();
-  std::vector<const edm4hep::TrackerHitCollection*> hitFTDCollections;
+  std::vector<const edm4hep::TrackerHit3DCollection*> hitFTDCollections;
   int pixelCollectionID = -1; 
   try {
     auto hitFTDPixelCol = _inFTDPixelColHdl.get();
@@ -264,7 +271,7 @@ StatusCode ForwardTrackingAlg::execute(){
     auto hitFTDSpacePointCol = _inFTDSpacePointColHdl.get();
     hitFTDCollections.push_back(hitFTDSpacePointCol);
     Navigation::Instance()->AddTrackerHitCollection(hitFTDSpacePointCol);
-    //const edm4hep::TrackerHitCollection* rawHitCol = nullptr;
+    //const edm4hep::TrackerHit3DCollection* rawHitCol = nullptr;
     try{
       auto rawHitCol = _inFTDRawColHdl.get();
       Navigation::Instance()->AddTrackerHitCollection(rawHitCol);
@@ -281,7 +288,7 @@ StatusCode ForwardTrackingAlg::execute(){
     return StatusCode::SUCCESS;
   }
   /*
-  const edm4hep::TrackerHitCollection* rawHitCol = nullptr;
+  const edm4hep::TrackerHit3DCollection* rawHitCol = nullptr;
   if(1){
     try{
       rawHitCol = _inFTDRawColHdl.get();
@@ -299,7 +306,7 @@ StatusCode ForwardTrackingAlg::execute(){
       if(pixelCollectionID==hitFTDCollections[iCol]->getID()){
 	if ( UTIL::BitSet32( trackerHit.getType() )[ UTIL::ILDTrkHitTypeBit::ONE_DIMENSIONAL ] ) continue;
       }
-      edm4hep::TrackerHit hit = trackerHit;
+      edm4hep::TrackerHit3D hit = trackerHit;
       debug() << "hit " << trackerHit.id() << " " << KiTrackMarlin::getCellID0Info( trackerHit.getCellID() ) 
 	      << " " << KiTrackMarlin::getPositionInfo( hit )<< endmsg;
          
@@ -994,7 +1001,7 @@ void ForwardTrackingAlg::finaliseTrack( edm4hep::MutableTrack* trackImpl ){
   
   unsigned int nHits = trackImpl->trackerHits_size();
   for( unsigned j=0; j<nHits; j++ ){
-    const edm4hep::TrackerHit& hit = trackImpl->getTrackerHits(j);
+    const edm4hep::TrackerHit3D& hit = trackImpl->getTrackerHits(j);
     UTIL::BitField64 encoder( UTIL::ILDCellID0::encoder_string );
     encoder.setValue( hit.getCellID() );
     int subdet =  encoder[UTIL::ILDCellID0::subdet];

--- a/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.h
+++ b/Reconstruction/SiliconTracking/src/ForwardTrackingAlg.h
@@ -6,13 +6,27 @@
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 
 #include <string>
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "TrackSystemSvc/IMarlinTrkSystem.h"
 #include "Tracking/ITrackFitterTool.h"
 //#include "gear/BField.h"
@@ -228,9 +242,9 @@ class ForwardTrackingAlg : public GaudiAlgorithm {
   std::string getInfo_map_sector_hits();
       
   /* Input collection names */
-  DataHandle<edm4hep::TrackerHitCollection> _inFTDPixelColHdl{"FTDPixelTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inFTDSpacePointColHdl{"FTDSpacePoints", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inFTDRawColHdl{"FTDStripTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inFTDPixelColHdl{"FTDPixelTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inFTDSpacePointColHdl{"FTDSpacePoints", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inFTDRawColHdl{"FTDStripTrackerHits", Gaudi::DataHandle::Reader, this};
   
   /** Output collection name */
   DataHandle<edm4hep::TrackCollection> _outColHdl{"ForwardTracks", Gaudi::DataHandle::Writer, this};

--- a/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.cpp
@@ -5,7 +5,14 @@
 #include "DataHelper/Navigation.h"
 #include "DataHelper/TrackerHitHelper.h"
 #include "edm4hep/MCParticle.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 //#include "edm4hep/TrackerHitPlane.h"
 #include "edm4hep/Track.h"
 #include "edm4hep/TrackState.h"
@@ -475,7 +482,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
   
   // Reading in FTD Pixel Hits Collection
   //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  const edm4hep::TrackerHitCollection* hitFTDPixelCol = nullptr;
+  const edm4hep::TrackerHit3DCollection* hitFTDPixelCol = nullptr;
   try {
     hitFTDPixelCol = _inFTDPixelColHdl.get();
   }
@@ -574,7 +581,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
   }
   // Reading out FTD SpacePoint Collection
   //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  const edm4hep::TrackerHitCollection* hitFTDSpacePointCol = nullptr;
+  const edm4hep::TrackerHit3DCollection* hitFTDSpacePointCol = nullptr;
   try {
     hitFTDSpacePointCol = _inFTDSpacePointColHdl.get();
   }
@@ -583,7 +590,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
     //success = 0;
   }
 
-  const edm4hep::TrackerHitCollection* rawHitCol = nullptr;
+  const edm4hep::TrackerHit3DCollection* rawHitCol = nullptr;
   if(hitFTDSpacePointCol){
     try{
       rawHitCol = _inFTDRawColHdl.get();
@@ -608,7 +615,7 @@ int SiliconTrackingAlg::InitialiseFTD() {
     
     //for (int ielem=0; ielem<nelem; ++ielem) {
     for(auto hit : *hitFTDSpacePointCol){
-    //edm4hep::TrackerHit hit =  hitFTDSpacePointCol->at(ielem);
+    //edm4hep::TrackerHit3D hit =  hitFTDSpacePointCol->at(ielem);
       
       TrackerHitExtended * hitExt = new TrackerHitExtended(hit);
       
@@ -700,7 +707,7 @@ int SiliconTrackingAlg::InitialiseVTX() {
   int success = 1;
   // Reading out VTX Hits Collection
   //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  
-  const edm4hep::TrackerHitCollection* hitVTXCol = nullptr;
+  const edm4hep::TrackerHit3DCollection* hitVTXCol = nullptr;
   try {
     hitVTXCol = _inVTXColHdl.get();
   }
@@ -783,7 +790,7 @@ int SiliconTrackingAlg::InitialiseVTX() {
   }
   
   if (_useSIT > 0 ) {
-    const edm4hep::TrackerHitCollection* hitSITCol = nullptr;
+    const edm4hep::TrackerHit3DCollection* hitSITCol = nullptr;
     try {
       hitSITCol = _inSITColHdl.get();
     }
@@ -792,7 +799,7 @@ int SiliconTrackingAlg::InitialiseVTX() {
       success = 0;
     }
 
-    const edm4hep::TrackerHitCollection* rawHitCol = nullptr;
+    const edm4hep::TrackerHit3DCollection* rawHitCol = nullptr;
     if(hitSITCol){
       try{
 	rawHitCol = _inSITRawColHdl.get();
@@ -832,7 +839,7 @@ int SiliconTrackingAlg::InitialiseVTX() {
         //    iv)  TrackerHitZCylinder 
         //    v)   Must be standard TrackerHit
         
-	//const edm4hep::TrackerHit trkhit = hitSITCol->at(ielem);
+	//const edm4hep::TrackerHit3D trkhit = hitSITCol->at(ielem);
         int layer = getLayerID(trkhit);
         
         // VXD and SIT are treated as one system so SIT layers start from _nLayersVTX
@@ -1577,7 +1584,7 @@ int SiliconTrackingAlg::BuildTrack(TrackerHitExtended * outerHit,
       float epar[15];
       
       for (int ih=0;ih<nHits;++ih) {
-	edm4hep::TrackerHit trkHit = hvec[ih]->getTrackerHit();
+	edm4hep::TrackerHit3D trkHit = hvec[ih]->getTrackerHit();
         xh[ih] = trkHit.getPosition()[0];
         yh[ih] = trkHit.getPosition()[1];
         zh[ih] = float(trkHit.getPosition()[2]);
@@ -1588,7 +1595,7 @@ int SiliconTrackingAlg::BuildTrack(TrackerHitExtended * outerHit,
         if (ph[ih] < 0.) 
           ph[ih] = TWOPI + ph[ih]; 
       }      
-      edm4hep::TrackerHit assignedTrkHit = assignedhit->getTrackerHit();
+      edm4hep::TrackerHit3D assignedTrkHit = assignedhit->getTrackerHit();
       xh[nHits] = assignedTrkHit.getPosition()[0];
       yh[nHits] = assignedTrkHit.getPosition()[1];
       zh[nHits] = float(assignedTrkHit.getPosition()[2]);
@@ -1695,7 +1702,7 @@ void SiliconTrackingAlg::CreateTrack(TrackExtended * trackAR ) {
   
   for (int i=0; i<nHits; ++i) {
     TrackExtendedVec& trackVec = hitVec[i]->getTrackExtendedVec();
-    //edm4hep::TrackerHit trkHit = hitVec[i]->getTrackerHit();
+    //edm4hep::TrackerHit3D trkHit = hitVec[i]->getTrackerHit();
     //debug() << "Hit " << trkHit.id().collectionID << "-" << trkHit.id().index << endmsg;
     if (trackVec.size() != 0) {
       //debug() << "    used in TrackExtended " << endmsg;
@@ -1737,7 +1744,7 @@ void SiliconTrackingAlg::CreateTrack(TrackExtended * trackAR ) {
       float epar[15];
       float refPoint[3] = {0.,0.,0.};
       for (int ih=0;ih<nHits;++ih) {
-	edm4hep::TrackerHit trkHit = hitVec[ih]->getTrackerHit();
+	edm4hep::TrackerHit3D trkHit = hitVec[ih]->getTrackerHit();
         float rR = hitVec[ih]->getResolutionRPhi();
         float rZ = hitVec[ih]->getResolutionZ();
         if (int(hitVec[ih]->getTrackExtendedVec().size()) != 0)
@@ -1751,7 +1758,7 @@ void SiliconTrackingAlg::CreateTrack(TrackExtended * trackAR ) {
         ph[ih] = float(atan2(yh[ih],xh[ih]));
       }      
       for (int ih=0;ih<nHitsOld;++ih) {
-	edm4hep::TrackerHit trkHit = hitVecOld[ih]->getTrackerHit();
+	edm4hep::TrackerHit3D trkHit = hitVecOld[ih]->getTrackerHit();
 	//debug() << "old track's hit " << trkHit.id().collectionID << " " << trkHit.id().index << endmsg;
         xh[ih+nHits] = trkHit.getPosition()[0];
         yh[ih+nHits] = trkHit.getPosition()[1];
@@ -1958,7 +1965,7 @@ void SiliconTrackingAlg::AttachRemainingVTXHitsFast() {
           TrackerHitExtended * hitExt = hitVec[iH];
           TrackExtendedVec& trackVec = hitExt->getTrackExtendedVec();
           if (trackVec.size()==0) {
-	    edm4hep::TrackerHit hit = hitExt->getTrackerHit();
+	    edm4hep::TrackerHit3D hit = hitExt->getTrackerHit();
             double pos[3];
             double radius = 0;
             for (int i=0; i<3; ++i) {
@@ -2022,8 +2029,8 @@ void SiliconTrackingAlg::AttachRemainingVTXHitsFast() {
                 for (int IHIT=0;IHIT<NHITS;++IHIT) {
                   
                   // Here we are trying to find if a hits are too close i.e. closer than _minDistToDelta
-		  edm4hep::TrackerHit trkhit1 = hit->getTrackerHit();
-		  edm4hep::TrackerHit trkhit2 = hitVector[IHIT]->getTrackerHit();                  
+		  edm4hep::TrackerHit3D trkhit1 = hit->getTrackerHit();
+		  edm4hep::TrackerHit3D trkhit2 = hitVector[IHIT]->getTrackerHit();                  
                   
                   if ( trkhit1.getCellID() == trkhit2.getCellID() ){ // i.e. they are in the same sensor
                     float distance = 0.;
@@ -2131,8 +2138,8 @@ void SiliconTrackingAlg::AttachRemainingVTXHitsSlow() {
           for (int IHIT=0;IHIT<NHITS;++IHIT) {
             
             // Here we are trying to find if a hits are too close i.e. closer than _minDistToDelta
-	    edm4hep::TrackerHit trkhit1 = hit->getTrackerHit();
-	    edm4hep::TrackerHit trkhit2 = hitVector[IHIT]->getTrackerHit();                  
+	    edm4hep::TrackerHit3D trkhit1 = hit->getTrackerHit();
+	    edm4hep::TrackerHit3D trkhit2 = hitVector[IHIT]->getTrackerHit();                  
 	    
             if ( trkhit1.getCellID() == trkhit2.getCellID() ){ // i.e. they are in the same sensor
               
@@ -2492,7 +2499,7 @@ int SiliconTrackingAlg::BuildTrackFTD(TrackExtended * trackAR, int * nLR, int iS
         int nH = int(hitVec.size());
         for (int iH=0; iH<nH; ++iH) {
           TrackerHitExtended * hit = hitVec[iH];
-	  edm4hep::TrackerHit trkHit = hit->getTrackerHit();
+	  edm4hep::TrackerHit3D trkHit = hit->getTrackerHit();
           float pos[3];
           for (int i=0;i<3;++i)
             pos[i] = float(trkHit.getPosition()[i]);
@@ -2535,7 +2542,7 @@ int SiliconTrackingAlg::AttachHitToTrack(TrackExtended * trackAR, TrackerHitExte
   float epar[15];
   
   for (int i=0; i<nHits; ++i) {
-    edm4hep::TrackerHit trkHit = hitVec[i]->getTrackerHit();
+    edm4hep::TrackerHit3D trkHit = hitVec[i]->getTrackerHit();
     xh[i] = double(trkHit.getPosition()[0]);
     yh[i] = double(trkHit.getPosition()[1]);
     zh[i] = float(trkHit.getPosition()[2]);
@@ -2547,7 +2554,7 @@ int SiliconTrackingAlg::AttachHitToTrack(TrackExtended * trackAR, TrackerHitExte
     wzh[i] = 1.0/(rZ*rZ);
   }
   
-  edm4hep::TrackerHit trkHit = hit->getTrackerHit();
+  edm4hep::TrackerHit3D trkHit = hit->getTrackerHit();
   xh[nHits] = double(trkHit.getPosition()[0]);
   yh[nHits] = double(trkHit.getPosition()[1]);
   zh[nHits] = float(trkHit.getPosition()[2]);
@@ -2678,7 +2685,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
         lh[ihit] = 1; // only hits which have lh=1 will be used for the fit
         
         // get the pointer to the lcio trackerhit for this hit
-	edm4hep::TrackerHit trkHit = hitVec[ihit]->getTrackerHit();
+	edm4hep::TrackerHit3D trkHit = hitVec[ihit]->getTrackerHit();
         
         int det = getDetectorID(trkHit);
         
@@ -2692,7 +2699,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
           for (int lhit=0;lhit<ihit;++lhit) {
             
             // get the pointer to the lcio trackerhit for the previously checked hit
-	    edm4hep::TrackerHit trkHitS = hitVec[lhit]->getTrackerHit();
+	    edm4hep::TrackerHit3D trkHitS = hitVec[lhit]->getTrackerHit();
             
             
             //          int layerS = getLayerID(trkHitS);
@@ -2759,11 +2766,11 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       
       int nFit = 0;
       for (int i=0; i<nHits; ++i) {
-	edm4hep::TrackerHit trkHit = hitVec[i]->getTrackerHit();
+	edm4hep::TrackerHit3D trkHit = hitVec[i]->getTrackerHit();
 	debug() << "TrackerHit " << i << " id = " << trkHit.id().collectionID << "-" << trkHit.id().index << endmsg;
         // check if the hit has been rejected as being on the same layer and further from the helix lh==0
         if (lh[i] == 1) {
-	  //edm4hep::TrackerHit trkHit = hitVec[i]->getTrackerHit();
+	  //edm4hep::TrackerHit3D trkHit = hitVec[i]->getTrackerHit();
 	  debug() << "                  accept" << endmsg;
           nFit++;
           if(trkHit.isAvailable()) { 
@@ -2807,11 +2814,11 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       covMatrix[14] = ( _initialTrackError_tanL  ); //sigma_tanl^2
       
       
-      std::vector< std::pair<float, edm4hep::TrackerHit> > r2_values;
+      std::vector< std::pair<float, edm4hep::TrackerHit3D> > r2_values;
       r2_values.reserve(trkHits.size());
       
-      for (std::vector<edm4hep::TrackerHit>::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
-        edm4hep::TrackerHit h = *it;
+      for (std::vector<edm4hep::TrackerHit3D>::iterator it=trkHits.begin(); it!=trkHits.end(); ++it) {
+        edm4hep::TrackerHit3D h = *it;
         float r2 = h.getPosition()[0]*h.getPosition()[0]+h.getPosition()[1]*h.getPosition()[1];
         r2_values.push_back(std::make_pair(r2, *it));
       }
@@ -2821,7 +2828,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       trkHits.clear();
       trkHits.reserve(r2_values.size());
 
-      for (std::vector< std::pair<float, edm4hep::TrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
+      for (std::vector< std::pair<float, edm4hep::TrackerHit3D> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
         trkHits.push_back(it->second);
       }
 
@@ -2849,9 +2856,9 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
 #endif
       */
       
-      std::vector<std::pair<edm4hep::TrackerHit , double> > hits_in_fit ;  
-      std::vector<std::pair<edm4hep::TrackerHit , double> > outliers ;
-      std::vector<edm4hep::TrackerHit> all_hits;    
+      std::vector<std::pair<edm4hep::TrackerHit3D , double> > hits_in_fit ;  
+      std::vector<std::pair<edm4hep::TrackerHit3D , double> > outliers ;
+      std::vector<edm4hep::TrackerHit3D> all_hits;    
 
       UTIL::BitField64 cellID_encoder( UTIL::ILDCellID0::encoder_string ) ;
 
@@ -2859,7 +2866,7 @@ void SiliconTrackingAlg::FinalRefit(edm4hep::TrackCollection* trk_col) {
       hits_in_fit = m_fitTool->GetHitsInFit();
 
       for ( unsigned ihit = 0; ihit < hits_in_fit.size(); ++ihit) {
-	edm4hep::TrackerHit hit = hits_in_fit[ihit].first;
+	edm4hep::TrackerHit3D hit = hits_in_fit[ihit].first;
         //all_hits.push_back(hit);//hits_in_fit[ihit].first);
 	if (m_tupleDebug) {
 	  cellID_encoder.setValue(hit.getCellID());

--- a/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.h
+++ b/Reconstruction/SiliconTracking/src/SiliconTrackingAlg.h
@@ -8,7 +8,14 @@
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 
@@ -294,12 +301,12 @@ class SiliconTrackingAlg : public GaudiAlgorithm {
   // Input collections
   DataHandle<edm4hep::EventHeaderCollection> _headerColHdl{"EventHeaderCol", Gaudi::DataHandle::Reader, this};
   DataHandle<edm4hep::MCParticleCollection> _inMCColHdl{"MCParticle", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inVTXColHdl{"VXDTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inFTDPixelColHdl{"FTDPixelTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inFTDSpacePointColHdl{"FTDSpacePoints", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inSITColHdl{"SITSpacePoints", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inSITRawColHdl{"SITTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inFTDRawColHdl{"FTDStripTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inVTXColHdl{"VXDTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inFTDPixelColHdl{"FTDPixelTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inFTDSpacePointColHdl{"FTDSpacePoints", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inSITColHdl{"SITSpacePoints", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inSITRawColHdl{"SITTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inFTDRawColHdl{"FTDStripTrackerHits", Gaudi::DataHandle::Reader, this};
   // Output collections
   DataHandle<edm4hep::TrackCollection> _outColHdl{"SiTracks", Gaudi::DataHandle::Writer, this};
   //DataHandle<edm4hep::LCRelationCollection> _outRelColHdl{"TrackerHitRelations", Gaudi::DataHandle::Reader, this};
@@ -417,11 +424,11 @@ class SiliconTrackingAlg : public GaudiAlgorithm {
   //  int _createMap;
   
   UTIL::BitField64* _encoder;
-  int getDetectorID(edm4hep::TrackerHit hit) { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::subdet]; }
-  int getSideID(edm4hep::TrackerHit hit)     { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::side]; };
-  int getLayerID(edm4hep::TrackerHit hit)    { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::layer]; };
-  int getModuleID(edm4hep::TrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::module]; };
-  int getSensorID(edm4hep::TrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::sensor]; };
+  int getDetectorID(edm4hep::TrackerHit3D hit) { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::subdet]; }
+  int getSideID(edm4hep::TrackerHit3D hit)     { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::side]; };
+  int getLayerID(edm4hep::TrackerHit3D hit)    { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::layer]; };
+  int getModuleID(edm4hep::TrackerHit3D hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::module]; };
+  int getSensorID(edm4hep::TrackerHit3D hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::sensor]; };
   
   StatusCode setupGearGeom() ;
   

--- a/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.cpp
@@ -72,7 +72,7 @@ StatusCode SpacePointBuilderAlg::execute(){
   auto spCol = _outSPColHdl.createAndPut();
   auto relCol = _outSPAssColHdl.createAndPut();
 
-  const edm4hep::TrackerHitCollection* hitCol = nullptr;
+  const edm4hep::TrackerHit3DCollection* hitCol = nullptr;
   try {
     hitCol = _inHitColHdl.get();
   }
@@ -98,7 +98,7 @@ StatusCode SpacePointBuilderAlg::execute(){
     _nStripsTooParallel = 0;
     _nPlanesNotParallel = 0;
     
-    //edm4hep::TrackerHitCollection* spCol = new edm4hep::TrackerHitCollection();    // output spacepoint collection
+    //edm4hep::TrackerHit3DCollection* spCol = new edm4hep::TrackerHit3DCollection();    // output spacepoint collection
     //edm4hep::MCRecoTrackerAssociationCollection* relCol = new edm4hep::MCRecoTrackerAssociationCollection();    // output relation collection
     
     // to store the weights
@@ -268,7 +268,7 @@ StatusCode SpacePointBuilderAlg::finalize(){
   return GaudiAlgorithm::finalize();
 }
 
-edm4hep::MutableTrackerHit SpacePointBuilderAlg::createSpacePoint( edm4hep::TrackerHit a , edm4hep::TrackerHit b, double stripLength ){
+edm4hep::MutableTrackerHit SpacePointBuilderAlg::createSpacePoint( edm4hep::TrackerHit3D a , edm4hep::TrackerHit3D b, double stripLength ){
   
   const edm4hep::Vector3d& pa = a.getPosition();
   double xa = pa[0];
@@ -406,7 +406,7 @@ edm4hep::MutableTrackerHit SpacePointBuilderAlg::createSpacePoint( edm4hep::Trac
   }
   
   //Create the new TrackerHit
-  edm4hep::MutableTrackerHit spacePoint;// = new edm4hep::TrackerHit();
+  edm4hep::MutableTrackerHit spacePoint;// = new edm4hep::TrackerHit3D();
   
   edm4hep::Vector3d pos(point.x(), point.y(), point.z());
   spacePoint.setPosition(pos) ;

--- a/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.h
+++ b/Reconstruction/SiliconTracking/src/SpacePointBuilderAlg.h
@@ -6,7 +6,14 @@
 //#include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 
 #include "CLHEP/Vector/ThreeVector.h"
@@ -73,10 +80,10 @@ class SpacePointBuilderAlg : public GaudiAlgorithm {
  protected:
   // Input collection
   DataHandle<edm4hep::MCParticleCollection> _inMCColHdl{"MCParticle", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inHitColHdl{"FTDStripTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inHitColHdl{"FTDStripTrackerHits", Gaudi::DataHandle::Reader, this};
   DataHandle<edm4hep::MCRecoTrackerAssociationCollection> _inHitAssColHdl{"FTDStripTrackerHitsAssociation", Gaudi::DataHandle::Reader, this};
   // Output collection
-  DataHandle<edm4hep::TrackerHitCollection> _outSPColHdl{"FTDSpacePoints", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _outSPColHdl{"FTDSpacePoints", Gaudi::DataHandle::Writer, this};
   DataHandle<edm4hep::MCRecoTrackerAssociationCollection> _outSPAssColHdl{"FTDSpacePointsAssociation", Gaudi::DataHandle::Writer, this};
 
   Gaudi::Property<float> _nominal_vertex_x{this, "NominalVertexX", 0.0};
@@ -144,7 +151,7 @@ class SpacePointBuilderAlg : public GaudiAlgorithm {
   
   
   /** @return a spacepoint (in the form of a TrackerHitImpl* ) created from two TrackerHitPlane* which stand for si-strips */
-  edm4hep::MutableTrackerHit createSpacePoint( edm4hep::TrackerHit a , edm4hep::TrackerHit b, double stripLength );
+  edm4hep::MutableTrackerHit createSpacePoint( edm4hep::TrackerHit3D a , edm4hep::TrackerHit3D b, double stripLength );
   
 //   TrackerHitImpl* createSpacePointOld( TrackerHitPlane* a , TrackerHitPlane* b );
   

--- a/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
+++ b/Reconstruction/SiliconTracking/src/TrackSubsetAlg.cpp
@@ -67,7 +67,7 @@ StatusCode TrackSubsetAlg::initialize() {
   }
 
   for(unsigned i=0; i<_trackerHitInputColNames.size(); i++){
-    _inTrackerHitColHdls.push_back(new DataHandle<edm4hep::TrackerHitCollection> (_trackerHitInputColNames[i], Gaudi::DataHandle::Reader, this));
+    _inTrackerHitColHdls.push_back(new DataHandle<edm4hep::TrackerHit3DCollection> (_trackerHitInputColNames[i], Gaudi::DataHandle::Reader, this));
   }
   /**********************************************************************************************/
   /*       Initialise the MarlinTrkSystem, needed by the tracks for fitting                     */
@@ -182,7 +182,7 @@ StatusCode TrackSubsetAlg::execute(){
     tracks_p.push_back(track);
     double qi = trackQI( track );
     debug() << "Track " << track->id() << " address " << track << "\t" << qi << "( ";
-    std::vector<edm4hep::TrackerHit> hits;
+    std::vector<edm4hep::TrackerHit3D> hits;
     std::copy(track->trackerHits_begin(), track->trackerHits_end(), std::back_inserter(hits));
     
     std::sort( hits.begin(), hits.end(), KiTrackMarlin::compare_TrackerHit_z );
@@ -230,8 +230,8 @@ StatusCode TrackSubsetAlg::execute(){
     
     auto track = accepted[i];
     
-    std::vector<edm4hep::TrackerHit> trackerHitsObj;
-    std::vector<edm4hep::TrackerHit> trackerHits;
+    std::vector<edm4hep::TrackerHit3D> trackerHitsObj;
+    std::vector<edm4hep::TrackerHit3D> trackerHits;
     std::copy(track->trackerHits_begin(), track->trackerHits_end(), std::back_inserter(trackerHitsObj));
 
     for(unsigned i=0; i<trackerHitsObj.size(); i++){
@@ -250,11 +250,11 @@ StatusCode TrackSubsetAlg::execute(){
     covMatrix[9]  = ( _initialTrackError_z0    ); //sigma_z0^2
     covMatrix[14] = ( _initialTrackError_tanL  ); //sigma_tanl^2
     
-    std::vector< std::pair<float, edm4hep::TrackerHit> > r2_values;
+    std::vector< std::pair<float, edm4hep::TrackerHit3D> > r2_values;
     r2_values.reserve(trackerHits.size());
     
-    for (std::vector<edm4hep::TrackerHit>::iterator it=trackerHits.begin(); it!=trackerHits.end(); ++it) {
-      edm4hep::TrackerHit h = *it;
+    for (std::vector<edm4hep::TrackerHit3D>::iterator it=trackerHits.begin(); it!=trackerHits.end(); ++it) {
+      edm4hep::TrackerHit3D h = *it;
       float r2 = h.getPosition()[0]*h.getPosition()[0]+h.getPosition()[1]*h.getPosition()[1];
       r2_values.push_back(std::make_pair(r2, *it));
     }
@@ -264,7 +264,7 @@ StatusCode TrackSubsetAlg::execute(){
     trackerHits.clear();
     trackerHits.reserve(r2_values.size());
     
-    for (std::vector< std::pair<float, edm4hep::TrackerHit> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
+    for (std::vector< std::pair<float, edm4hep::TrackerHit3D> >::iterator it=r2_values.begin(); it!=r2_values.end(); ++it) {
       trackerHits.push_back(it->second);
     }
 
@@ -290,9 +290,9 @@ StatusCode TrackSubsetAlg::execute(){
     
     // Add hit numbers 
     
-    std::vector<std::pair<edm4hep::TrackerHit , double> > hits_in_fit ;
-    std::vector<std::pair<edm4hep::TrackerHit , double> > outliers ;
-    std::vector<edm4hep::TrackerHit> all_hits;
+    std::vector<std::pair<edm4hep::TrackerHit3D , double> > hits_in_fit ;
+    std::vector<std::pair<edm4hep::TrackerHit3D , double> > outliers ;
+    std::vector<edm4hep::TrackerHit3D> all_hits;
     //all_hits.reserve(300);
     
     //marlinTrk->getHitsInFit(hits_in_fit);

--- a/Reconstruction/SiliconTracking/src/TrackSubsetAlg.h
+++ b/Reconstruction/SiliconTracking/src/TrackSubsetAlg.h
@@ -5,7 +5,14 @@
 #include "GaudiAlg/GaudiAlgorithm.h"
 
 #include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 //#include "edm4hep/Track.h"
 #include "TrackSystemSvc/IMarlinTrkSystem.h"
 #include "Tracking/ITrackFitterTool.h"
@@ -60,7 +67,7 @@ class TrackSubsetAlg : public GaudiAlgorithm {
   ToolHandle<ITrackFitterTool> m_fitTool;
   /* Input collection */
   std::vector<DataHandle<edm4hep::TrackCollection>* > _inTrackColHdls;
-  std::vector<DataHandle<edm4hep::TrackerHitCollection>* > _inTrackerHitColHdls;
+  std::vector<DataHandle<edm4hep::TrackerHit3DCollection>* > _inTrackerHitColHdls;
   /* Output collection */
   DataHandle<edm4hep::TrackCollection> _outColHdl{"SubsetTracks", Gaudi::DataHandle::Writer, this};
   

--- a/Reconstruction/Tracking/include/Tracking/ITrackFitterTool.h
+++ b/Reconstruction/Tracking/include/Tracking/ITrackFitterTool.h
@@ -28,12 +28,12 @@ class ITrackFitterTool: virtual public IAlgTool {
   DeclareInterfaceID(ITrackFitterTool, 0, 1);
   virtual ~ITrackFitterTool() {}
 
-  virtual int Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit>& trackHits,
+  virtual int Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit3D>& trackHits,
                   const decltype(edm4hep::TrackState::covMatrix)& covMatrix, double maxChi2perHit, bool backward) = 0;
-  virtual int Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit>& trackHits,
+  virtual int Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit3D>& trackHits,
                   edm4hep::TrackState trackState, double maxChi2perHit, bool backward) = 0;
-  virtual std::vector<std::pair<edm4hep::TrackerHit, double> >& GetHitsInFit() = 0;
-  virtual std::vector<std::pair<edm4hep::TrackerHit, double> >& GetOutliers() = 0;
+  virtual std::vector<std::pair<edm4hep::TrackerHit3D, double> >& GetHitsInFit() = 0;
+  virtual std::vector<std::pair<edm4hep::TrackerHit3D, double> >& GetOutliers() = 0;
   virtual void Clear() = 0;
 };
 

--- a/Reconstruction/Tracking/include/Tracking/TrackingHelper.h
+++ b/Reconstruction/Tracking/include/Tracking/TrackingHelper.h
@@ -54,7 +54,7 @@ inline float getPhi(const edm4hep::Track &track) {
 }
 
 
-inline int getLayer(const edm4hep::TrackerHit hit) {
+inline int getLayer(const edm4hep::TrackerHit3D hit) {
     UTIL::BitField64* _encoder = new UTIL::BitField64(lcio::ILDCellID0::encoder_string);
     _encoder->setValue(hit.getCellID());
     int layer = (*_encoder)[lcio::ILDCellID0::layer];

--- a/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.cpp
@@ -43,7 +43,14 @@
 
 #include "RuntimeMap.h"
 
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackCollection.h"
 // #include "edm4hep/TrackerHitPlane.h"
 
@@ -65,7 +72,7 @@ using namespace clupatra_new ;
 RuntimeMap<edm4hep::Track, clupatra_new::TrackInfoStruct*> TrackInfo_of_edm4hepTrack;
 RuntimeMap<edm4hep::Track, MarlinTrk::IMarlinTrack*> MarTrk_of_edm4hepTrack;
 RuntimeMap<MarlinTrk::IMarlinTrack*, clupatra_new::CluTrack*> CluTrk_of_MarTrack;
-RuntimeMap<edm4hep::TrackerHit, clupatra_new::Hit*> GHitof;
+RuntimeMap<edm4hep::TrackerHit3D, clupatra_new::Hit*> GHitof;
 RuntimeMap<clupatra_new::CluTrack*, MarlinTrk::IMarlinTrack*> MarTrkof;
 
 gear::GearMgr* gearMgr; 
@@ -285,7 +292,7 @@ StatusCode ClupatraAlg::execute() {
 	ZIndex zIndex( -driftLength , driftLength , _nZBins  ) ;
 
 
-	const edm4hep::TrackerHitCollection* col = nullptr;
+	const edm4hep::TrackerHit3DCollection* col = nullptr;
         debug() << "col" << endmsg;
 
 	try{   col = _TPCHitCollectionHandle.get();
@@ -546,7 +553,7 @@ StatusCode ClupatraAlg::execute() {
 
 				MarlinTrk::IMarlinTrack* mTrk = fitter( *icv ) ;
 				debug() << "before add hits and filter" << endmsg;
-                // std::vector<std::pair<edm4hep::TrackerHit, double> > hitsInFit ;
+                // std::vector<std::pair<edm4hep::TrackerHit3D, double> > hitsInFit ;
                 // mTrk->getHitsInFit( hitsInFit ) ;
                 // for (auto hit : hitsInFit) std::cout << hit.first << std::endl;
 
@@ -919,7 +926,7 @@ StatusCode ClupatraAlg::execute() {
 					//	std::copy( trk->getTrackerHits().begin() , trk->getTrackerHits().end() , std::back_inserter( hits ) ) ;
 
 					/*
-					   for( edm4hep::TrackerHitVec::const_iterator it = trk->getTrackerHits().begin() , END =  trk->getTrackerHits().end() ; it != END ; ++ it ){
+					   for( edm4hep::TrackerHit3DVec::const_iterator it = trk->getTrackerHits().begin() , END =  trk->getTrackerHits().end() ; it != END ; ++ it ){
 					   hits.addElement( GHitof(*it) )  ;
 					   }
 					   */

--- a/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.h
+++ b/Reconstruction/Tracking/src/Clupatra/ClupatraAlg.h
@@ -8,8 +8,22 @@
 
 #include "GaudiAlg/GaudiAlgorithm.h"
 #include "edm4hep/Track.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackCollection.h"
 #include <string>
 
@@ -143,9 +157,9 @@ class ClupatraAlg : public GaudiAlgorithm {
   Gaudi::Property<std::string> m_fitToolName{this, "FitterTool", "KalTestTool/KalTest010"};
 
 
-  DataHandle<edm4hep::TrackerHitCollection> _TPCHitCollectionHandle{"TPCTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _SITHitCollectionHandle{"SIDTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _VTXHitCollectionHandle{"VTXTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _TPCHitCollectionHandle{"TPCTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _SITHitCollectionHandle{"SIDTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _VTXHitCollectionHandle{"VTXTrackerHits", Gaudi::DataHandle::Reader, this};
 
   DataHandle<edm4hep::TrackCollection> _ClupatraTrackCollectionHandle{"ClupatraTracks", Gaudi::DataHandle::Writer, this};
   DataHandle<edm4hep::TrackCollection> _ClupatraTrackSegmentCollectionHandle{"ClupatraSegmentTracks", Gaudi::DataHandle::Writer, this};

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.cpp
@@ -46,7 +46,7 @@ namespace clupatra_new{
 		edm4hep::MutableTrack lTrk  = o ;
 
 		// compute z-extend of this track segment
-		// const edm4hep::TrackerHitVec& hv = lTrk->getTrackerHits() ;
+		// const edm4hep::TrackerHit3DVec& hv = lTrk->getTrackerHits() ;
 
 		float zMin =  1e99 ;
 		float zMax = -1e99 ;
@@ -291,9 +291,9 @@ namespace clupatra_new{
 		encoder[UTIL::ILDCellID0::subdet] = UTIL::ILDDetID::TPC ;
 
 #if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
-		edm4hep::TrackerHit firstHit = 0;
+		edm4hep::TrackerHit3D firstHit = 0;
 #else
-		auto firstHit = edm4hep::TrackerHit::makeEmpty();
+		auto firstHit = edm4hep::TrackerHit3D::makeEmpty();
 #endif
 		// = 0 equal to unlink()
                 //firstHit.unlink();
@@ -438,7 +438,7 @@ namespace clupatra_new{
 
 						double deltaChi = 0. ;
 
-						edm4hep::TrackerHit ht = bestHit->first->edm4hepHit;
+						edm4hep::TrackerHit3D ht = bestHit->first->edm4hepHit;
 						int addHit =  theTrk->addAndFit(ht , deltaChi, dChi2Max )  ;
 
 
@@ -565,7 +565,7 @@ namespace clupatra_new{
 				if( ch2Min  < chi2Cut ) {
 
 					double deltaChi = 0. ;
-					edm4hep::TrackerHit bh = bestHit->first->edm4hepHit;
+					edm4hep::TrackerHit3D bh = bestHit->first->edm4hepHit;
 					int addHit = trk->addAndFit( bh, deltaChi, dChi2Max ) ;
 
 
@@ -1250,7 +1250,7 @@ start:
 		if( reverse_order ){
 		  //std::cout << "It is true order" << std::endl;
 		  for( CluTrack::reverse_iterator it=clu->rbegin() ; it != clu->rend() ; ++it){
-		    edm4hep::TrackerHit ph = (*it)->first->edm4hepHit;
+		    edm4hep::TrackerHit3D ph = (*it)->first->edm4hepHit;
 		    trk->addHit(ph) ;
 		    ++nHit ;
 		    //std::cout  <<  "   hit  added  " <<  (*it)->first->edm4hepHit.id() << std::endl ;
@@ -1261,7 +1261,7 @@ start:
 		} else {
 		  //std::cout << "It is reverse order" << std::endl;
 		  for( CluTrack::iterator it=clu->begin() ; it != clu->end() ; ++it){
-		    edm4hep::TrackerHit ph = (*it)->first->edm4hepHit;
+		    edm4hep::TrackerHit3D ph = (*it)->first->edm4hepHit;
 		    if( trk->addHit(ph) == MarlinTrk::IMarlinTrack::success ){
 		      //std::cout << "   hit added  " <<  (*it)->first->edm4hepHit.id() << std::endl;
 		    }
@@ -1287,7 +1287,7 @@ start:
 		}
 
 
-                std::vector<std::pair<edm4hep::TrackerHit, double> > hitsInFit ;
+                std::vector<std::pair<edm4hep::TrackerHit3D, double> > hitsInFit ;
                 trk->getHitsInFit( hitsInFit ) ;
 		//----- if the fit did not fail but has a small number of hits used,
 		//      we try again one more time with a larger max-chi2-increment
@@ -1346,12 +1346,12 @@ start:
 		   trk->subdetectorHitNumbers()[ 2*lcio::ILDDetID::TPC - 1 ] =  nHit ;
 		   */
 
-		RuntimeMap<edm4hep::TrackerHit, int> DChi2_of_hit;
+		RuntimeMap<edm4hep::TrackerHit3D, int> DChi2_of_hit;
 
 		if( mtrk != 0 && ! c->empty() ){
 
 
-			std::vector<std::pair<edm4hep::TrackerHit, double> > hitsInFit ;
+			std::vector<std::pair<edm4hep::TrackerHit3D, double> > hitsInFit ;
 			mtrk->getHitsInFit( hitsInFit ) ;
                         // for (auto hit : hitsInFit) std::cout << hit.second << std::endl;
 			// FIXME Mingrui
@@ -1395,8 +1395,8 @@ start:
 				// lcio::TrackerHit* fHit =  ( reverse_order ?  hb->first->lcioHit  :  hf->first->lcioHit ) ;
 				// lcio::TrackerHit* lHit =  ( reverse_order ?  hf->first->lcioHit  :  hb->first->lcioHit ) ;
 
-				edm4hep::TrackerHit fHit = (hitsInFit.back().first);
-				edm4hep::TrackerHit lHit = (hitsInFit.front().first);
+				edm4hep::TrackerHit3D fHit = (hitsInFit.back().first);
+				edm4hep::TrackerHit3D lHit = (hitsInFit.front().first);
 
 				//order of hits in fit is reversed wrt time  (we fit inwards)
 
@@ -1418,9 +1418,9 @@ start:
 				code = mtrk->getTrackState( lHit, tsLH, chi2, ndf ) ;
 #else     // get the track state at the last hit by propagating from the last(first) constrained fit position (a la MarlinTrkUtils)
 #if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
-				edm4hep::TrackerHit last_constrained_hit(0);
+				edm4hep::TrackerHit3D last_constrained_hit(0);
 #else
-				auto last_constrained_hit = edm4hep::TrackerHit::makeEmpty();
+				auto last_constrained_hit = edm4hep::TrackerHit3D::makeEmpty();
 #endif
 				code = mtrk->getTrackerHitAtPositiveNDF( last_constrained_hit );
 				//code = mtrk->smooth() ;

--- a/Reconstruction/Tracking/src/Clupatra/clupatra_new.h
+++ b/Reconstruction/Tracking/src/Clupatra/clupatra_new.h
@@ -62,13 +62,13 @@ namespace clupatra_new{
 #if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
 		edm4hepHit(0),
 #else
-		edm4hepHit(edm4hep::TrackerHit::makeEmpty()),
+		edm4hepHit(edm4hep::TrackerHit3D::makeEmpty()),
 #endif
 		pos(0.,0.,0.) {}
 		int layer ;
 		int zIndex ;
 		int phiIndex ;
-		edm4hep::TrackerHit edm4hepHit ;
+		edm4hep::TrackerHit3D edm4hepHit ;
 		gear::Vector3D pos ;
 
 	};
@@ -405,11 +405,11 @@ namespace clupatra_new{
 				unsigned nhit0 = trk0.trackerHits_size() ;
 				unsigned nhit1 = trk1.trackerHits_size() ;
 
-				edm4hep::TrackerHit thf0 = trk0.getTrackerHits( 0 ) ;
-				edm4hep::TrackerHit thf1 = trk1.getTrackerHits( 0 ) ;
+				edm4hep::TrackerHit3D thf0 = trk0.getTrackerHits( 0 ) ;
+				edm4hep::TrackerHit3D thf1 = trk1.getTrackerHits( 0 ) ;
 
-				edm4hep::TrackerHit thl0 = trk0.getTrackerHits( nhit0 - 1 ) ;
-				edm4hep::TrackerHit thl1 = trk1.getTrackerHits( nhit1 - 1 ) ;
+				edm4hep::TrackerHit3D thl0 = trk0.getTrackerHits( nhit0 - 1 ) ;
+				edm4hep::TrackerHit3D thl1 = trk1.getTrackerHits( nhit1 - 1 ) ;
 
 				// lcio::TrackerHit* thm1 = trk1->getTrackerHits()[ nhit1 / 2 ] ;
 				// lcio::TrackerHit* thm0 = trk0->getTrackerHits()[ nhit0 / 2 ] ;
@@ -439,9 +439,9 @@ namespace clupatra_new{
 
 				unsigned n = oth.trackerHits_size() ;
 
-				edm4hep::TrackerHit th0 =  ( outward ? oth.getTrackerHits(0) : oth.getTrackerHits(n-1) ) ;
-				edm4hep::TrackerHit th1 =              (oth.getTrackerHits(n/2) );
-				edm4hep::TrackerHit th2 =  ( outward ? oth.getTrackerHits(n-1) : oth.getTrackerHits(0) );
+				edm4hep::TrackerHit3D th0 =  ( outward ? oth.getTrackerHits(0) : oth.getTrackerHits(n-1) ) ;
+				edm4hep::TrackerHit3D th1 =              (oth.getTrackerHits(n/2) );
+				edm4hep::TrackerHit3D th2 =  ( outward ? oth.getTrackerHits(n-1) : oth.getTrackerHits(0) );
 
 
 				// track state at last hit migyt be rubish....
@@ -475,7 +475,7 @@ namespace clupatra_new{
 				// streamlog_out( DEBUG3  )  << "               -- extrapolate TrackState : " << lcshort( ts )    << std::endl ;
 				// fucd: getTrackerHits(0) is possible to miss ILDVTrackHit
 				for(int ih=0;ih<nHit;ih++){
-				  edm4hep::TrackerHit ht = trk.getTrackerHits(ih);
+				  edm4hep::TrackerHit3D ht = trk.getTrackerHits(ih);
 				  //need to add a dummy hit to the track
 				  if(mTrk->addHit( ht ) == MarlinTrk::IMarlinTrack::success) break;  // is this the right hit ??????????
 				}

--- a/Reconstruction/Tracking/src/FitterTool/KalTestTool.cpp
+++ b/Reconstruction/Tracking/src/FitterTool/KalTestTool.cpp
@@ -8,7 +8,14 @@
 #include "DD4hep/Detector.h"
 #include "DD4hep/DD4hepUnits.h"
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackState.h"
 #include "edm4hep/MutableTrack.h"
 
@@ -58,7 +65,7 @@ StatusCode KalTestTool::finalize() {
   return sc;
 }
 
-int KalTestTool::Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit>& trackHits,
+int KalTestTool::Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit3D>& trackHits,
 			  const decltype(edm4hep::TrackState::covMatrix)& covMatrix, double maxChi2perHit, bool backward) {
   if (m_hitsInFit.size()!=0 || m_outliers.size()!=0) {
     error() << "Important! vector not clear, still store the data of last event!" << endmsg;
@@ -80,7 +87,7 @@ int KalTestTool::Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHi
   return 0;
 }
 
-int KalTestTool::Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit>& trackHits,
+int KalTestTool::Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit3D>& trackHits,
                           edm4hep::TrackState trackState, double maxChi2perHit, bool backward) {
   if (m_hitsInFit.size()!=0 || m_outliers.size()!=0) {
     error() << "Important! vector not clear, still store the data of last event!" << endmsg;

--- a/Reconstruction/Tracking/src/FitterTool/KalTestTool.h
+++ b/Reconstruction/Tracking/src/FitterTool/KalTestTool.h
@@ -14,16 +14,16 @@ class KalTestTool : public extends<AlgTool, ITrackFitterTool> {
   using extends::extends;
   //KalTestTool(void* p) { m_pAlgUsing=p; };
   
-  virtual int Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit>& trackHits,
+  virtual int Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit3D>& trackHits,
 		  const decltype(edm4hep::TrackState::covMatrix)& covMatrix, double maxChi2perHit, bool backward = true) override;
-  virtual int Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit>& trackHits,
+  virtual int Fit(edm4hep::MutableTrack track, std::vector<edm4hep::TrackerHit3D>& trackHits,
                   edm4hep::TrackState trackState, double maxChi2perHit, bool backward = true) override;
 
   StatusCode initialize() override;
   StatusCode finalize() override;
 
-  std::vector<std::pair<edm4hep::TrackerHit, double> >& GetHitsInFit() override {return m_hitsInFit;};
-  std::vector<std::pair<edm4hep::TrackerHit, double> >& GetOutliers() override {return m_outliers;};
+  std::vector<std::pair<edm4hep::TrackerHit3D, double> >& GetHitsInFit() override {return m_hitsInFit;};
+  std::vector<std::pair<edm4hep::TrackerHit3D, double> >& GetOutliers() override {return m_outliers;};
   void Clear() override {m_hitsInFit.clear(); m_outliers.clear();};
 
  private:
@@ -36,8 +36,8 @@ class KalTestTool : public extends<AlgTool, ITrackFitterTool> {
   MarlinTrk::IMarlinTrkSystem* m_factoryMarlinTrk = nullptr;
 
   void* m_pAlgUsing = nullptr;
-  std::vector<std::pair<edm4hep::TrackerHit, double> > m_hitsInFit ;
-  std::vector<std::pair<edm4hep::TrackerHit, double> > m_outliers ;
+  std::vector<std::pair<edm4hep::TrackerHit3D, double> > m_hitsInFit ;
+  std::vector<std::pair<edm4hep::TrackerHit3D, double> > m_outliers ;
 };
 
 #endif

--- a/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.h
+++ b/Reconstruction/Tracking/src/FullLDCTracking/FullLDCTrackingAlg.h
@@ -22,7 +22,14 @@
 #include "Tracking/ITrackFitterTool.h"
 
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackCollection.h"
 
 #include <UTIL/BitField64.h>
@@ -408,11 +415,11 @@ protected:
   std::set<TrackExtended*> _candidateCombinedTracks;
   
   UTIL::BitField64* _encoder;
-  int getDetectorID(edm4hep::TrackerHit hit) { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::subdet]; }
-  int getSideID(edm4hep::TrackerHit hit)     { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::side]; };
-  int getLayerID(edm4hep::TrackerHit hit)    { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::layer]; };
-  int getModuleID(edm4hep::TrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::module]; };
-  int getSensorID(edm4hep::TrackerHit hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::sensor]; };
+  int getDetectorID(edm4hep::TrackerHit3D hit) { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::subdet]; }
+  int getSideID(edm4hep::TrackerHit3D hit)     { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::side]; };
+  int getLayerID(edm4hep::TrackerHit3D hit)    { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::layer]; };
+  int getModuleID(edm4hep::TrackerHit3D hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::module]; };
+  int getSensorID(edm4hep::TrackerHit3D hit)   { _encoder->setValue(hit.getCellID()); return (*_encoder)[lcio::ILDCellID0::sensor]; };
 
   
   void setupGearGeom() ;
@@ -502,16 +509,16 @@ protected:
   int _nPhiFTD; 
   bool  _petalBasedFTDWithOverlaps;
 
-  DataHandle<edm4hep::TrackerHitCollection> _TPCTrackerHitColHdl{"TPCTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _FTDSpacePointColHdl{"FTDSpacePoints", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _FTDPixelTrackerHitColHdl{"FTDPixelTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _SITTrackerHitColHdl{"SITSpacePoints", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _SETTrackerHitColHdl{"SETSpacePoints", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _VTXTrackerHitColHdl{"VTXTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _TPCTrackerHitColHdl{"TPCTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _FTDSpacePointColHdl{"FTDSpacePoints", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _FTDPixelTrackerHitColHdl{"FTDPixelTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _SITTrackerHitColHdl{"SITSpacePoints", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _SETTrackerHitColHdl{"SETSpacePoints", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _VTXTrackerHitColHdl{"VTXTrackerHits", Gaudi::DataHandle::Reader, this};
  
-  DataHandle<edm4hep::TrackerHitCollection> _inSITRawColHdl{"SITTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inSETRawColHdl{"SETTrackerHits", Gaudi::DataHandle::Reader, this};
-  DataHandle<edm4hep::TrackerHitCollection> _inFTDRawColHdl{"FTDStripTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inSITRawColHdl{"SITTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inSETRawColHdl{"SETTrackerHits", Gaudi::DataHandle::Reader, this};
+  DataHandle<edm4hep::TrackerHit3DCollection> _inFTDRawColHdl{"FTDStripTrackerHits", Gaudi::DataHandle::Reader, this};
   //DataHandle<edm4hep::SimTrackerHitCollection> _inVTXRawColHdl{"VXDCollection", Gaudi::DataHandle::Reader, this};
 
   DataHandle<edm4hep::TrackCollection> _TPCTrackColHdl{"ClupatraTracks", Gaudi::DataHandle::Reader, this};

--- a/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.cpp
+++ b/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.cpp
@@ -14,7 +14,14 @@
 #include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 #include "edm4hep/MCRecoParticleAssociationCollection.h"
@@ -187,7 +194,7 @@ StatusCode TruthTrackerAlg::execute()
         return StatusCode::SUCCESS;
     }
     ///Retrieve DC digi
-    const edm4hep::TrackerHitCollection* digiDCHitsCol=nullptr;
+    const edm4hep::TrackerHit3DCollection* digiDCHitsCol=nullptr;
     const edm4hep::SimTrackerHitCollection* dcSimHitCol
         =m_DCSimTrackerHitCol.get();
     const edm4hep::MCRecoTrackerAssociationCollection* assoHits
@@ -217,7 +224,7 @@ StatusCode TruthTrackerAlg::execute()
     edm4hep::SimTrackerHitCollection* SimVec = w_SimNoiseHCol.createAndPut();
     edm4hep::MCRecoTrackerAssociationCollection* AssoVec = 
         w_NoiseAssociationCol.createAndPut();
-    edm4hep::TrackerHitCollection* Vec = w_NoiseHitCol.createAndPut();
+    edm4hep::TrackerHit3DCollection* Vec = w_NoiseHitCol.createAndPut();
 
     ////TODO
     //Output MCRecoTrackerAssociationCollection collection
@@ -592,13 +599,13 @@ void TruthTrackerAlg::debugEvent()
     }
 }
 
-int TruthTrackerAlg::addIdealHitsToTk(DataHandle<edm4hep::TrackerHitCollection>&
-        colHandle, edm4hep::TrackerHitCollection*& truthTrackerHitCol,
+int TruthTrackerAlg::addIdealHitsToTk(DataHandle<edm4hep::TrackerHit3DCollection>&
+        colHandle, edm4hep::TrackerHit3DCollection*& truthTrackerHitCol,
         edm4hep::MutableTrack& track, const char* msg,int nHitAdded)
 {
     if(nHitAdded>0) return nHitAdded;
     int nHit=0;
-    const edm4hep::TrackerHitCollection* col=colHandle.get();
+    const edm4hep::TrackerHit3DCollection* col=colHandle.get();
     debug()<<"add "<<msg<<" "<<col->size()<<" trackerHit"<<endmsg;
     debug()<<track<<endmsg;
     for(auto hit:*col){
@@ -633,7 +640,7 @@ int TruthTrackerAlg::addIdealHitsToTk(DataHandle<edm4hep::TrackerHitCollection>&
     return nHit;
 }
 
-bool TruthTrackerAlg::debugNoiseHitsCol(edm4hep::TrackerHitCollection* Vec)
+bool TruthTrackerAlg::debugNoiseHitsCol(edm4hep::TrackerHit3DCollection* Vec)
 {
     m_nNoiseDCTrackHit = Vec->size();
 std::cout << "  m_nNoiseDCTrackHit = " <<  m_nNoiseDCTrackHit << std::endl;
@@ -648,16 +655,16 @@ std::cout << "  m_nNoiseDCTrackHit = " <<  m_nNoiseDCTrackHit << std::endl;
 }
 
 int TruthTrackerAlg::makeNoiseHit(edm4hep::SimTrackerHitCollection* SimVec,
-        edm4hep::TrackerHitCollection* Vec,
+        edm4hep::TrackerHit3DCollection* Vec,
         edm4hep::MCRecoTrackerAssociationCollection* AssoVec,
-        const edm4hep::TrackerHitCollection* digiDCHitsCol,
+        const edm4hep::TrackerHit3DCollection* digiDCHitsCol,
         const edm4hep::MCRecoTrackerAssociationCollection* assoHits)
 {
     int nNoise = 0;
     //loop all hits
     for(unsigned int i = 0; i<(digiDCHitsCol->size()); i++)
     {
-        edm4hep::TrackerHit mcHit = digiDCHitsCol->at(i);
+        edm4hep::TrackerHit3D mcHit = digiDCHitsCol->at(i);
         unsigned long long wcellid = mcHit.getCellID();
 
         float pocaTime = mcHit.getTime();
@@ -720,8 +727,8 @@ std::cout << " Truth Noise number = " << nNoise << std::endl;
     return nNoise;
 }
 
-int TruthTrackerAlg::smearDCTkhit(DataHandle<edm4hep::TrackerHitCollection>&
-        colHandle,DataHandle<edm4hep::TrackerHitCollection>& smearCol,
+int TruthTrackerAlg::smearDCTkhit(DataHandle<edm4hep::TrackerHit3DCollection>&
+        colHandle,DataHandle<edm4hep::TrackerHit3DCollection>& smearCol,
         DataHandle<edm4hep::SimTrackerHitCollection>& SimDCHitCol,
         DataHandle<edm4hep::SimTrackerHitCollection>& SimSmearDCHitCol,
         DataHandle<edm4hep::MCRecoTrackerAssociationCollection>& AssoDCHitCol,
@@ -729,7 +736,7 @@ int TruthTrackerAlg::smearDCTkhit(DataHandle<edm4hep::TrackerHitCollection>&
         double resX, double resY, double resZ)
 {
     int nHit=0;
-    const edm4hep::TrackerHitCollection* col=colHandle.get();
+    const edm4hep::TrackerHit3DCollection* col=colHandle.get();
     auto smearTrackerHitCol = smearCol.createAndPut();
 
     auto simDCCol = SimDCHitCol.get();
@@ -791,12 +798,12 @@ int TruthTrackerAlg::smearDCTkhit(DataHandle<edm4hep::TrackerHitCollection>&
     return nHit;
 }
 
-int TruthTrackerAlg::addHitsToTk(DataHandle<edm4hep::TrackerHitCollection>&
+int TruthTrackerAlg::addHitsToTk(DataHandle<edm4hep::TrackerHit3DCollection>&
         colHandle, edm4hep::MutableTrack& track, const char* msg,int nHitAdded)
 {
     if(nHitAdded>0) return nHitAdded;
     int nHit=0;
-    const edm4hep::TrackerHitCollection* col=colHandle.get();
+    const edm4hep::TrackerHit3DCollection* col=colHandle.get();
     debug()<<"add "<<msg<<" "<<col->size()<<" trackerHit"<<endmsg;
     //sort,FIXME
     for(auto hit:*col){
@@ -808,7 +815,7 @@ int TruthTrackerAlg::addHitsToTk(DataHandle<edm4hep::TrackerHitCollection>&
 
 int TruthTrackerAlg::addSimHitsToTk(
         DataHandle<edm4hep::SimTrackerHitCollection>& colHandle,
-        edm4hep::TrackerHitCollection*& truthTrackerHitCol,
+        edm4hep::TrackerHit3DCollection*& truthTrackerHitCol,
         edm4hep::MutableTrack& track, const char* msg,int nHitAdded)
 {
     if(nHitAdded>0) return nHitAdded;
@@ -869,7 +876,7 @@ int TruthTrackerAlg::addHotsToTk(edm4hep::Track& sourceTrack,
     if(nHitAdded>0) return nHitAdded;
     int nHit=0;
     for(unsigned int iHit=0;iHit<sourceTrack.trackerHits_size();iHit++){
-        edm4hep::TrackerHit hit=sourceTrack.getTrackerHits(iHit);
+        edm4hep::TrackerHit3D hit=sourceTrack.getTrackerHits(iHit);
         UTIL::BitField64 encoder(lcio::ILDCellID0::encoder_string);
         encoder.setValue(hit.getCellID());
         if(encoder[lcio::ILDCellID0::subdet]==hitType){
@@ -888,7 +895,7 @@ int TruthTrackerAlg::nHotsOnTrack(edm4hep::Track& track, int hitType)
 {
     int nHit=0;
     for(unsigned int iHit=0;iHit<track.trackerHits_size();iHit++){
-        edm4hep::TrackerHit hit=track.getTrackerHits(iHit);
+        edm4hep::TrackerHit3D hit=track.getTrackerHits(iHit);
         UTIL::BitField64 encoder(lcio::ILDCellID0::encoder_string);
         encoder.setValue(hit.getCellID());
         if(encoder[lcio::ILDCellID0::subdet]==hitType){
@@ -898,9 +905,9 @@ int TruthTrackerAlg::nHotsOnTrack(edm4hep::Track& track, int hitType)
     return nHit;
 }
 
-int TruthTrackerAlg::trackerHitColSize(DataHandle<edm4hep::TrackerHitCollection>& col)
+int TruthTrackerAlg::trackerHitColSize(DataHandle<edm4hep::TrackerHit3DCollection>& col)
 {
-    const edm4hep::TrackerHitCollection* c=col.get();
+    const edm4hep::TrackerHit3DCollection* c=col.get();
     if(nullptr!=c) return c->size();
     return 0;
 }

--- a/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.h
+++ b/Reconstruction/Tracking/src/TruthTracker/TruthTrackerAlg.h
@@ -42,25 +42,25 @@ class TruthTrackerAlg: public GaudiAlgorithm
         void getTrackStateFromMcParticle(const edm4hep::MCParticleCollection*
                 mcParticleCol, edm4hep::TrackState& stat);
         int addSimHitsToTk(DataHandle<edm4hep::SimTrackerHitCollection>&
-                colHandle, edm4hep::TrackerHitCollection*& truthTrackerHitCol,
+                colHandle, edm4hep::TrackerHit3DCollection*& truthTrackerHitCol,
                 edm4hep::MutableTrack& track, const char* msg,int nHitAdded);
-        int smearDCTkhit(DataHandle<edm4hep::TrackerHitCollection>&
-                colHandle,DataHandle<edm4hep::TrackerHitCollection>& smearCol,
+        int smearDCTkhit(DataHandle<edm4hep::TrackerHit3DCollection>&
+                colHandle,DataHandle<edm4hep::TrackerHit3DCollection>& smearCol,
                 DataHandle<edm4hep::SimTrackerHitCollection>& SimDCHitCol,
                 DataHandle<edm4hep::SimTrackerHitCollection>& SimSmearDCHitCol,
                 DataHandle<edm4hep::MCRecoTrackerAssociationCollection>& AssoDCHitCol,
                 DataHandle<edm4hep::MCRecoTrackerAssociationCollection>& AssoSmearDCHitCol,
                 double resX, double resY, double resZ);
-        int addHitsToTk(DataHandle<edm4hep::TrackerHitCollection>&
+        int addHitsToTk(DataHandle<edm4hep::TrackerHit3DCollection>&
                 colHandle, edm4hep::MutableTrack& track, const char* msg,int nHitAdded);
-        int addIdealHitsToTk(DataHandle<edm4hep::TrackerHitCollection>&
-                colHandle, edm4hep::TrackerHitCollection*& truthTrackerHitCol,
+        int addIdealHitsToTk(DataHandle<edm4hep::TrackerHit3DCollection>&
+                colHandle, edm4hep::TrackerHit3DCollection*& truthTrackerHitCol,
                 edm4hep::MutableTrack& track, const char* msg,int nHitAdded);
 
         int addHotsToTk(edm4hep::Track& sourceTrack,edm4hep::MutableTrack&
                 targetTrack, int hitType,const char* msg,int nHitAdded);
         int nHotsOnTrack(edm4hep::Track& track, int hitType);
-        int trackerHitColSize(DataHandle<edm4hep::TrackerHitCollection>& hitCol);
+        int trackerHitColSize(DataHandle<edm4hep::TrackerHit3DCollection>& hitCol);
         int simTrackerHitColSize(DataHandle<edm4hep::SimTrackerHitCollection>& hitCol);
         bool getTrackStateFirstHit(
                 DataHandle<edm4hep::SimTrackerHitCollection>& dcSimTrackerHitCol,
@@ -75,20 +75,20 @@ class TruthTrackerAlg: public GaudiAlgorithm
         void getCircleFromPosMom(double pos[3],double mom[3],
                 double Bz,double q,double& helixRadius,double& helixXC,double& helixYC);
         int makeNoiseHit(edm4hep::SimTrackerHitCollection* SimVec,
-                edm4hep::TrackerHitCollection* Vec,
+                edm4hep::TrackerHit3DCollection* Vec,
                 edm4hep::MCRecoTrackerAssociationCollection* AssoVec,
-                const edm4hep::TrackerHitCollection* digiDCHitsCol,
+                const edm4hep::TrackerHit3DCollection* digiDCHitsCol,
                 const edm4hep::MCRecoTrackerAssociationCollection* assoHits);
-        bool debugNoiseHitsCol(edm4hep::TrackerHitCollection* Vec);
+        bool debugNoiseHitsCol(edm4hep::TrackerHit3DCollection* Vec);
 
             //reader
-            //        DataHandle<edm4hep::TrackerHitCollection> m_NoiseHitCol{
+            //        DataHandle<edm4hep::TrackerHit3DCollection> m_NoiseHitCol{
             //            "NoiseDCHitsCollection", Gaudi::DataHandle::Reader, this};
         DataHandle<edm4hep::MCParticleCollection> m_mcParticleCol{
             "MCParticle", Gaudi::DataHandle::Reader, this};
         DataHandle<edm4hep::SimTrackerHitCollection> m_DCSimTrackerHitCol{
             "DriftChamberHitsCollection", Gaudi::DataHandle::Reader, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_DCDigiCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_DCDigiCol{
             "DigiDCHitCollection", Gaudi::DataHandle::Reader, this};
         DataHandle<edm4hep::MCRecoTrackerAssociationCollection>
             m_DCHitAssociationCol{ "DCHitAssociationCollection",
@@ -96,19 +96,19 @@ class TruthTrackerAlg: public GaudiAlgorithm
         DataHandle<edm4hep::TrackCollection>
             m_siSubsetTrackCol{ "SubsetTracks",
                 Gaudi::DataHandle::Reader, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_SITSpacePointCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_SITSpacePointCol{
             "SITSpacePoints" , Gaudi::DataHandle::Reader, this};
-        //        DataHandle<edm4hep::TrackerHitCollection> m_SETSpacePointCol{
+        //        DataHandle<edm4hep::TrackerHit3DCollection> m_SETSpacePointCol{
         //            "SETSpacePoints" , Gaudi::DataHandle::Reader, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_FTDSpacePointCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_FTDSpacePointCol{
             "FTDSpacePoints" , Gaudi::DataHandle::Reader, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_VXDTrackerHits{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_VXDTrackerHits{
             "VXDTrackerHits" , Gaudi::DataHandle::Reader, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_SETTrackerHits{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_SETTrackerHits{
             "SETTrackerHits" , Gaudi::DataHandle::Reader, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_SITTrackerHits{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_SITTrackerHits{
             "SITTrackerHits" , Gaudi::DataHandle::Reader, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_FTDTrackerHits{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_FTDTrackerHits{
             "FTDTrackerHits" , Gaudi::DataHandle::Reader, this};
         DataHandle<edm4hep::SimTrackerHitCollection> m_VXDCollection{
             "VXDCollection" , Gaudi::DataHandle::Reader, this};
@@ -123,20 +123,20 @@ class TruthTrackerAlg: public GaudiAlgorithm
             "DCTrackCollection", Gaudi::DataHandle::Writer, this};
         DataHandle<edm4hep::TrackCollection> m_SDTTrackCol{
             "SDTTrackCollection", Gaudi::DataHandle::Writer, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_truthTrackerHitCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_truthTrackerHitCol{
             "TruthTrackerHitCollection", Gaudi::DataHandle::Writer, this};
 
         // Smear hit
         DataHandle<edm4hep::SimTrackerHitCollection> w_SimSmearHCol{
             "SmearSimHitsCollection", Gaudi::DataHandle::Writer, this};
-        DataHandle<edm4hep::TrackerHitCollection> m_SmeartruthTrackerHitCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> m_SmeartruthTrackerHitCol{
             "SmearTrackerHitCollection", Gaudi::DataHandle::Writer, this};
         DataHandle<edm4hep::MCRecoTrackerAssociationCollection> w_SmearAssociationCol{
             "SmearDCHitAssociationCollection", Gaudi::DataHandle::Writer, this};
         // make noise hit
         DataHandle<edm4hep::SimTrackerHitCollection> w_SimNoiseHCol{
             "NoiseSimHitsCollection", Gaudi::DataHandle::Writer, this};
-        DataHandle<edm4hep::TrackerHitCollection> w_NoiseHitCol{
+        DataHandle<edm4hep::TrackerHit3DCollection> w_NoiseHitCol{
             "NoiseDCHitsCollection", Gaudi::DataHandle::Writer, this};
         DataHandle<edm4hep::MCRecoTrackerAssociationCollection> w_NoiseAssociationCol{
             "NoiseDCHitAssociationCollection", Gaudi::DataHandle::Writer, this};

--- a/Service/TrackSystemSvc/include/TrackSystemSvc/IMarlinTrack.h
+++ b/Service/TrackSystemSvc/include/TrackSystemSvc/IMarlinTrack.h
@@ -5,8 +5,22 @@
 
 //#include "lcio.h"
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackState.h"
 
 //#include "gearimpl/Vector3D.h"
@@ -55,7 +69,7 @@ namespace MarlinTrk{
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */
-    virtual int addHit(edm4hep::TrackerHit& hit) = 0 ;
+    virtual int addHit(edm4hep::TrackerHit3D& hit) = 0 ;
     
     /** initialise the fit using the hits added up to this point -
      *  the fit direction has to be specified using IMarlinTrack::backward or IMarlinTrack::forward. 
@@ -82,12 +96,12 @@ namespace MarlinTrk{
     /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from adding the hit via reference. 
      *  the given hit will not be added if chi2increment > maxChi2Increment. 
      */
-    virtual int addAndFit( edm4hep::TrackerHit& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) = 0 ;
+    virtual int addAndFit( edm4hep::TrackerHit3D& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) = 0 ;
 
     
     /** obtain the chi2 increment which would result in adding the hit to the fit. This method will not alter the current fit, and the hit will not be stored in the list of hits or outliers
      */
-    virtual int testChi2Increment( edm4hep::TrackerHit& hit, double& chi2increment ) = 0 ;
+    virtual int testChi2Increment( edm4hep::TrackerHit3D& hit, double& chi2increment ) = 0 ;
 
     
     /** smooth all track states 
@@ -97,7 +111,7 @@ namespace MarlinTrk{
     
     /** smooth track states from the last filtered hit back to the measurement site associated with the given hit 
      */
-    virtual int smooth( edm4hep::TrackerHit& hit ) = 0 ;
+    virtual int smooth( edm4hep::TrackerHit3D& hit ) = 0 ;
     
     
     
@@ -110,21 +124,21 @@ namespace MarlinTrk{
     
     /** get track state at measurement associated with the given hit, returning TrackState, chi2 and ndf via reference 
      */
-    virtual int getTrackState( edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
+    virtual int getTrackState( edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
     
     /** get the list of hits included in the fit, together with the chi2 contributions of the hits. 
      *  Pointers to the hits together with their chi2 contribution will be filled into a vector of 
      *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
      *  the second.
      */
-    virtual int getHitsInFit( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) = 0 ;
+    virtual int getHitsInFit( std::vector<std::pair<edm4hep::TrackerHit3D, double> >& hits ) = 0 ;
 
     /** get the list of hits which have been rejected by from the fit due to the a chi2 increment greater than threshold,
      *  Pointers to the hits together with their chi2 contribution will be filled into a vector of 
      *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
      *  the second.
      */
-    virtual int getOutliers( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) = 0 ;
+    virtual int getOutliers( std::vector<std::pair<edm4hep::TrackerHit3D, double> >& hits ) = 0 ;
     
     /** get the current number of degrees of freedom for the fit.
      */
@@ -132,7 +146,7 @@ namespace MarlinTrk{
     
     /** get TrackeHit at which fit became constrained, i.e. ndf >= 0
      */
-    virtual int getTrackerHitAtPositiveNDF( edm4hep::TrackerHit& trkhit ) = 0 ;
+    virtual int getTrackerHitAtPositiveNDF( edm4hep::TrackerHit3D& trkhit ) = 0 ;
     
     // PROPAGATORS 
     
@@ -144,7 +158,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point,
      *  returning TrackState, chi2 and ndf via reference   
      */
-    virtual int propagate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
+    virtual int propagate( const edm4hep::Vector3d& point, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
     
     
     /** propagate fit to numbered sensitive layer, returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference 
@@ -154,7 +168,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference 
      */
-    virtual int propagateToLayer(int layerID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0;
+    virtual int propagateToLayer(int layerID, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0;
     
     /** propagate the fit to sensitive detector element, returning TrackState, chi2 and ndf via reference
      */
@@ -163,7 +177,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
      */
-    virtual int propagateToDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
+    virtual int propagateToDetElement( int detEementID, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
     
     
     
@@ -176,7 +190,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point, 
      *  returning TrackState, chi2 and ndf via reference   
      */
-    virtual int extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
+    virtual int extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) = 0 ;
     
     /** extrapolate the fit to numbered sensitive layer, returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference
      */
@@ -185,7 +199,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of the intersected sensitive detector element via reference 
      */
-    virtual int extrapolateToLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0  ;
+    virtual int extrapolateToLayer( int layerID, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest ) = 0  ;
     
     /** extrapolate the fit to sensitive detector element, returning TrackState, chi2 and ndf via reference
      */
@@ -194,7 +208,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
      */
-    virtual int extrapolateToDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
+    virtual int extrapolateToDetElement( int detEementID, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) = 0  ;
     
     
     // INTERSECTORS
@@ -207,7 +221,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer,
      *  returning intersection point in global coordinates and integer ID of the intersected sensitive detector element via reference 
      */
-    virtual int intersectionWithLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest ) = 0  ;
+    virtual int intersectionWithLayer( int layerID, edm4hep::TrackerHit3D& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest ) = 0  ;
     
     
     /** extrapolate the fit to numbered sensitive detector element, returning intersection point in global coordinates via reference 
@@ -217,7 +231,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element,
      *  returning intersection point in global coordinates via reference 
      */
-    virtual int intersectionWithDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::Vector3d& point, int mode=modeClosest ) = 0  ;
+    virtual int intersectionWithDetElement( int detEementID, edm4hep::TrackerHit3D& hit, edm4hep::Vector3d& point, int mode=modeClosest ) = 0  ;
     
     
   protected:

--- a/Service/TrackSystemSvc/include/TrackSystemSvc/MarlinTrkUtils.h
+++ b/Service/TrackSystemSvc/include/TrackSystemSvc/MarlinTrkUtils.h
@@ -4,7 +4,14 @@
 #include <vector>
 #include <array>
 #include <cfloat>
-#include <edm4hep/TrackerHit.h>
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
+#include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include <edm4hep/Track.h>
 
 #include <LCIOSTLTypes.h>
@@ -40,7 +47,7 @@ namespace MarlinTrk{
    *  it @IP, @First_Hit, @Last_Hit and @CaloFace */
   int createFinalisedLCIOTrack(
       IMarlinTrack* marlinTrk,
-      std::vector<edm4hep::TrackerHit>& hit_list,
+      std::vector<edm4hep::TrackerHit3D>& hit_list,
       edm4hep::MutableTrack* track,
       bool fit_backwards,
       edm4hep::TrackState* pre_fit,
@@ -52,7 +59,7 @@ namespace MarlinTrk{
    *  it @IP, @First_Hit, @Last_Hit and @CaloFace */
   int createFinalisedLCIOTrack(
       IMarlinTrack* marlinTrk,
-      std::vector<edm4hep::TrackerHit>& hit_list,
+      std::vector<edm4hep::TrackerHit3D>& hit_list,
       edm4hep::MutableTrack* track,
       bool fit_backwards,
       const decltype(edm4hep::TrackState::covMatrix)& initial_cov_for_prefit,
@@ -60,10 +67,10 @@ namespace MarlinTrk{
       double maxChi2Increment=DBL_MAX);
   
   /** Provides the values of a track state from the first, middle and last hits in the hit_list. */
-  int createPrefit( std::vector<edm4hep::TrackerHit>& hit_list, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards );
+  int createPrefit( std::vector<edm4hep::TrackerHit3D>& hit_list, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards );
 
   /** Takes a list of hits and uses the IMarlinTrack inferface to fit them using a supplied prefit containing a covariance matrix for the initialisation. */  
-  int createFit( std::vector<edm4hep::TrackerHit>& hit_list, IMarlinTrack* marlinTrk, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards, double maxChi2Increment=DBL_MAX );
+  int createFit( std::vector<edm4hep::TrackerHit3D>& hit_list, IMarlinTrack* marlinTrk, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards, double maxChi2Increment=DBL_MAX );
 
   /** Takes a fitted MarlinTrack, TrackImpl to record the fit and the hits which have been added to the fit.
    *  The TrackImpl will have the 4 trackstates added to it @IP, @First_Hit, @Last_Hit and @CaloFace.
@@ -73,15 +80,15 @@ namespace MarlinTrk{
   int finaliseLCIOTrack(
       IMarlinTrack* marlinTrk,
       edm4hep::MutableTrack* track,
-      std::vector<edm4hep::TrackerHit>& hit_list,
+      std::vector<edm4hep::TrackerHit3D>& hit_list,
       edm4hep::TrackState* atLastHit=0,
       edm4hep::TrackState* atCaloFace=0);
   
   /** Set the subdetector hit numbers for the TrackImpl */
-  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<edm4hep::TrackerHit>& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder);
+  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<edm4hep::TrackerHit3D>& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder);
 
   /** Set the subdetector hit numbers for the TrackImpl */
-  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<std::pair<edm4hep::TrackerHit , double> >& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder);
+  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<std::pair<edm4hep::TrackerHit3D , double> >& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder);
   
 }
 

--- a/Service/TrackSystemSvc/src/MarlinKalTest.cc
+++ b/Service/TrackSystemSvc/src/MarlinKalTest.cc
@@ -415,7 +415,7 @@ namespace MarlinTrk{
     return ml_retval;
   }
   
-  const ILDVMeasLayer* MarlinKalTest::findMeasLayer( edm4hep::TrackerHit trkhit) const {
+  const ILDVMeasLayer* MarlinKalTest::findMeasLayer( edm4hep::TrackerHit3D trkhit) const {
     
     const TVector3 hit_pos( trkhit.getPosition()[0], trkhit.getPosition()[1], trkhit.getPosition()[2]) ;
     

--- a/Service/TrackSystemSvc/src/MarlinKalTest.h
+++ b/Service/TrackSystemSvc/src/MarlinKalTest.h
@@ -2,7 +2,14 @@
 #define MarlinKalTest_h
 
 #include "TrackSystemSvc/IMarlinTrkSystem.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 #include "gear/GearMgr.h"
 
@@ -80,7 +87,7 @@ namespace MarlinTrk{
     bool is_initialised ;
     
     //** find the measurment layer for a given hit 
-    const ILDVMeasLayer* findMeasLayer(edm4hep::TrackerHit trkhit) const ; 
+    const ILDVMeasLayer* findMeasLayer(edm4hep::TrackerHit3D trkhit) const ; 
     //** find the measurment layer for a given det element ID and point in space 
     const ILDVMeasLayer* findMeasLayer(int detElementID, const TVector3& point) const ;
     

--- a/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
+++ b/Service/TrackSystemSvc/src/MarlinKalTestTrack.cc
@@ -10,7 +10,14 @@
 #include "kaltest/TKalFilterCond.h"
 
 //#include <lcio.h>
-#include <edm4hep/TrackerHit.h>
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
+#include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 //#include <plcio/TrackerHitPlane.h>
 
 #include <UTIL/BitField64.h>
@@ -80,9 +87,9 @@ namespace MarlinTrk {
   MarlinKalTestTrack::MarlinKalTestTrack(MarlinKalTest* ktest) 
     : _ktest(ktest),
 #if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
-      _trackHitAtPositiveNDF(edm4hep::TrackerHit(0)) {
+      _trackHitAtPositiveNDF(edm4hep::TrackerHit3D(0)) {
 #else
-      _trackHitAtPositiveNDF(edm4hep::TrackerHit::makeEmpty()) {
+      _trackHitAtPositiveNDF(edm4hep::TrackerHit3D::makeEmpty()) {
 #endif
     _kaltrack = new TKalTrack() ;
     _kaltrack->SetOwner() ;
@@ -115,13 +122,13 @@ namespace MarlinTrk {
   
   
   
-  int MarlinKalTestTrack::addHit( edm4hep::TrackerHit& trkhit) {
+  int MarlinKalTestTrack::addHit( edm4hep::TrackerHit3D& trkhit) {
     
     return this->addHit( trkhit, _ktest->findMeasLayer( trkhit )) ;
     
   } 
   
-  int MarlinKalTestTrack::addHit( edm4hep::TrackerHit& trkhit, const ILDVMeasLayer* ml) {
+  int MarlinKalTestTrack::addHit( edm4hep::TrackerHit3D& trkhit, const ILDVMeasLayer* ml) {
     //std::cout << "MarlinKalTestTrack::addHit: trkhit = "  << trkhit.id() << " addr: " << trkhit << " ml = " << ml << std::endl ;
     if( trkhit.isAvailable() && ml ) {
       //if(ml){
@@ -134,7 +141,7 @@ namespace MarlinTrk {
     return bad_intputs ;
   }
   
-  int MarlinKalTestTrack::addHit( edm4hep::TrackerHit& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) {
+  int MarlinKalTestTrack::addHit( edm4hep::TrackerHit3D& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) {
     //std::cout << "MarlinKalTestTrack::addHit: trkhit = "  << trkhit.id() << " ILDVTrackHit: " << kalhit << " ml = " << ml << std::endl ;
     if( kalhit && ml ) {
       //if(ml){
@@ -665,10 +672,10 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::addAndFit( edm4hep::TrackerHit& trkhit, double& chi2increment, double maxChi2Increment) {
+  int MarlinKalTestTrack::addAndFit( edm4hep::TrackerHit3D& trkhit, double& chi2increment, double maxChi2Increment) {
     
     if( ! trkhit.isAvailable() ) {
-      std::cout << "Error: MarlinKalTestTrack::addAndFit(edm4hep::TrackerHit trkhit, double& chi2increment, double maxChi2Increment): trkhit == 0" << std::endl;
+      std::cout << "Error: MarlinKalTestTrack::addAndFit(edm4hep::TrackerHit3D trkhit, double& chi2increment, double maxChi2Increment): trkhit == 0" << std::endl;
       return bad_intputs ; 
     }
     
@@ -742,10 +749,10 @@ namespace MarlinTrk {
   
   
   
-  int MarlinKalTestTrack::testChi2Increment( edm4hep::TrackerHit& trkhit, double& chi2increment ) {
+  int MarlinKalTestTrack::testChi2Increment( edm4hep::TrackerHit3D& trkhit, double& chi2increment ) {
     
     //if( ! trkhit ) {
-    //  streamlog_out( ERROR) << "MarlinKalTestTrack::addAndFit(edm4hep::TrackerHit trkhit, double& chi2increment, double maxChi2Increment): trkhit == 0" << std::endl;
+    //  streamlog_out( ERROR) << "MarlinKalTestTrack::addAndFit(edm4hep::TrackerHit3D trkhit, double& chi2increment, double maxChi2Increment): trkhit == 0" << std::endl;
     //  return IMarlinTrack::bad_intputs ; 
     //}
     
@@ -816,7 +823,7 @@ namespace MarlinTrk {
       int error_code = this->addAndFit( kalhit, chi2increment, site, maxChi2Increment );
       
       
-      edm4hep::TrackerHit trkhit = kalhit->getLCIOTrackerHit();
+      edm4hep::TrackerHit3D trkhit = kalhit->getLCIOTrackerHit();
       
       if( error_code == 0 ){ // add trkhit to map associating trkhits and sites
         _hit_used_for_sites[trkhit] = site;
@@ -906,15 +913,15 @@ namespace MarlinTrk {
   
   /** smooth track states from the last filtered hit back to the measurement site associated with the given hit 
    */
-  int MarlinKalTestTrack::smooth( edm4hep::TrackerHit& trkhit ) {
+  int MarlinKalTestTrack::smooth( edm4hep::TrackerHit3D& trkhit ) {
     
-    //streamlog_out( DEBUG2 )  << "MarlinKalTestTrack::smooth( edm4hep::TrackerHit " << trkhit << "  ) " << std::endl ;
+    //streamlog_out( DEBUG2 )  << "MarlinKalTestTrack::smooth( edm4hep::TrackerHit3D " << trkhit << "  ) " << std::endl ;
 
     if ( !trkhit.isAvailable() ) {
       return bad_intputs ;
     }
         
-    std::map<edm4hep::TrackerHit, TKalTrackSite*>::const_iterator it;
+    std::map<edm4hep::TrackerHit3D, TKalTrackSite*>::const_iterator it;
         
     TKalTrackSite* site = 0 ;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -947,9 +954,9 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::getTrackState( edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
+  int MarlinKalTestTrack::getTrackState( edm4hep::TrackerHit3D& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
     
-    //streamlog_out( DEBUG2 )  << "MarlinKalTestTrack::getTrackState(edm4hep::TrackerHit trkhit, edm4hep::TrackState& ts ) using hit: " << trkhit << " with cellID0 = " << trkhit.getCellID() << std::endl ;
+    //streamlog_out( DEBUG2 )  << "MarlinKalTestTrack::getTrackState(edm4hep::TrackerHit3D trkhit, edm4hep::TrackState& ts ) using hit: " << trkhit << " with cellID0 = " << trkhit.getCellID() << std::endl ;
     
     TKalTrackSite* site = 0 ;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -964,7 +971,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::getHitsInFit( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) {
+  int MarlinKalTestTrack::getHitsInFit( std::vector<std::pair<edm4hep::TrackerHit3D, double> >& hits ) {
     //std::cout << "debug: _hit_chi2_values address= " << &_hit_chi2_values << " " << &(*(_hit_chi2_values.begin())) << " want to copy to hits address=" << &hits << std::endl; 
     std::copy( _hit_chi2_values.begin() , _hit_chi2_values.end() , std::back_inserter(  hits  )  ) ;
     //hits.resize(_hit_chi2_values.size());
@@ -986,7 +993,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::getOutliers( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) {
+  int MarlinKalTestTrack::getOutliers( std::vector<std::pair<edm4hep::TrackerHit3D, double> >& hits ) {
 
     std::copy( _outlier_chi2_values.begin() , _outlier_chi2_values.end() , std::back_inserter(  hits  )  ) ;
    
@@ -1017,7 +1024,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::getTrackerHitAtPositiveNDF( edm4hep::TrackerHit& trkhit ) {
+  int MarlinKalTestTrack::getTrackerHitAtPositiveNDF( edm4hep::TrackerHit3D& trkhit ) {
     if(_trackHitAtPositiveNDF.isAvailable()){
       trkhit = _trackHitAtPositiveNDF;
       return success;    
@@ -1037,7 +1044,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
+  int MarlinKalTestTrack::extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackerHit3D& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ) {
     
     TKalTrackSite* site = 0 ;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1089,7 +1096,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::extrapolateToLayer( int layerID, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
+  int MarlinKalTestTrack::extrapolateToLayer( int layerID, edm4hep::TrackerHit3D& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1126,7 +1133,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
+  int MarlinKalTestTrack::extrapolateToDetElement( int detElementID, edm4hep::TrackerHit3D& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1167,7 +1174,7 @@ namespace MarlinTrk {
     
   }
   
-  int MarlinKalTestTrack::propagate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ){
+  int MarlinKalTestTrack::propagate( const edm4hep::Vector3d& point, edm4hep::TrackerHit3D& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf ){
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1277,7 +1284,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::propagateToLayer( int layerID, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
+  int MarlinKalTestTrack::propagateToLayer( int layerID, edm4hep::TrackerHit3D& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1315,7 +1322,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::propagateToDetElement( int detElementID, edm4hep::TrackerHit& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
+  int MarlinKalTestTrack::propagateToDetElement( int detElementID, edm4hep::TrackerHit3D& trkhit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1353,7 +1360,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::intersectionWithDetElement( int detElementID,  edm4hep::TrackerHit& trkhit, edm4hep::Vector3d& point, int mode ) {
+  int MarlinKalTestTrack::intersectionWithDetElement( int detElementID,  edm4hep::TrackerHit3D& trkhit, edm4hep::Vector3d& point, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1420,7 +1427,7 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::intersectionWithLayer( int layerID,  edm4hep::TrackerHit& trkhit, edm4hep::Vector3d& point, int& detElementID, int mode ) {
+  int MarlinKalTestTrack::intersectionWithLayer( int layerID,  edm4hep::TrackerHit3D& trkhit, edm4hep::Vector3d& point, int& detElementID, int mode ) {
     
     TKalTrackSite* site = 0;
     int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -1668,9 +1675,9 @@ namespace MarlinTrk {
   }
   
   
-  int MarlinKalTestTrack::getSiteFromLCIOHit( edm4hep::TrackerHit& trkhit, TKalTrackSite*& site ) const {
+  int MarlinKalTestTrack::getSiteFromLCIOHit( edm4hep::TrackerHit3D& trkhit, TKalTrackSite*& site ) const {
     
-    std::map<edm4hep::TrackerHit,TKalTrackSite*>::const_iterator it;
+    std::map<edm4hep::TrackerHit3D,TKalTrackSite*>::const_iterator it;
     
     it = _hit_used_for_sites.find(trkhit) ;  
     

--- a/Service/TrackSystemSvc/src/MarlinKalTestTrack.h
+++ b/Service/TrackSystemSvc/src/MarlinKalTestTrack.h
@@ -49,17 +49,17 @@ namespace MarlinTrk{
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */
-    int addHit(edm4hep::TrackerHit& hit) ;
+    int addHit(edm4hep::TrackerHit3D& hit) ;
     
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */    
-    int addHit(edm4hep::TrackerHit& trkhit, const ILDVMeasLayer* ml) ;
+    int addHit(edm4hep::TrackerHit3D& trkhit, const ILDVMeasLayer* ml) ;
     
     /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
      *  this order will define the direction of the energy loss used in the fit
      */    
-    int addHit( edm4hep::TrackerHit& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) ;
+    int addHit( edm4hep::TrackerHit3D& trkhit, ILDVTrackHit* kalhit, const ILDVMeasLayer* ml) ;
     
     /** initialise the fit using the hits added up to this point -
      *  the fit direction has to be specified using IMarlinTrack::backward or IMarlinTrack::forward. 
@@ -90,13 +90,13 @@ namespace MarlinTrk{
     
     /** smooth track states from the last filtered hit back to the measurement site associated with the given hit 
      */
-    int smooth( edm4hep::TrackerHit& hit )  ;
+    int smooth( edm4hep::TrackerHit3D& hit )  ;
     
     
     /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from adding the hit via reference. 
      *  the given hit will not be added if chi2increment > maxChi2Increment. 
      */
-    int addAndFit( edm4hep::TrackerHit& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) ;
+    int addAndFit( edm4hep::TrackerHit3D& hit, double& chi2increment, double maxChi2Increment=DBL_MAX ) ;
     
     /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from adding the hit via reference. 
      *  the given hit will not be added if chi2increment > maxChi2Increment. 
@@ -106,7 +106,7 @@ namespace MarlinTrk{
     
     /** obtain the chi2 increment which would result in adding the hit to the fit. This method will not alter the current fit, and the hit will not be stored in the list of hits or outliers
      */
-    int testChi2Increment( edm4hep::TrackerHit& hit, double& chi2increment ) ;
+    int testChi2Increment( edm4hep::TrackerHit3D& hit, double& chi2increment ) ;
     
     
     // Track State Accessesors
@@ -118,7 +118,7 @@ namespace MarlinTrk{
     
     /** get track state at measurement associated with the given hit, returning TrackState, chi2 and ndf via reference 
      */
-    int getTrackState( edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
+    int getTrackState( edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
     
     
     /** get the list of hits included in the fit, together with the chi2 contributions of the hits. 
@@ -126,14 +126,14 @@ namespace MarlinTrk{
      *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
      *  the second.
      */
-    int getHitsInFit( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) ;
+    int getHitsInFit( std::vector<std::pair<edm4hep::TrackerHit3D, double> >& hits ) ;
     
     /** get the list of hits which have been rejected by from the fit due to the a chi2 increment greater than threshold,
      *  Pointers to the hits together with their chi2 contribution will be filled into a vector of 
      *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
      *  the second.
      */
-    int getOutliers( std::vector<std::pair<edm4hep::TrackerHit, double> >& hits ) ;
+    int getOutliers( std::vector<std::pair<edm4hep::TrackerHit3D, double> >& hits ) ;
     
     
     /** get the current number of degrees of freedom for the fit.
@@ -142,7 +142,7 @@ namespace MarlinTrk{
     
     /** get TrackeHit at which fit became constrained, i.e. ndf >= 0
      */
-    int getTrackerHitAtPositiveNDF( edm4hep::TrackerHit& trkhit ) ;
+    int getTrackerHitAtPositiveNDF( edm4hep::TrackerHit3D& trkhit ) ;
     
     // PROPAGATORS 
   
@@ -154,7 +154,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point,
      *  returning TrackState, chi2 and ndf via reference   
      */
-    int propagate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
+    int propagate( const edm4hep::Vector3d& point, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
     
     
     /** propagate the fit at the provided measurement site, to the point of closest approach to the given point,
@@ -170,7 +170,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
      */
-    int propagateToLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
+    int propagateToLayer( int layerID, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
     
     /** propagate the fit at the measurement site, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -184,7 +184,7 @@ namespace MarlinTrk{
     /** propagate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
      */
-    int propagateToDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
+    int propagateToDetElement( int detEementID, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
   
     /** propagate the fit at the measurement site, to sensitive detector element, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -202,7 +202,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to the point of closest approach to the given point, 
      *    returning TrackState, chi2 and ndf via reference   
      */
-    int extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
+    int extrapolate( const edm4hep::Vector3d& point, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf ) ;
     
     /** extrapolate the fit at the measurement site, to the point of closest approach to the given point, 
      *    returning TrackState, chi2 and ndf via reference   
@@ -216,7 +216,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
      */
-    int extrapolateToLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
+    int extrapolateToLayer( int layerID, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode=modeClosest )  ;
     
     /** extrapolate the fit at the measurement site, to numbered sensitive layer, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -230,7 +230,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element, 
      *  returning TrackState, chi2 and ndf via reference 
    */
-    int extrapolateToDetElement( int detEementID, edm4hep::TrackerHit& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
+    int extrapolateToDetElement( int detEementID, edm4hep::TrackerHit3D& hit, edm4hep::TrackState& ts, double& chi2, int& ndf, int mode=modeClosest ) ;
     
     /** extrapolate the fit at the measurement site, to sensitive detector element, 
      *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference 
@@ -250,7 +250,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to numbered sensitive layer,
      *  returning intersection point in global coordinates and integer ID of the intersected sensitive detector element via reference 
      */
-    int intersectionWithLayer( int layerID, edm4hep::TrackerHit& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest )  ;
+    int intersectionWithLayer( int layerID, edm4hep::TrackerHit3D& hit, edm4hep::Vector3d& point, int& detElementID, int mode=modeClosest )  ;
     
     /** extrapolate the fit at the measurement site, to numbered sensitive layer,
      *  returning intersection point in global coordinates and integer ID of the intersected sensitive detector element via reference 
@@ -265,7 +265,7 @@ namespace MarlinTrk{
     /** extrapolate the fit at the measurement site associated with the given hit, to sensitive detector element,
      *  returning intersection point in global coordinates via reference 
      */ 
-    int intersectionWithDetElement( int detElementID, edm4hep::TrackerHit& hit, edm4hep::Vector3d& point, int mode=modeClosest )  ;
+    int intersectionWithDetElement( int detElementID, edm4hep::TrackerHit3D& hit, edm4hep::Vector3d& point, int mode=modeClosest )  ;
     
     /** extrapolate the fit at the measurement site, to sensitive detector element,
      *  returning intersection point in global coordinates via reference 
@@ -297,7 +297,7 @@ namespace MarlinTrk{
     
     /** get the measurement site associated with the given lcio TrackerHit trkhit
      */
-    int getSiteFromLCIOHit( edm4hep::TrackerHit& trkhit, TKalTrackSite*& site ) const ;
+    int getSiteFromLCIOHit( edm4hep::TrackerHit3D& trkhit, TKalTrackSite*& site ) const ;
     
     
     
@@ -314,13 +314,13 @@ namespace MarlinTrk{
     
     TKalTrack* _kaltrack;
     
-    std::vector<edm4hep::TrackerHit> _lcioHits ; 
+    std::vector<edm4hep::TrackerHit3D> _lcioHits ; 
     
     TObjArray* _kalhits;
     
     MarlinKalTest* _ktest;
   
-    edm4hep::TrackerHit _trackHitAtPositiveNDF;
+    edm4hep::TrackerHit3D _trackHitAtPositiveNDF;
     int _hitIndexAtPositiveNDF;
     
     /** used to store whether initial track state has been supplied or created 
@@ -338,23 +338,23 @@ namespace MarlinTrk{
     
     /** map to store relation between lcio hits and measurement sites
      */
-    std::map<edm4hep::TrackerHit, TKalTrackSite*> _hit_used_for_sites ;
+    std::map<edm4hep::TrackerHit3D, TKalTrackSite*> _hit_used_for_sites ;
   
     /** map to store relation between lcio hits kaltest hits
      */
-    std::map<edm4hep::TrackerHit, ILDVTrackHit*> _lcio_hits_to_kaltest_hits ;
+    std::map<edm4hep::TrackerHit3D, ILDVTrackHit*> _lcio_hits_to_kaltest_hits ;
     
     /** vector to store lcio hits rejected for measurement sites
      */
-    std::vector<edm4hep::TrackerHit> _hit_not_used_for_sites ;
+    std::vector<edm4hep::TrackerHit3D> _hit_not_used_for_sites ;
     
     /** vector to store the chi-sqaure increment for measurement sites
      */
-    std::vector< std::pair<edm4hep::TrackerHit, double> > _hit_chi2_values ;
+    std::vector< std::pair<edm4hep::TrackerHit3D, double> > _hit_chi2_values ;
     
     /** vector to store the chi-sqaure increment for measurement sites
      */
-    std::vector< std::pair<edm4hep::TrackerHit, double> > _outlier_chi2_values ;
+    std::vector< std::pair<edm4hep::TrackerHit3D, double> > _outlier_chi2_values ;
     
   } ;
 }

--- a/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
+++ b/Service/TrackSystemSvc/src/MarlinTrkUtils.cc
@@ -11,7 +11,14 @@
 //#include <IMPL/TrackImpl.h>
 //#include <IMPL/TrackStateImpl.h>
 //#include <EVENT/TrackerHit.h>
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "edm4hep/TrackState.h"
 #include "edm4hep/Track.h"
 #include "edm4hep/MutableTrack.h"
@@ -103,9 +110,9 @@ namespace MarlinTrk {
   
   
   
-  int createTrackStateAtCaloFace( IMarlinTrack* marlinTrk, edm4hep::TrackState* track, edm4hep::TrackerHit trkhit, bool tanL_is_positive );
+  int createTrackStateAtCaloFace( IMarlinTrack* marlinTrk, edm4hep::TrackState* track, edm4hep::TrackerHit3D trkhit, bool tanL_is_positive );
   
-    int createFinalisedLCIOTrack( IMarlinTrack* marlinTrk, std::vector<edm4hep::TrackerHit>& hit_list, edm4hep::MutableTrack* track, bool fit_backwards, const decltype(edm4hep::TrackState::covMatrix)& initial_cov_for_prefit, float bfield_z, double maxChi2Increment){
+    int createFinalisedLCIOTrack( IMarlinTrack* marlinTrk, std::vector<edm4hep::TrackerHit3D>& hit_list, edm4hep::MutableTrack* track, bool fit_backwards, const decltype(edm4hep::TrackState::covMatrix)& initial_cov_for_prefit, float bfield_z, double maxChi2Increment){
     
     ///////////////////////////////////////////////////////
     // check inputs 
@@ -142,7 +149,7 @@ namespace MarlinTrk {
     return return_error;
   }
   
-  int createFinalisedLCIOTrack( IMarlinTrack* marlinTrk, std::vector<edm4hep::TrackerHit>& hit_list, edm4hep::MutableTrack* track, bool fit_backwards, edm4hep::TrackState* pre_fit, float bfield_z, double maxChi2Increment){
+  int createFinalisedLCIOTrack( IMarlinTrack* marlinTrk, std::vector<edm4hep::TrackerHit3D>& hit_list, edm4hep::MutableTrack* track, bool fit_backwards, edm4hep::TrackState* pre_fit, float bfield_z, double maxChi2Increment){
     
     
     ///////////////////////////////////////////////////////
@@ -174,7 +181,7 @@ namespace MarlinTrk {
   
   
   
-  int createFit( std::vector<edm4hep::TrackerHit>& hit_list, IMarlinTrack* marlinTrk, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards, double maxChi2Increment){
+  int createFit( std::vector<edm4hep::TrackerHit3D>& hit_list, IMarlinTrack* marlinTrk, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards, double maxChi2Increment){
     
     
     ///////////////////////////////////////////////////////
@@ -213,17 +220,17 @@ namespace MarlinTrk {
     // add hits to IMarlinTrk  
     ///////////////////////////////////////////////////////
     
-    std::vector<edm4hep::TrackerHit>::iterator it = hit_list.begin();
+    std::vector<edm4hep::TrackerHit3D>::iterator it = hit_list.begin();
     
     //  start by trying to add the hits to the track we want to finally use. 
     //std::cout << "MarlinTrk::createFit Start Fit: AddHits: number of hits to fit " << hit_list.size() << std::endl;
     
-    std::vector<edm4hep::TrackerHit> added_hits;
+    std::vector<edm4hep::TrackerHit3D> added_hits;
     unsigned int ndof_added = 0;
     
     for( it = hit_list.begin() ; it != hit_list.end() ; ++it ) {
       
-      edm4hep::TrackerHit trkHit = *it;
+      edm4hep::TrackerHit3D trkHit = *it;
       bool isSuccessful = false;
       //std::cout << "debug: TrackerHit pointer " << trkHit << std::endl;
       if( UTIL::BitSet32( trkHit.getType() )[ UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT ]   ){ //it is a composite spacepoint        
@@ -233,7 +240,7 @@ namespace MarlinTrk {
 	//exit(1);
         int nRawHit = trkHit.rawHits_size();
         for( unsigned k=0; k< nRawHit; k++ ){
-          edm4hep::TrackerHit rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
+          edm4hep::TrackerHit3D rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
 	  if( marlinTrk->addHit( rawHit ) == IMarlinTrack::success ){
 	    isSuccessful = true; //if at least one hit from the spacepoint gets added
             ++ndof_added;
@@ -292,7 +299,7 @@ namespace MarlinTrk {
   
   
   
-  int createPrefit( std::vector<edm4hep::TrackerHit>& hit_list, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards){
+  int createPrefit( std::vector<edm4hep::TrackerHit3D>& hit_list, edm4hep::TrackState* pre_fit, float bfield_z, bool fit_backwards){
     
     ///////////////////////////////////////////////////////
     // check inputs 
@@ -307,7 +314,7 @@ namespace MarlinTrk {
     // loop over all the hits and create a list consisting only 2D hits 
     ///////////////////////////////////////////////////////
     
-    std::vector<edm4hep::TrackerHit> twoD_hits;
+    std::vector<edm4hep::TrackerHit3D> twoD_hits;
     
     for (unsigned ihit=0; ihit < hit_list.size(); ++ihit) {
       
@@ -362,7 +369,7 @@ namespace MarlinTrk {
     
   }
   
-  int finaliseLCIOTrack( IMarlinTrack* marlintrk, edm4hep::MutableTrack* track, std::vector<edm4hep::TrackerHit>& hit_list, edm4hep::TrackState* atLastHit, edm4hep::TrackState* atCaloFace){
+  int finaliseLCIOTrack( IMarlinTrack* marlintrk, edm4hep::MutableTrack* track, std::vector<edm4hep::TrackerHit3D>& hit_list, edm4hep::TrackState* atLastHit, edm4hep::TrackState* atCaloFace){
     
     ///////////////////////////////////////////////////////
     // check inputs 
@@ -417,9 +424,9 @@ namespace MarlinTrk {
     // add these to the track, add spacepoints as long as at least on strip hit is used.  
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
     
-    std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
-    std::vector<std::pair<edm4hep::TrackerHit, double> > outliers;
-    std::vector<edm4hep::TrackerHit> used_hits;
+    std::vector<std::pair<edm4hep::TrackerHit3D, double> > hits_in_fit;
+    std::vector<std::pair<edm4hep::TrackerHit3D, double> > outliers;
+    std::vector<edm4hep::TrackerHit3D> used_hits;
         
     hits_in_fit.reserve(300);
     outliers.reserve(300);
@@ -435,7 +442,7 @@ namespace MarlinTrk {
     
     for ( unsigned ihit = 0; ihit < hit_list.size(); ++ihit) {
       
-      edm4hep::TrackerHit trkHit = hit_list[ihit];
+      edm4hep::TrackerHit3D trkHit = hit_list[ihit];
       
       if( UTIL::BitSet32( trkHit.getType() )[ UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT ]   ){ //it is a composite spacepoint
 	//std::cout << "Error: space point is not still valid! pelease wait updating..." <<std::endl;
@@ -443,7 +450,7 @@ namespace MarlinTrk {
 	// get strip hits 
         int nRawHit = trkHit.rawHits_size();
         for( unsigned k=0; k< nRawHit; k++ ){
-	  edm4hep::TrackerHit rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
+	  edm4hep::TrackerHit3D rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
 	  bool is_outlier = false;
 	  // here we loop over outliers as this will be faster than looping over the used hits
           for ( unsigned ohit = 0; ohit < outliers.size(); ++ohit) {
@@ -487,7 +494,7 @@ namespace MarlinTrk {
     ///////////////////////////////////////////////////////
     
     edm4hep::TrackState* trkStateAtFirstHit = new edm4hep::TrackState() ;
-    edm4hep::TrackerHit firstHit = hits_in_fit.back().first;
+    edm4hep::TrackerHit3D firstHit = hits_in_fit.back().first;
 
     ///////////////////////////////////////////////////////
     // last hit
@@ -495,12 +502,12 @@ namespace MarlinTrk {
     
     edm4hep::TrackState* trkStateAtLastHit = new edm4hep::TrackState() ;
 
-    edm4hep::TrackerHit lastHit = hits_in_fit.front().first;
+    edm4hep::TrackerHit3D lastHit = hits_in_fit.front().first;
           
 #if PODIO_BUILD_VERSION < PODIO_VERSION(0, 17, 4)
-    edm4hep::TrackerHit last_constrained_hit(0);// = 0 ;
+    edm4hep::TrackerHit3D last_constrained_hit(0);// = 0 ;
 #else
-		auto last_constrained_hit = edm4hep::TrackerHit::makeEmpty();
+		auto last_constrained_hit = edm4hep::TrackerHit3D::makeEmpty();
 #endif
     marlintrk->getTrackerHitAtPositiveNDF(last_constrained_hit);
 
@@ -636,7 +643,7 @@ namespace MarlinTrk {
   }
   
   
-  int createTrackStateAtCaloFace( IMarlinTrack* marlintrk, edm4hep::TrackState* trkStateCalo, edm4hep::TrackerHit trkhit, bool tanL_is_positive ){
+  int createTrackStateAtCaloFace( IMarlinTrack* marlintrk, edm4hep::TrackState* trkStateCalo, edm4hep::TrackerHit3D trkhit, bool tanL_is_positive ){
     
     //streamlog_out( DEBUG5 ) << "  >>>>>>>>>>> createTrackStateAtCaloFace : using trkhit " << trkhit << " tanL_is_positive = " << tanL_is_positive << std::endl ;
     
@@ -691,7 +698,7 @@ namespace MarlinTrk {
     
   }
   
-  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<edm4hep::TrackerHit>& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder){
+  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<edm4hep::TrackerHit3D>& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder){
     
     ///////////////////////////////////////////////////////
     // check inputs 
@@ -743,7 +750,7 @@ namespace MarlinTrk {
     //track->subdetectorHitNumbers()[ 2 * lcio::ILDDetID::ETD - offset ] = hitNumbers[lcio::ILDDetID::ETD];
   }
   
-  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<std::pair<edm4hep::TrackerHit , double> >& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder){
+  void addHitNumbersToTrack(edm4hep::MutableTrack* track, std::vector<std::pair<edm4hep::TrackerHit3D , double> >& hit_list, bool hits_in_fit, UTIL::BitField64& cellID_encoder){
     
     ///////////////////////////////////////////////////////
     // check inputs 

--- a/Utilities/DataHelper/include/DataHelper/Navigation.h
+++ b/Utilities/DataHelper/include/DataHelper/Navigation.h
@@ -2,7 +2,14 @@
 #define Navigation_h
 
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
 #include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+} // namespace edm4hep
+#endif
 #include <map>
 
 #if __has_include("edm4hep/EDM4hepVersion.h")
@@ -23,25 +30,25 @@ class Navigation{
   
   void Initialize();
   //void AddDataHandle(DataHandle* hdl){if(hdl)m_hdlVec.push_back(hdl);};
-  void AddTrackerHitCollection(const edm4hep::TrackerHitCollection* col){m_hitColVec.push_back(col);};
+  void AddTrackerHitCollection(const edm4hep::TrackerHit3DCollection* col){m_hitColVec.push_back(col);};
   void AddTrackerAssociationCollection(const edm4hep::MCRecoTrackerAssociationCollection* col){m_assColVec.push_back(col);};
 
 #if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 5)
-  edm4hep::TrackerHit GetTrackerHit(const edm4hep::ObjectID& id, bool delete_by_caller=true);
+  edm4hep::TrackerHit3D GetTrackerHit(const edm4hep::ObjectID& id, bool delete_by_caller=true);
   std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::ObjectID& id);
 #else
-  edm4hep::TrackerHit GetTrackerHit(const podio::ObjectID& id, bool delete_by_caller=true);
+  edm4hep::TrackerHit3D GetTrackerHit(const podio::ObjectID& id, bool delete_by_caller=true);
   std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const podio::ObjectID& id);
 #endif
-  std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::TrackerHit& hit);
-  std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::TrackerHit& hit, const edm4hep::MCRecoTrackerAssociationCollection* col);
+  std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::TrackerHit3D& hit);
+  std::vector<edm4hep::SimTrackerHit> GetRelatedTrackerHit(const edm4hep::TrackerHit3D& hit, const edm4hep::MCRecoTrackerAssociationCollection* col);
   
   //static Navigation* m_fNavigation;
  private:
   static Navigation* m_fNavigation;
   //DataHandle<edm4hep::MCRecoTrackerAssociationCollection> _inHitAssColHdl{"FTDStripTrackerHitsAssociation", Gaudi::DataHandle::Reader, this};
-  std::vector<const edm4hep::TrackerHitCollection*> m_hitColVec;
+  std::vector<const edm4hep::TrackerHit3DCollection*> m_hitColVec;
   std::vector<const edm4hep::MCRecoTrackerAssociationCollection*> m_assColVec;
-  std::map<int, edm4hep::TrackerHit> m_trkHits;
+  std::map<int, edm4hep::TrackerHit3D> m_trkHits;
 };
 #endif 

--- a/Utilities/DataHelper/include/DataHelper/TrackerHitExtended.h
+++ b/Utilities/DataHelper/include/DataHelper/TrackerHitExtended.h
@@ -3,7 +3,14 @@
 
 //#include "lcio.h"
 //#include "EVENT/LCIO.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 //#include "TrackExtended.h"
 #include <vector>
 
@@ -24,14 +31,14 @@ class TrackerHitExtended {
   
  public:
   
-  TrackerHitExtended(const edm4hep::TrackerHit trackerhit);
+  TrackerHitExtended(const edm4hep::TrackerHit3D trackerhit);
   ~TrackerHitExtended();
   void setTrackExtended(TrackExtended * trackAR);
     void addTrackExtended(TrackExtended * trackAR);
     void setTrackerHitTo(TrackerHitExtended * hitTo);
     void setTrackerHitFrom(TrackerHitExtended * hitFrom);
     void setGenericDistance(float genericDistance);
-    //void setTrackerHit(edm4hep::TrackerHit hit);
+    //void setTrackerHit(edm4hep::TrackerHit3D hit);
     void setYresTo(float yresTo);
     void setYresFrom(float yresFrom);
     void setDirVec(float * dirVec);
@@ -42,7 +49,7 @@ class TrackerHitExtended {
     void setDet(int idet);
     void setUsedInFit(bool usedInFit);
 
-    edm4hep::TrackerHit getTrackerHit();
+    edm4hep::TrackerHit3D getTrackerHit();
     TrackExtended * getTrackExtended();
     TrackExtendedVec & getTrackExtendedVec();
     TrackerHitExtended * getTrackerHitFrom();
@@ -59,7 +66,7 @@ class TrackerHitExtended {
 
  private:
 
-    edm4hep::TrackerHit _trackerHit;
+    edm4hep::TrackerHit3D _trackerHit;
     TrackExtended * _trackAR;
     TrackerHitExtended * _hitTo;
     TrackerHitExtended * _hitFrom;

--- a/Utilities/DataHelper/include/DataHelper/TrackerHitHelper.h
+++ b/Utilities/DataHelper/include/DataHelper/TrackerHitHelper.h
@@ -1,7 +1,14 @@
 #ifndef TrackerHitHelper_H
 #define TrackerHitHelper_H
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "edm4hep/SimTrackerHit.h"
 #include "edm4hep/MCRecoTrackerAssociationCollection.h"
 #include "DDSegmentation/Segmentation.h"
@@ -16,13 +23,13 @@
 //}
 
 namespace CEPC{
-  std::array<float, 6> GetCovMatrix(edm4hep::TrackerHit& hit, bool useSpacePointerBuilderMethod = false);
-  float                GetResolutionRPhi(edm4hep::TrackerHit& hit);
-  float                GetResolutionZ(edm4hep::TrackerHit& hit);
+  std::array<float, 6> GetCovMatrix(edm4hep::TrackerHit3D& hit, bool useSpacePointerBuilderMethod = false);
+  float                GetResolutionRPhi(edm4hep::TrackerHit3D& hit);
+  float                GetResolutionZ(edm4hep::TrackerHit3D& hit);
   std::array<float, 6> ConvertToCovXYZ(float dU, float thetaU, float phiU, float dV, float thetaV, float phiV, bool useSpacePointBuilderMethod = false);
   const edm4hep::SimTrackerHit getAssoClosestSimTrackerHit(
           const edm4hep::MCRecoTrackerAssociationCollection* assoHits,
-          const edm4hep::TrackerHit trackerHit,
+          const edm4hep::TrackerHit3D trackerHit,
           const dd4hep::DDSegmentation::GridDriftChamber* segmentation,
           int docaMehtod);
 }

--- a/Utilities/DataHelper/src/Navigation.cpp
+++ b/Utilities/DataHelper/src/Navigation.cpp
@@ -1,7 +1,14 @@
 #include "DataHelper/Navigation.h"
 
 #include "edm4hep/SimTrackerHit.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 Navigation* Navigation::m_fNavigation = nullptr;
 
@@ -19,16 +26,16 @@ Navigation::~Navigation(){
 void Navigation::Initialize(){
   m_hitColVec.clear();
   m_assColVec.clear();
-  for(std::map<int, edm4hep::TrackerHit>::iterator it=m_trkHits.begin();it!=m_trkHits.end();it++){
+  for(std::map<int, edm4hep::TrackerHit3D>::iterator it=m_trkHits.begin();it!=m_trkHits.end();it++){
     // delete it->second;
   }
   m_trkHits.clear();
 }
 
 #if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 5)
-edm4hep::TrackerHit Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_id, bool delete_by_caller){
+edm4hep::TrackerHit3D Navigation::GetTrackerHit(const edm4hep::ObjectID& obj_id, bool delete_by_caller){
 #else
-edm4hep::TrackerHit Navigation::GetTrackerHit(const podio::ObjectID& obj_id, bool delete_by_caller){
+edm4hep::TrackerHit3D Navigation::GetTrackerHit(const podio::ObjectID& obj_id, bool delete_by_caller){
 #endif
   int id = obj_id.collectionID * 10000000 + obj_id.index;
   if(!delete_by_caller){
@@ -51,7 +58,7 @@ edm4hep::TrackerHit Navigation::GetTrackerHit(const podio::ObjectID& obj_id, boo
       auto this_id = hit.getObjectID();
       if(this_id.collectionID!=obj_id.collectionID)break;
       else if(this_id.index==obj_id.index){
-	edm4hep::TrackerHit hit_copy = edm4hep::TrackerHit(hit);
+	edm4hep::TrackerHit3D hit_copy = edm4hep::TrackerHit3D(hit);
 	if(!delete_by_caller) m_trkHits[id] = hit_copy;
 	return hit_copy;//&(m_trkHits[id]);
       }
@@ -77,7 +84,7 @@ std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const podio
   return hits;
 }
 
-std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::TrackerHit& hit){
+std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::TrackerHit3D& hit){
   std::vector<edm4hep::SimTrackerHit> hits;
   for(int i=0;i<m_assColVec.size();i++){
     for(auto ass : *m_assColVec[i]){
@@ -88,7 +95,7 @@ std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4h
   return hits;
 }
 
-std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::TrackerHit& hit, const edm4hep::MCRecoTrackerAssociationCollection* col){
+std::vector<edm4hep::SimTrackerHit> Navigation::GetRelatedTrackerHit(const edm4hep::TrackerHit3D& hit, const edm4hep::MCRecoTrackerAssociationCollection* col){
   std::vector<edm4hep::SimTrackerHit> hits;
   for(auto ass : *col){
     if(ass.getRec().getObjectID().collectionID != hit.getObjectID().collectionID) break;

--- a/Utilities/DataHelper/src/TrackerHitExtended.cc
+++ b/Utilities/DataHelper/src/TrackerHitExtended.cc
@@ -1,7 +1,7 @@
 #include "DataHelper/TrackExtended.h"
 #include "DataHelper/TrackerHitExtended.h"
 
-TrackerHitExtended::TrackerHitExtended(const edm4hep::TrackerHit trackerhit):
+TrackerHitExtended::TrackerHitExtended(const edm4hep::TrackerHit3D trackerhit):
   _trackerHit(trackerhit){
   _trackAR = NULL;
   _trackVecAR.clear();
@@ -41,7 +41,7 @@ void TrackerHitExtended::setGenericDistance(float genericDistance) {
     _genericDistance = genericDistance; 
 }
 
-//void TrackerHitExtended::setTrackerHit(edm4hep::TrackerHit hit) {
+//void TrackerHitExtended::setTrackerHit(edm4hep::TrackerHit3D hit) {
 //    _trackerHit = hit;
 //}
 
@@ -67,7 +67,7 @@ void TrackerHitExtended::setDet(int idet) {
     _idet = idet;
 }
 
-edm4hep::TrackerHit TrackerHitExtended::getTrackerHit() {
+edm4hep::TrackerHit3D TrackerHitExtended::getTrackerHit() {
     return _trackerHit;
 }
 

--- a/Utilities/DataHelper/src/TrackerHitHelper.cpp
+++ b/Utilities/DataHelper/src/TrackerHitHelper.cpp
@@ -10,7 +10,7 @@
 #include "TVector3.h"
 #include "DD4hep/DD4hepUnits.h"
 
-std::array<float,6> CEPC::GetCovMatrix(edm4hep::TrackerHit& hit, bool useSpacePointBuilderMethod){
+std::array<float,6> CEPC::GetCovMatrix(edm4hep::TrackerHit3D& hit, bool useSpacePointBuilderMethod){
   if(hit.isAvailable()){
     int type = hit.getType();
     if(std::bitset<32>(type)[CEPCConf::TrkHitTypeBit::COMPOSITE_SPACEPOINT]){
@@ -34,7 +34,7 @@ std::array<float,6> CEPC::GetCovMatrix(edm4hep::TrackerHit& hit, bool useSpacePo
   return cov;
 }
 
-float CEPC::GetResolutionRPhi(edm4hep::TrackerHit& hit){
+float CEPC::GetResolutionRPhi(edm4hep::TrackerHit3D& hit){
   if(hit.isAvailable()){
     int type = hit.getType();
     if(std::bitset<32>(type)[CEPCConf::TrkHitTypeBit::COMPOSITE_SPACEPOINT]){
@@ -51,7 +51,7 @@ float CEPC::GetResolutionRPhi(edm4hep::TrackerHit& hit){
   return 0.;
 }
 
-float CEPC::GetResolutionZ(edm4hep::TrackerHit& hit){
+float CEPC::GetResolutionZ(edm4hep::TrackerHit3D& hit){
   if(hit.isAvailable()){
     int type = hit.getType();
     if(std::bitset<32>(type)[CEPCConf::TrkHitTypeBit::COMPOSITE_SPACEPOINT]){
@@ -120,7 +120,7 @@ std::array<float, 6> CEPC::ConvertToCovXYZ(float dU, float thetaU, float phiU, f
 
 const edm4hep::SimTrackerHit CEPC::getAssoClosestSimTrackerHit(
         const edm4hep::MCRecoTrackerAssociationCollection* assoHits,
-        const edm4hep::TrackerHit trackerHit,
+        const edm4hep::TrackerHit3D trackerHit,
         const dd4hep::DDSegmentation::GridDriftChamber* segmentation,
         int docaMehtod)
 {

--- a/Utilities/KalDet/include/kaldet/ILDConeMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDConeMeasLayer.h
@@ -21,7 +21,14 @@
 #include "iostream"
 /* #include "streamlog/streamlog.h" */
 #include "UTIL/ILDConf.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 class ILDConeMeasLayer : public ILDVMeasLayer, public TCutCone {
 public:
@@ -60,7 +67,7 @@ public:
    Bool_t IsOnSurface(const TVector3 &xx) const;
 
    /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
-   virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+   virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
       
       /* streamlog_out( ERROR ) << "Don't use this, it's not implemented!"; */
       return NULL;

--- a/Utilities/KalDet/include/kaldet/ILDCylinderHit.h
+++ b/Utilities/KalDet/include/kaldet/ILDCylinderHit.h
@@ -17,7 +17,7 @@ public:
   
   /** Constructor Taking R and Rphi coordinates and associated measurement layer, with bfield */
   ILDCylinderHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-                 Double_t bfield, edm4hep::TrackerHit trkhit ) 
+                 Double_t bfield, edm4hep::TrackerHit3D trkhit ) 
   : ILDVTrackHit(ms, x, dx, bfield, 2, trkhit)
   { /* no op */ } 
     

--- a/Utilities/KalDet/include/kaldet/ILDCylinderMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDCylinderMeasLayer.h
@@ -71,7 +71,7 @@ public:
                                 TKalMatrix &H)    const;
   
   /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
   /** Get the intersection and the CellID, needed for multilayers */
   virtual int getIntersectionAndCellID(const TVTrack  &hel,

--- a/Utilities/KalDet/include/kaldet/ILDDiscMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDDiscMeasLayer.h
@@ -70,7 +70,7 @@ public:
     
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
   /** Check if global point is on surface  */
   inline virtual Bool_t   IsOnSurface (const TVector3 &xx) const;

--- a/Utilities/KalDet/include/kaldet/ILDParallelPlanarStripMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDParallelPlanarStripMeasLayer.h
@@ -50,7 +50,7 @@ public:
   
   void CalcDhDa(const TVTrackHit &vht, const TVector3   &xxv, const TKalMatrix &dxphiada, TKalMatrix &H)  const;
     
-  ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const;
+  ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const;
   
 private:
   

--- a/Utilities/KalDet/include/kaldet/ILDPlanarHit.h
+++ b/Utilities/KalDet/include/kaldet/ILDPlanarHit.h
@@ -21,7 +21,7 @@ public:
                Double_t           *x,
                Double_t           *dx,
                Double_t           bfield,
-               edm4hep::TrackerHit trkhit) 
+               edm4hep::TrackerHit3D trkhit) 
   : ILDVTrackHit(ms, x, dx, bfield, ILDPlanarHit_DIM,trkhit)
   { /* no op */ } 
   

--- a/Utilities/KalDet/include/kaldet/ILDPlanarMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDPlanarMeasLayer.h
@@ -63,7 +63,7 @@ public:
                                 const TKalMatrix &dxphiada,
                                 TKalMatrix &H)  const;
   
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
   virtual Bool_t   IsOnSurface (const TVector3 &xx) const;
   

--- a/Utilities/KalDet/include/kaldet/ILDPlanarStripHit.h
+++ b/Utilities/KalDet/include/kaldet/ILDPlanarStripHit.h
@@ -22,7 +22,7 @@ public:
                Double_t       *x,
                Double_t       *dx,
                Double_t        bfield,
-               edm4hep::TrackerHit trkhit) 
+               edm4hep::TrackerHit3D trkhit) 
   : ILDVTrackHit(ms, x, dx, bfield, ILDPlanarStripHit_DIM,trkhit)
   { /* no op */ } 
   

--- a/Utilities/KalDet/include/kaldet/ILDPolygonBarrelMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDPolygonBarrelMeasLayer.h
@@ -70,7 +70,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
 
   /** overloaded version of CalcXingPointWith using closed solution*/
   virtual Int_t    CalcXingPointWith(const TVTrack  &hel,

--- a/Utilities/KalDet/include/kaldet/ILDRotatedTrapMeaslayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDRotatedTrapMeaslayer.h
@@ -57,7 +57,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
   /** Check if global point is on surface  */
   inline virtual Bool_t   IsOnSurface (const TVector3 &xx) const;

--- a/Utilities/KalDet/include/kaldet/ILDSegmentedDiscMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDSegmentedDiscMeasLayer.h
@@ -77,7 +77,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
 
   /** overloaded version of CalcXingPointWith using closed solution*/
   virtual Int_t    CalcXingPointWith(const TVTrack  &hel,

--- a/Utilities/KalDet/include/kaldet/ILDSegmentedDiscStripMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDSegmentedDiscStripMeasLayer.h
@@ -67,7 +67,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
 private:
   

--- a/Utilities/KalDet/include/kaldet/ILDVMeasLayer.h
+++ b/Utilities/KalDet/include/kaldet/ILDVMeasLayer.h
@@ -13,7 +13,14 @@
 #include "kaltest/TAttDrawable.h"
 #include "kaltest/KalTrackDim.h"
 #include "TString.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 #include <vector>
 
@@ -44,7 +51,7 @@ public:
   inline Double_t GetBz() const { return _Bz; }
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const = 0 ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const = 0 ;
   
   /** Check whether the measurement layer represents a series of detector elements */
   bool isMultilayer() const { return _isMultiLayer; } 

--- a/Utilities/KalDet/include/kaldet/ILDVTrackHit.h
+++ b/Utilities/KalDet/include/kaldet/ILDVTrackHit.h
@@ -11,7 +11,14 @@
 
 #include "ILDVMeasLayer.h"
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 class ILDVTrackHit : public TVTrackHit {
   
@@ -19,15 +26,15 @@ public:
   
    /** Constructor Taking coordinates and associated measurement layer, with bfield and number of measurement dimentions*/
   ILDVTrackHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-               Double_t bfield , Int_t dim, edm4hep::TrackerHit trkhit) 
+               Double_t bfield , Int_t dim, edm4hep::TrackerHit3D trkhit) 
   : TVTrackHit(ms, x, dx, bfield, dim), _trkhit(trkhit)
   { /* no op */ }
   
-  edm4hep::TrackerHit getLCIOTrackerHit() const { return _trkhit; }
+  edm4hep::TrackerHit3D getLCIOTrackerHit() const { return _trkhit; }
   
 private:
   
-  edm4hep::TrackerHit _trkhit;
+  edm4hep::TrackerHit3D _trkhit;
   
 };
 #endif

--- a/Utilities/KalDet/src/ild/common/ILDConeMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDConeMeasLayer.h
@@ -21,7 +21,14 @@
 #include "iostream"
 /* #include "streamlog/streamlog.h" */
 #include "UTIL/ILDConf.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 class ILDConeMeasLayer : public ILDVMeasLayer, public TCutCone {
 public:
@@ -60,7 +67,7 @@ public:
    Bool_t IsOnSurface(const TVector3 &xx) const;
 
    /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
-   virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+   virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
       
       /* streamlog_out( ERROR ) << "Don't use this, it's not implemented!"; */
       return NULL;

--- a/Utilities/KalDet/src/ild/common/ILDCylinderHit.h
+++ b/Utilities/KalDet/src/ild/common/ILDCylinderHit.h
@@ -17,7 +17,7 @@ public:
   
   /** Constructor Taking R and Rphi coordinates and associated measurement layer, with bfield */
   ILDCylinderHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-                 Double_t bfield, edm4hep::TrackerHit trkhit ) 
+                 Double_t bfield, edm4hep::TrackerHit3D trkhit ) 
   : ILDVTrackHit(ms, x, dx, bfield, 2, trkhit)
   { /* no op */ } 
     

--- a/Utilities/KalDet/src/ild/common/ILDCylinderMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDCylinderMeasLayer.cc
@@ -10,7 +10,14 @@
 #include "ILDCylinderHit.h"
 
 #include <lcio.h>
-#include <edm4hep/TrackerHit.h>
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
+#include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 //#include <EVENT/TrackerHitZCylinder.h>
 
 #include "GaudiKernel/CommonMessaging.h"
@@ -110,7 +117,7 @@ void ILDCylinderMeasLayer::CalcDhDa(const TVTrackHit &vht, // tracker hit not us
 
 /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
 
-ILDVTrackHit* ILDCylinderMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+ILDVTrackHit* ILDCylinderMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
   if ( ! trkhit.isAvailable() ) {
     // streamlog_out(ERROR) << "ILDCylinderMeasLayer::ConvertLCIOTrkHit trkhit pointer is NULL" << std::endl;
     return NULL;

--- a/Utilities/KalDet/src/ild/common/ILDCylinderMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDCylinderMeasLayer.h
@@ -71,7 +71,7 @@ public:
                                 TKalMatrix &H)    const;
   
   /** Convert LCIO Tracker Hit to an ILDCylinderHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
   /** Get the intersection and the CellID, needed for multilayers */
   virtual int getIntersectionAndCellID(const TVTrack  &hel,

--- a/Utilities/KalDet/src/ild/common/ILDDiscMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDDiscMeasLayer.cc
@@ -12,7 +12,14 @@
 #include "TNode.h"
 #include "TString.h"
 
-#include <edm4hep/TrackerHit.h>
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
+#include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 #include "gearimpl/Vector3D.h"
 
@@ -207,13 +214,13 @@ Bool_t ILDDiscMeasLayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDDiscMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+ILDVTrackHit* ILDDiscMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
   
-  //edm4hep::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
-  //edm4hep::TrackerHitPlane* plane_hit = trkhit;
+  //edm4hep::TrackerHit3DPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
+  //edm4hep::TrackerHit3DPlane* plane_hit = trkhit;
   if((trkhit.getType()&8)!=8) return NULL;
   
-  //edm4hep::TrackerHit plane_hit = trkhit;
+  //edm4hep::TrackerHit3D plane_hit = trkhit;
   //if( plane_hit == NULL )  return NULL; // SJA:FIXME: should be replaced with an exception  
   
   //gear::Vector3D U(1.0,plane_hit.getU()[1],plane_hit.getU()[0],gear::Vector3D::spherical);

--- a/Utilities/KalDet/src/ild/common/ILDDiscMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDDiscMeasLayer.h
@@ -70,7 +70,7 @@ public:
     
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
   /** Check if global point is on surface  */
   inline virtual Bool_t   IsOnSurface (const TVector3 &xx) const;

--- a/Utilities/KalDet/src/ild/common/ILDParallelPlanarStripMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDParallelPlanarStripMeasLayer.cc
@@ -162,7 +162,7 @@ void ILDParallelPlanarStripMeasLayer::CalcDhDa(const TVTrackHit &vht,
   
 }
 
-ILDVTrackHit* ILDParallelPlanarStripMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+ILDVTrackHit* ILDParallelPlanarStripMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
   
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8) {

--- a/Utilities/KalDet/src/ild/common/ILDParallelPlanarStripMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDParallelPlanarStripMeasLayer.h
@@ -50,7 +50,7 @@ public:
   
   void CalcDhDa(const TVTrackHit &vht, const TVector3   &xxv, const TKalMatrix &dxphiada, TKalMatrix &H)  const;
     
-  ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const;
+  ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const;
   
 private:
   

--- a/Utilities/KalDet/src/ild/common/ILDPlanarHit.h
+++ b/Utilities/KalDet/src/ild/common/ILDPlanarHit.h
@@ -21,7 +21,7 @@ public:
                Double_t           *x,
                Double_t           *dx,
                Double_t           bfield,
-               edm4hep::TrackerHit trkhit) 
+               edm4hep::TrackerHit3D trkhit) 
   : ILDVTrackHit(ms, x, dx, bfield, ILDPlanarHit_DIM,trkhit)
   { /* no op */ } 
   

--- a/Utilities/KalDet/src/ild/common/ILDPlanarMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDPlanarMeasLayer.cc
@@ -244,7 +244,7 @@ Bool_t ILDPlanarMeasLayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDPlanarMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+ILDVTrackHit* ILDPlanarMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
   //std::cout << "ILDPlanarMeasLayer::ConvertLCIOTrkHit " << trkhit << " type=" << trkhit.getType() << std::endl;
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8){

--- a/Utilities/KalDet/src/ild/common/ILDPlanarMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDPlanarMeasLayer.h
@@ -63,7 +63,7 @@ public:
                                 const TKalMatrix &dxphiada,
                                 TKalMatrix &H)  const;
   
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
   virtual Bool_t   IsOnSurface (const TVector3 &xx) const;
   

--- a/Utilities/KalDet/src/ild/common/ILDPlanarStripHit.h
+++ b/Utilities/KalDet/src/ild/common/ILDPlanarStripHit.h
@@ -22,7 +22,7 @@ public:
                Double_t       *x,
                Double_t       *dx,
                Double_t        bfield,
-               edm4hep::TrackerHit trkhit) 
+               edm4hep::TrackerHit3D trkhit) 
   : ILDVTrackHit(ms, x, dx, bfield, ILDPlanarStripHit_DIM,trkhit)
   { /* no op */ } 
   

--- a/Utilities/KalDet/src/ild/common/ILDPolygonBarrelMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDPolygonBarrelMeasLayer.cc
@@ -13,7 +13,14 @@
 #include "TString.h"
 
 //#include <EVENT/TrackerHitPlane.h>
-#include <edm4hep/TrackerHit.h>
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
+#include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 #include <math.h>
 #include <assert.h>
@@ -136,7 +143,7 @@ Bool_t ILDPolygonBarrelMeasLayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDPolygonBarrelMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+ILDVTrackHit* ILDPolygonBarrelMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
   
   // streamlog_out(ERROR) << "ILDPolygonBarrelMeasLayer::ConvertLCIOTrkHit Not implemented: exit(1) called from " << __FILE__ << "   line " << __LINE__ << std::endl; 
   exit(1);

--- a/Utilities/KalDet/src/ild/common/ILDPolygonBarrelMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDPolygonBarrelMeasLayer.h
@@ -70,7 +70,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
 
   /** overloaded version of CalcXingPointWith using closed solution*/
   virtual Int_t    CalcXingPointWith(const TVTrack  &hel,

--- a/Utilities/KalDet/src/ild/common/ILDRotatedTrapMeaslayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDRotatedTrapMeaslayer.cc
@@ -155,7 +155,7 @@ Bool_t ILDRotatedTrapMeaslayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDRotatedTrapMeaslayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+ILDVTrackHit* ILDRotatedTrapMeaslayer::ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
   
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8) return NULL;

--- a/Utilities/KalDet/src/ild/common/ILDRotatedTrapMeaslayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDRotatedTrapMeaslayer.h
@@ -57,7 +57,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
   /** Check if global point is on surface  */
   inline virtual Bool_t   IsOnSurface (const TVector3 &xx) const;

--- a/Utilities/KalDet/src/ild/common/ILDSegmentedDiscMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDSegmentedDiscMeasLayer.cc
@@ -193,7 +193,7 @@ TVector3 ILDSegmentedDiscMeasLayer::HitToXv(const TVTrackHit &vht) const
 //  double z = this->GetXc().Z() ;
 
   UTIL::BitField64 encoder( lcio::ILDCellID0::encoder_string ) ;
-  edm4hep::TrackerHit hit = mv.getLCIOTrackerHit();
+  edm4hep::TrackerHit3D hit = mv.getLCIOTrackerHit();
   encoder.setValue(hit.getCellID());
   int segmentIndex = encoder[lcio::ILDCellID0::module] / 2 ;
   
@@ -495,7 +495,7 @@ Bool_t ILDSegmentedDiscMeasLayer::IsOnSurface(const TVector3 &xx) const
 }
 
 
-ILDVTrackHit* ILDSegmentedDiscMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+ILDVTrackHit* ILDSegmentedDiscMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8) {
   //if( plane_hit == NULL )  { 

--- a/Utilities/KalDet/src/ild/common/ILDSegmentedDiscMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDSegmentedDiscMeasLayer.h
@@ -77,7 +77,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
 
   /** overloaded version of CalcXingPointWith using closed solution*/
   virtual Int_t    CalcXingPointWith(const TVTrack  &hel,

--- a/Utilities/KalDet/src/ild/common/ILDSegmentedDiscStripMeasLayer.cc
+++ b/Utilities/KalDet/src/ild/common/ILDSegmentedDiscStripMeasLayer.cc
@@ -115,7 +115,7 @@ TVector3 ILDSegmentedDiscStripMeasLayer::HitToXv(const TVTrackHit &vht) const
   const ILDPlanarStripHit &mv = dynamic_cast<const ILDPlanarStripHit &>(vht);
   
   UTIL::BitField64 encoder( lcio::ILDCellID0::encoder_string ) ;
-  edm4hep::TrackerHit hit = mv.getLCIOTrackerHit();
+  edm4hep::TrackerHit3D hit = mv.getLCIOTrackerHit();
   encoder.setValue(hit.getCellID());
   int segmentIndex = encoder[lcio::ILDCellID0::module] / 2 ;
   
@@ -242,7 +242,7 @@ void ILDSegmentedDiscStripMeasLayer::CalcDhDa(const TVTrackHit &vht,
 
 
 
-ILDVTrackHit* ILDSegmentedDiscStripMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const {
+ILDVTrackHit* ILDSegmentedDiscStripMeasLayer::ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const {
   
   //EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   if((trkhit.getType()&8)!=8){

--- a/Utilities/KalDet/src/ild/common/ILDSegmentedDiscStripMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDSegmentedDiscStripMeasLayer.h
@@ -67,7 +67,7 @@ public:
                                 TKalMatrix &H)  const;
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const ;
   
 private:
   

--- a/Utilities/KalDet/src/ild/common/ILDVMeasLayer.h
+++ b/Utilities/KalDet/src/ild/common/ILDVMeasLayer.h
@@ -13,7 +13,14 @@
 #include "kaltest/TAttDrawable.h"
 #include "kaltest/KalTrackDim.h"
 #include "TString.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 #include <vector>
 
@@ -44,7 +51,7 @@ public:
   inline Double_t GetBz() const { return _Bz; }
   
   /** Convert LCIO Tracker Hit to an ILDPLanarTrackHit  */
-  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit trkhit) const = 0 ;
+  virtual ILDVTrackHit* ConvertLCIOTrkHit(edm4hep::TrackerHit3D trkhit) const = 0 ;
   
   /** Check whether the measurement layer represents a series of detector elements */
   bool isMultilayer() const { return _isMultiLayer; } 

--- a/Utilities/KalDet/src/ild/common/ILDVTrackHit.h
+++ b/Utilities/KalDet/src/ild/common/ILDVTrackHit.h
@@ -11,7 +11,14 @@
 
 #include "ILDVMeasLayer.h"
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 class ILDVTrackHit : public TVTrackHit {
   
@@ -19,15 +26,15 @@ public:
   
    /** Constructor Taking coordinates and associated measurement layer, with bfield and number of measurement dimentions*/
   ILDVTrackHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-               Double_t bfield , Int_t dim, edm4hep::TrackerHit trkhit) 
+               Double_t bfield , Int_t dim, edm4hep::TrackerHit3D trkhit) 
   : TVTrackHit(ms, x, dx, bfield, dim), _trkhit(trkhit)
   { /* no op */ }
   
-  edm4hep::TrackerHit getLCIOTrackerHit() const { return _trkhit; }
+  edm4hep::TrackerHit3D getLCIOTrackerHit() const { return _trkhit; }
   
 private:
   
-  edm4hep::TrackerHit _trkhit;
+  edm4hep::TrackerHit3D _trkhit;
   
 };
 #endif

--- a/Utilities/KiTrack/include/ILDImpl/FTDHit01.h
+++ b/Utilities/KiTrack/include/ILDImpl/FTDHit01.h
@@ -14,7 +14,7 @@ namespace KiTrackMarlin{
   class FTDHit01 : public IFTDHit{
   public:
       
-    FTDHit01( edm4hep::TrackerHit trackerHit , const SectorSystemFTD* const sectorSystemFTD );
+    FTDHit01( edm4hep::TrackerHit3D trackerHit , const SectorSystemFTD* const sectorSystemFTD );
   };
 }
 #endif

--- a/Utilities/KiTrack/include/ILDImpl/IFTDHit.h
+++ b/Utilities/KiTrack/include/ILDImpl/IFTDHit.h
@@ -2,7 +2,14 @@
 #define IFTDHit_h
 
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 #include "KiTrack/IHit.h"
 
@@ -16,7 +23,7 @@ namespace KiTrackMarlin{
   class IFTDHit : public IHit{
   public:
         
-    edm4hep::TrackerHit* getTrackerHit() { return &_trackerHit; };
+    edm4hep::TrackerHit3D* getTrackerHit() { return &_trackerHit; };
             
     int getSide() { return _side; }
     unsigned getModule() { return _module; }
@@ -31,7 +38,7 @@ namespace KiTrackMarlin{
     
   protected:
     
-    edm4hep::TrackerHit _trackerHit;
+    edm4hep::TrackerHit3D _trackerHit;
             
     int _side;
     unsigned _layer;

--- a/Utilities/KiTrack/include/Tools/FTDHelixFitter.h
+++ b/Utilities/KiTrack/include/Tools/FTDHelixFitter.h
@@ -3,7 +3,14 @@
 
 #include "edm4hep/Track.h"
 #include "edm4hep/MutableTrack.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 class FTDHelixFitterException : public std::exception {
  protected:
@@ -34,7 +41,7 @@ class FTDHelixFitter{
  public:
    
   FTDHelixFitter( edm4hep::MutableTrack* track ) ;
-  FTDHelixFitter( std::vector<edm4hep::TrackerHit> trackerHits ) ;
+  FTDHelixFitter( std::vector<edm4hep::TrackerHit3D> trackerHits ) ;
    
    
    double getChi2(){ return _chi2; }
@@ -59,7 +66,7 @@ class FTDHelixFitter{
    float _d0;
    float _z0;
    
-   std::vector< edm4hep::TrackerHit > _trackerHits;
+   std::vector< edm4hep::TrackerHit3D > _trackerHits;
      
 };
 

--- a/Utilities/KiTrack/include/Tools/Fitter.h
+++ b/Utilities/KiTrack/include/Tools/Fitter.h
@@ -71,7 +71,7 @@ class Fitter{
 public:
    
   Fitter( edm4hep::MutableTrack* track , MarlinTrk::IMarlinTrkSystem* trkSystem );
-  Fitter( std::vector < edm4hep::TrackerHit > trackerHits, MarlinTrk::IMarlinTrkSystem* trkSystem );
+  Fitter( std::vector < edm4hep::TrackerHit3D > trackerHits, MarlinTrk::IMarlinTrkSystem* trkSystem );
   Fitter( edm4hep::MutableTrack* track , MarlinTrk::IMarlinTrkSystem* trkSystem, int VXDFlag );  
 
    
@@ -111,7 +111,7 @@ private:
    static float _bField;
    
    
-   std::vector< edm4hep::TrackerHit > _trackerHits;
+   std::vector< edm4hep::TrackerHit3D > _trackerHits;
    
    /** here the created TrackStates (plus) are stored */
    std::vector< const TrackStatePlus* > _trackStatesPlus;

--- a/Utilities/KiTrack/include/Tools/KiTrackMarlinTools.h
+++ b/Utilities/KiTrack/include/Tools/KiTrackMarlinTools.h
@@ -7,7 +7,14 @@
 #include <map>
 //#include <sstream>
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "edm4hep/Track.h"
 
 #include "ILDImpl/FTDHitSimple.h"
@@ -62,8 +69,8 @@ void saveToRoot( std::string rootFileName, std::string treeName , std::vector < 
  * 
  * @return true if |a.z| < |b.z| , i.e. true if a is nearer to z=0 than b is
  */
-//bool compare_TrackerHit_z( edm4hep::TrackerHit* a, edm4hep::TrackerHit* b );
-bool compare_TrackerHit_z( edm4hep::TrackerHit& a, edm4hep::TrackerHit& b );
+//bool compare_TrackerHit_z( edm4hep::TrackerHit3D* a, edm4hep::TrackerHit3D* b );
+bool compare_TrackerHit_z( edm4hep::TrackerHit3D& a, edm4hep::TrackerHit3D& b );
 
 /** method that compares two TrackerHits.
  * 
@@ -71,7 +78,7 @@ bool compare_TrackerHit_z( edm4hep::TrackerHit& a, edm4hep::TrackerHit& b );
  *
  * to be used at the VXD-SIT system
  */
-bool compare_TrackerHit_R( edm4hep::TrackerHit& a, edm4hep::TrackerHit& b );
+bool compare_TrackerHit_R( edm4hep::TrackerHit3D& a, edm4hep::TrackerHit3D& b );
 
 
 FTDHitSimple* createVirtualIPHit( int side , const SectorSystemFTD* sectorSystemFTD );
@@ -79,7 +86,7 @@ FTDHitSimple* createVirtualIPHit( int side , const SectorSystemFTD* sectorSystem
 VXDHitSimple* createVirtualIPHit( const SectorSystemVXD* sectorSystemVXD );
 
 
-std::string getPositionInfo( edm4hep::TrackerHit hit );
+std::string getPositionInfo( edm4hep::TrackerHit3D hit );
 
 std::string getPositionInfo( IHit* hit );   
 

--- a/Utilities/KiTrack/src/ILDImpl/FTDHit01.cc
+++ b/Utilities/KiTrack/src/ILDImpl/FTDHit01.cc
@@ -6,7 +6,7 @@
 using namespace KiTrackMarlin;
 
 
-FTDHit01::FTDHit01( edm4hep::TrackerHit trackerHit , const SectorSystemFTD* const sectorSystemFTD ){
+FTDHit01::FTDHit01( edm4hep::TrackerHit3D trackerHit , const SectorSystemFTD* const sectorSystemFTD ){
    
    
    _sectorSystemFTD = sectorSystemFTD;

--- a/Utilities/KiTrack/src/ILDImpl/IMiniVector.h
+++ b/Utilities/KiTrack/src/ILDImpl/IMiniVector.h
@@ -3,7 +3,14 @@
 
 #include <iostream>
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 #include "KiTrack/IHit.h"
 #include "ILDImpl/MiniVector.h"

--- a/Utilities/KiTrack/src/ILDImpl/IVXDHit.h
+++ b/Utilities/KiTrack/src/ILDImpl/IVXDHit.h
@@ -3,7 +3,14 @@
 
 #include <iostream>
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 //#include "lcio.h"
 
 #include "KiTrack/IHit.h"
@@ -18,7 +25,7 @@ namespace KiTrackMarlin{
   class IVXDHit : public IHit{
   public:
     
-    edm4hep::TrackerHit* getTrackerHit() { return _trackerHit; };
+    edm4hep::TrackerHit3D* getTrackerHit() { return _trackerHit; };
             
     int getTheta() { return _theta; }
     unsigned getPhi() { return _phi; }
@@ -35,7 +42,7 @@ namespace KiTrackMarlin{
     
   protected:
     
-    edm4hep::TrackerHit* _trackerHit;
+    edm4hep::TrackerHit3D* _trackerHit;
       
     int _layer;
     int _phi;

--- a/Utilities/KiTrack/src/ILDImpl/MiniVector.cc
+++ b/Utilities/KiTrack/src/ILDImpl/MiniVector.cc
@@ -6,7 +6,7 @@
 using namespace KiTrack;
 using namespace KiTrackMarlin;
 
-MiniVector::MiniVector(edm4hep::TrackerHit * outer, edm4hep::TrackerHit * inner) { 
+MiniVector::MiniVector(edm4hep::TrackerHit3D * outer, edm4hep::TrackerHit3D * inner) { 
   HitVec.push_back(outer);
   HitVec.push_back(inner);
 }

--- a/Utilities/KiTrack/src/ILDImpl/MiniVector.h
+++ b/Utilities/KiTrack/src/ILDImpl/MiniVector.h
@@ -4,7 +4,14 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <edm4hep/TrackerHit.h>
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
+#include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 //#include "UTIL/LCTrackerConf.h"
 #include "KiTrack/IHit.h"
 
@@ -13,7 +20,7 @@
 #include <vector>
 #include <math.h>
 
-typedef std::vector<edm4hep::TrackerHit*> TrackerHitVec;
+typedef std::vector<edm4hep::TrackerHit3D*> TrackerHitVec;
 
 namespace KiTrackMarlin{
   class MiniVector : public IHit{
@@ -21,7 +28,7 @@ namespace KiTrackMarlin{
     TrackerHitVec HitVec ;
     
     // Class constructor
-    MiniVector(edm4hep::TrackerHit * outer, edm4hep::TrackerHit * inner);
+    MiniVector(edm4hep::TrackerHit3D * outer, edm4hep::TrackerHit3D * inner);
     
     MiniVector(TrackerHitVec hitPair);
     

--- a/Utilities/KiTrack/src/ILDImpl/MiniVectorHit01.cc
+++ b/Utilities/KiTrack/src/ILDImpl/MiniVectorHit01.cc
@@ -11,7 +11,7 @@
 
 using namespace KiTrackMarlin;
 
-typedef std::vector<edm4hep::TrackerHit*> TrackerHitVec;
+typedef std::vector<edm4hep::TrackerHit3D*> TrackerHitVec;
 
 MiniVectorHit01::MiniVectorHit01( MiniVector* miniVector , const SectorSystemVXD* const sectorSystemVXD ){
    

--- a/Utilities/KiTrack/src/ILDImpl/VXDHit01.cc
+++ b/Utilities/KiTrack/src/ILDImpl/VXDHit01.cc
@@ -12,7 +12,7 @@
 using namespace KiTrackMarlin;
 
 
-VXDHit01::VXDHit01( edm4hep::TrackerHit* trackerHit , const SectorSystemVXD* const sectorSystemVXD ){
+VXDHit01::VXDHit01( edm4hep::TrackerHit3D* trackerHit , const SectorSystemVXD* const sectorSystemVXD ){
    
    
    _sectorSystemVXD = sectorSystemVXD;

--- a/Utilities/KiTrack/src/ILDImpl/VXDHit01.h
+++ b/Utilities/KiTrack/src/ILDImpl/VXDHit01.h
@@ -14,7 +14,7 @@ namespace KiTrackMarlin{
   class VXDHit01 : public IVXDHit{
   public:
     
-    VXDHit01( edm4hep::TrackerHit* trackerHit , const SectorSystemVXD* const sectorSystemVXD );
+    VXDHit01( edm4hep::TrackerHit3D* trackerHit , const SectorSystemVXD* const sectorSystemVXD );
   };
   //void setSectorisationInPhi(int PhiSectors);
   //void setSectorisationInTheta(int ThetaSectors);

--- a/Utilities/KiTrack/src/ILDImpl/VXDTrack.cc
+++ b/Utilities/KiTrack/src/ILDImpl/VXDTrack.cc
@@ -137,7 +137,7 @@ void VXDTrack::addHit( IMiniVector* MV ){
  	  
      for (TrackerHitVec::iterator it = HitVec.begin(); it != HitVec.end() ; ++it ){
 
-       edm4hep::TrackerHit *trkHit = *it ;   
+       edm4hep::TrackerHit3D *trkHit = *it ;   
        
        //_trkhits.push_back( trkHit );
      

--- a/Utilities/KiTrack/src/ILDImpl/VXDTrack.h
+++ b/Utilities/KiTrack/src/ILDImpl/VXDTrack.h
@@ -3,7 +3,14 @@
 
 #include "edm4hep/Track.h"
 #include "edm4hep/MutableTrack.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "TrackSystemSvc/IMarlinTrkSystem.h"
 #include "TrackSystemSvc/IMarlinTrack.h"
 

--- a/Utilities/KiTrack/src/Tools/FTDHelixFitter.cc
+++ b/Utilities/KiTrack/src/Tools/FTDHelixFitter.cc
@@ -4,7 +4,14 @@
 #include <algorithm>
 #include <cmath>
 
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 #include "UTIL/BitSet32.h"
 #include "UTIL/ILDConf.h"
 #include "UTIL/LCTrackerConf.h"
@@ -14,7 +21,7 @@
 #include "Tools/KiTrackMarlinTools.h"
 
 
-FTDHelixFitter::FTDHelixFitter( std::vector<edm4hep::TrackerHit> trackerHits ){
+FTDHelixFitter::FTDHelixFitter( std::vector<edm4hep::TrackerHit3D> trackerHits ){
   _trackerHits = trackerHits;
   fit();
 }
@@ -24,7 +31,7 @@ FTDHelixFitter::FTDHelixFitter( edm4hep::MutableTrack* track ){
   //int nHits = track->trackerHits_size();
   std::copy(track->trackerHits_begin(), track->trackerHits_end(), std::back_inserter(_trackerHits));
   //for(int i=0;i<nHits;i++){
-  //  edm4hep::TrackerHit hit = &track->getTrackerHits(i);
+  //  edm4hep::TrackerHit3D hit = &track->getTrackerHits(i);
   //  _trackerHits.push_back(hit);
   //}
   fit();
@@ -57,7 +64,7 @@ void FTDHelixFitter::fit(){
   float epar[15];
   
   for( int i=0; i<nHits; i++ ){
-    edm4hep::TrackerHit hit = _trackerHits[i];
+    edm4hep::TrackerHit3D hit = _trackerHits[i];
       
     xh[i] = hit.getPosition()[0];
     yh[i] = hit.getPosition()[1];

--- a/Utilities/KiTrack/src/Tools/Fitter.cc
+++ b/Utilities/KiTrack/src/Tools/Fitter.cc
@@ -13,7 +13,7 @@
 #include "DataHelper/Navigation.h"
 #include "Tools/KiTrackMarlinTools.h"
 
-typedef std::vector<edm4hep::TrackerHit> TrackerHitVec;
+typedef std::vector<edm4hep::TrackerHit3D> TrackerHitVec;
 using namespace MarlinTrk;
 
 // by fucd: 3.5->3.0 default, will be read from GeomSvc
@@ -33,11 +33,11 @@ void Fitter::init_BField(){
 
 }
 
-bool compare_TrackerHit_z( edm4hep::TrackerHit a, edm4hep::TrackerHit b ){
+bool compare_TrackerHit_z( edm4hep::TrackerHit3D a, edm4hep::TrackerHit3D b ){
   return ( fabs(a.getPosition()[2]) < fabs( b.getPosition()[2]) ); //compare their z values
 }
 
-bool compare_TrackerHit_R( edm4hep::TrackerHit a, edm4hep::TrackerHit b ){
+bool compare_TrackerHit_R( edm4hep::TrackerHit3D a, edm4hep::TrackerHit3D b ){
   double Rad_a2 = (a.getPosition()[0]*a.getPosition()[0]) + (a.getPosition()[1]*a.getPosition()[1]) ;
   double Rad_b2 = (b.getPosition()[0]*b.getPosition()[0]) + (b.getPosition()[1]*b.getPosition()[1]) ;
   
@@ -60,7 +60,7 @@ Fitter::Fitter( edm4hep::MutableTrack* track , MarlinTrk::IMarlinTrkSystem* trkS
   fitVXD();
 }
 
-Fitter::Fitter( std::vector<edm4hep::TrackerHit> trackerHits , MarlinTrk::IMarlinTrkSystem* trkSystem ): _trkSystem( trkSystem ){
+Fitter::Fitter( std::vector<edm4hep::TrackerHit3D> trackerHits , MarlinTrk::IMarlinTrkSystem* trkSystem ): _trkSystem( trkSystem ){
   _trackerHits = trackerHits;
   fit();
 }
@@ -84,21 +84,21 @@ void Fitter::fitVXD(){
      
   unsigned number_of_added_hits = 0;
   unsigned ndof_added = 0;
-  std::vector< edm4hep::TrackerHit > added_hits;
-  std::vector< edm4hep::TrackerHit > added_hits_2D;
+  std::vector< edm4hep::TrackerHit3D > added_hits;
+  std::vector< edm4hep::TrackerHit3D > added_hits_2D;
   
   for( it = _trackerHits.begin() ; it != _trackerHits.end() ; ++it ) {
-    edm4hep::TrackerHit trkHit = Navigation::Instance()->GetTrackerHit((*it).getObjectID());
+    edm4hep::TrackerHit3D trkHit = Navigation::Instance()->GetTrackerHit((*it).getObjectID());
     bool isSuccessful = false; 
     
     if( UTIL::BitSet32( trkHit.getType() )[ UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT ]   ){ //it is a composite spacepoint
       //Split it up and hits to the MarlinTrk
-      std::vector< edm4hep::TrackerHit > rawHits;
+      std::vector< edm4hep::TrackerHit3D > rawHits;
       //const LCObjectVec rawObjects = trkHit.getRawHits();
       //for( unsigned k=0; k<rawObjects.size(); k++ ) rawHits.push_back( dynamic_cast< ConstTrackerHit >( rawObjects[k] ) );
       int nRawHit = trkHit.rawHits_size();
       for( unsigned k=0; k< nRawHit; k++ ){
-	edm4hep::TrackerHit rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
+	edm4hep::TrackerHit3D rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
 	rawHits.push_back(rawHit);
       }
       std::sort( rawHits.begin(), rawHits.end(), compare_TrackerHit_R );
@@ -224,7 +224,7 @@ void Fitter::fitVXD(){
   
   // fitting finished get hits in the fit for safety checks:
   
-  std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
+  std::vector<std::pair<edm4hep::TrackerHit3D, double> > hits_in_fit;
   
   // remember the hits are ordered in the order in which they were fitted
   // here we are fitting inwards so the first is the last and vice verse
@@ -241,13 +241,13 @@ void Fitter::fitVXD(){
     throw FitterException( s.str() );
     
   }
-  edm4hep::TrackerHit first_hit_in_fit = hits_in_fit.back().first;
+  edm4hep::TrackerHit3D first_hit_in_fit = hits_in_fit.back().first;
   if (! first_hit_in_fit.isAvailable()) {
     throw FitterException( std::string("Fitter::fit(): TrackerHit pointer to first hit == NULL ")  ) ;
   }
   
   
-  edm4hep::TrackerHit last_hit_in_fit = hits_in_fit.front().first;
+  edm4hep::TrackerHit3D last_hit_in_fit = hits_in_fit.front().first;
   if (!last_hit_in_fit.isAvailable()) {
     throw FitterException( std::string("Fitter::fit(): TrackerHit pointer to last hit == NULL ")  ) ;
   }
@@ -276,20 +276,20 @@ void Fitter::fit(){
   
   unsigned number_of_added_hits = 0;
   unsigned ndof_added = 0;
-  std::vector<edm4hep::TrackerHit> added_hits;
+  std::vector<edm4hep::TrackerHit3D> added_hits;
   
   for( it = _trackerHits.begin() ; it != _trackerHits.end() ; ++it ) {
-    edm4hep::TrackerHit trkHit = Navigation::Instance()->GetTrackerHit((*it).getObjectID());
+    edm4hep::TrackerHit3D trkHit = Navigation::Instance()->GetTrackerHit((*it).getObjectID());
     bool isSuccessful = false; 
     //std::cout << "Hit " << trkHit->id() << " " << trkHit.getPosition() << std::endl;
     if( UTIL::BitSet32( trkHit.getType() )[ UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT ]   ){ //it is a composite spacepoint
       //Split it up and hits to the MarlinTrk
-      std::vector<edm4hep::TrackerHit> rawHits;
+      std::vector<edm4hep::TrackerHit3D> rawHits;
       //const LCObjectVec rawObjects = trkHit.getRawHits();                    
       //for( unsigned k=0; k<rawObjects.size(); k++ ) rawHits.push_back( dynamic_cast< ConstTrackerHit >( rawObjects[k] ) );
       int nRawHit = trkHit.rawHits_size();
       for( unsigned k=0; k< nRawHit; k++ ){
-	edm4hep::TrackerHit rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
+	edm4hep::TrackerHit3D rawHit = Navigation::Instance()->GetTrackerHit(trkHit.getRawHits(k));
 	//std::cout << "Raw Hit " << rawHit->id() << " " << rawHit.getPosition() << std::endl;
 	rawHits.push_back(rawHit);
       }
@@ -398,7 +398,7 @@ void Fitter::fit(){
   
   // fitting finished get hits in the fit for safety checks:
   
-  std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
+  std::vector<std::pair<edm4hep::TrackerHit3D, double> > hits_in_fit;
   
   // remember the hits are ordered in the order in which they were fitted
   // here we are fitting inwards so the first is the last and vice verse
@@ -412,12 +412,12 @@ void Fitter::fit(){
     
     throw FitterException( s.str() );
   }
-  edm4hep::TrackerHit first_hit_in_fit = hits_in_fit.back().first;
+  edm4hep::TrackerHit3D first_hit_in_fit = hits_in_fit.back().first;
   if (!first_hit_in_fit.isAvailable()) {
     throw FitterException( std::string("Fitter::fit(): TrackerHit pointer to first hit == NULL ")  ) ;
   }
   
-  edm4hep::TrackerHit last_hit_in_fit = hits_in_fit.front().first;
+  edm4hep::TrackerHit3D last_hit_in_fit = hits_in_fit.front().first;
   if (!last_hit_in_fit.isAvailable()) {
     throw FitterException( std::string("Fitter::fit(): TrackerHit pointer to last hit == NULL ")  ) ;
   }
@@ -480,13 +480,13 @@ const TrackStatePlus* Fitter::getTrackStatePlus( int trackStateLocation ){
      }
    }
    case 2/*lcio::TrackState::AtFirstHit*/:{
-     std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
+     std::vector<std::pair<edm4hep::TrackerHit3D, double> > hits_in_fit;
          
      // remember the hits are ordered in the order in which they were fitted
      // here we are fitting inwards so the first is the last and vice verse
      _marlinTrk->getHitsInFit(hits_in_fit);
      
-     edm4hep::TrackerHit first_hit_in_fit = hits_in_fit.back().first;
+     edm4hep::TrackerHit3D first_hit_in_fit = hits_in_fit.back().first;
           
      return_code = _marlinTrk->getTrackState(first_hit_in_fit, *trackState, chi2, ndf ) ;
      
@@ -508,10 +508,10 @@ const TrackStatePlus* Fitter::getTrackStatePlus( int trackStateLocation ){
      }
    }
    case 3/*lcio::TrackState::AtLastHit*/:{
-     std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
+     std::vector<std::pair<edm4hep::TrackerHit3D, double> > hits_in_fit;
      _marlinTrk->getHitsInFit(hits_in_fit);
      
-     edm4hep::TrackerHit last_hit_in_fit = hits_in_fit.front().first;
+     edm4hep::TrackerHit3D last_hit_in_fit = hits_in_fit.front().first;
           
      return_code = _marlinTrk->getTrackState(last_hit_in_fit, *trackState, chi2, ndf ) ;
          
@@ -533,10 +533,10 @@ const TrackStatePlus* Fitter::getTrackStatePlus( int trackStateLocation ){
      break;
    }
    case 4/*lcio::TrackState::AtCalorimeter*/:{
-     std::vector<std::pair<edm4hep::TrackerHit, double> > hits_in_fit;
+     std::vector<std::pair<edm4hep::TrackerHit3D, double> > hits_in_fit;
      _marlinTrk->getHitsInFit(hits_in_fit);
      
-     edm4hep::TrackerHit last_hit_in_fit = hits_in_fit.front().first;
+     edm4hep::TrackerHit3D last_hit_in_fit = hits_in_fit.front().first;
           
      UTIL::BitField64 encoder( UTIL::ILDCellID0::encoder_string ) ; 
      encoder.reset() ;  // reset to 0

--- a/Utilities/KiTrack/src/Tools/KiTrackMarlinTools.cc
+++ b/Utilities/KiTrack/src/Tools/KiTrackMarlinTools.cc
@@ -150,15 +150,15 @@ void KiTrackMarlin::saveToRoot( std::string rootFileName, std::string treeName ,
 }
 
 
-//bool KiTrackMarlin::compare_TrackerHit_z( edm4hep::TrackerHit a, edm4hep::TrackerHit b ){
+//bool KiTrackMarlin::compare_TrackerHit_z( edm4hep::TrackerHit3D a, edm4hep::TrackerHit3D b ){
 //  return ( fabs(a.getPosition()[2]) < fabs( b.getPosition()[2]) ); //compare their z values
 //}
 
-bool KiTrackMarlin::compare_TrackerHit_z( edm4hep::TrackerHit& a, edm4hep::TrackerHit& b ){
+bool KiTrackMarlin::compare_TrackerHit_z( edm4hep::TrackerHit3D& a, edm4hep::TrackerHit3D& b ){
   return ( fabs(a.getPosition()[2]) < fabs( b.getPosition()[2]) );
 }
 
-bool KiTrackMarlin::compare_TrackerHit_R( edm4hep::TrackerHit& a, edm4hep::TrackerHit& b ){
+bool KiTrackMarlin::compare_TrackerHit_R( edm4hep::TrackerHit3D& a, edm4hep::TrackerHit3D& b ){
   double Rad_a2 = (a.getPosition()[0]*a.getPosition()[0]) + (a.getPosition()[1]*a.getPosition()[1]) ;
   double Rad_b2 = (b.getPosition()[0]*b.getPosition()[0]) + (b.getPosition()[1]*b.getPosition()[1]) ;
   
@@ -197,7 +197,7 @@ VXDHitSimple* KiTrackMarlin::createVirtualIPHit( const SectorSystemVXD* sectorSy
 }
 
 
-std::string KiTrackMarlin::getPositionInfo( edm4hep::TrackerHit hit ){
+std::string KiTrackMarlin::getPositionInfo( edm4hep::TrackerHit3D hit ){
    
    std::stringstream info;
    
@@ -245,10 +245,10 @@ std::string KiTrackMarlin::getTrackHitInfo( ITrack* track){
 
 std::string KiTrackMarlin::getTrackHitInfo( edm4hep::Track* track){
   std::stringstream info;
-  //std::vector< edm4hep::TrackerHit > hits;
+  //std::vector< edm4hep::TrackerHit3D > hits;
   unsigned int nHits = track->trackerHits_size();
   for(unsigned i=0; i<nHits; i++){
-    edm4hep::TrackerHit hit = track->getTrackerHits(i);
+    edm4hep::TrackerHit3D hit = track->getTrackerHits(i);
     info << getPositionInfo(hit);
   }
    

--- a/Utilities/KiTrack/src/Tools/VXDHelixFitter.h
+++ b/Utilities/KiTrack/src/Tools/VXDHelixFitter.h
@@ -2,7 +2,14 @@
 #define VXDHelixFitter_h
 
 #include "edm4hep/Track.h"
+#if __has_include("edm4hep/TrackerHit3D.h")
+#include "edm4hep/TrackerHit3D.h"
+#else
 #include "edm4hep/TrackerHit.h"
+namespace edm4hep {
+  using TrackerHit3D = edm4hep::TrackerHit;
+} // namespace edm4hep
+#endif
 
 //#include "lcio.h"
 
@@ -47,7 +54,7 @@ class VXDHelixFitter{
 public:
    
   VXDHelixFitter( edm4hep::Track* track ) ;
-  VXDHelixFitter( std::vector < edm4hep::TrackerHit > trackerHits ) ;
+  VXDHelixFitter( std::vector < edm4hep::TrackerHit3D > trackerHits ) ;
    
    
    double getChi2(){ return _chi2; }
@@ -74,7 +81,7 @@ private:
    float _d0;
    float _z0;
    
-   std::vector< edm4hep::TrackerHit > _trackerHits;
+   std::vector< edm4hep::TrackerHit3D > _trackerHits;
   
    
 };


### PR DESCRIPTION
After a few changes in EDM4hep (see https://github.com/key4hep/EDM4hep/pull/261), CEPCSW doesn't compile with the current version. This is a starting point to fix it, where I made the change in many places to use `edm4hep::TrackerHit3D` instead of `edm4hep::TrackerHit`. Before merging, it should build with both the release and the nightlies.